### PR TITLE
Fix pointer-to-integer casting when building in 64 bit mode

### DIFF
--- a/codec/decoder/core/inc/macros.h
+++ b/codec/decoder/core/inc/macros.h
@@ -57,14 +57,14 @@ namespace WelsDec {
 */
 #define FORCE_STACK_ALIGN_1D(_tp, _nm, _sz, _al) \
 	_tp _nm ## _tEmP[(_sz)+(_al)-1]; \
-	_tp *_nm = _nm ## _tEmP + ((_al)-1) - (((int32_t)(_nm ## _tEmP + ((_al)-1)) & ((_al)-1))/sizeof(_tp))
+	_tp *_nm = _nm ## _tEmP + ((_al)-1) - (((intptr_t)(_nm ## _tEmP + ((_al)-1)) & ((_al)-1))/sizeof(_tp))
 
 
 #define ENFORCE_STACK_ALIGN_2D(_tp, _nm, _cx, _cy, _al) \
 	assert( ((_al) && !((_al) & ((_al) - 1))) && ((_al) >= sizeof(_tp)) ); /*_al should be power-of-2 and >= sizeof(_tp)*/\
 	_tp _nm ## _tEmP[(_cx)*(_cy)+(_al)/sizeof(_tp)-1]; \
 	_tp *_nm ## _tEmP_al = _nm ## _tEmP + ((_al)/sizeof(_tp)-1); \
-	_nm ## _tEmP_al -= (((int32_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
+	_nm ## _tEmP_al -= (((intptr_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
 	_tp (*_nm)[(_cy)] = (_tp (*)[(_cy)])_nm ## _tEmP_al;
 
 

--- a/codec/decoder/core/inc/typedefs.h
+++ b/codec/decoder/core/inc/typedefs.h
@@ -56,6 +56,11 @@ typedef int              int32_t ;
 typedef unsigned int     uint32_t;
 typedef __int64          int64_t ;
 typedef unsigned __int64 uint64_t;
+#ifdef  _WIN64
+typedef __int64          intptr_t;
+#else
+typedef int              intptr_t;
+#endif
 
 #endif // _MSC_VER defined
 

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -86,7 +86,7 @@ uint8_t* DetectStartCodePrefix (const uint8_t* kpBuf, int32_t* pOffset, int32_t 
     ++ pBits;
 
     if ((iIdx >= 3) && ((* (pBits - 1)) == 0x1)) {
-      *pOffset = ((uint32_t)pBits) - ((uint32_t)kpBuf);
+      *pOffset = ((intptr_t)pBits) - ((intptr_t)kpBuf);
       return pBits;
     }
 

--- a/codec/decoder/core/src/mem_align.cpp
+++ b/codec/decoder/core/src/mem_align.cpp
@@ -84,7 +84,7 @@ void_t* WelsMalloc (const uint32_t kuiSize, const str_t* kpTag) {
   memset (pBuf, 0, kuiSize + kiAlignBytes + kiSizeVoidPtr + kiSizeInt);
 
   pAlignBuf = pBuf + kiAlignBytes + kiSizeVoidPtr + kiSizeInt;
-  pAlignBuf -= (int32_t) pAlignBuf & kiAlignBytes;
+  pAlignBuf -= (intptr_t) pAlignBuf & kiAlignBytes;
   * ((void_t**) (pAlignBuf - kiSizeVoidPtr)) = pBuf;
   * ((int32_t*) (pAlignBuf - (kiSizeVoidPtr + kiSizeInt))) = kuiSize;
 

--- a/codec/encoder/core/inc/array_stack_align.h
+++ b/codec/encoder/core/inc/array_stack_align.h
@@ -67,7 +67,7 @@
 assert( ((_al) && !((_al) & ((_al) - 1))) && ((_al) >= sizeof(_tp)) ); /*_al should be power-of-2 and >= sizeof(_tp)*/\
 _tp _nm ## _tEmP[(_sz)+(_al)/sizeof(_tp)-1]; \
 _tp *_nm = _nm ## _tEmP + ((_al)/sizeof(_tp)-1); \
-_nm -= (((int32_t)_nm & ((_al)-1))/sizeof(_tp));
+_nm -= (((intptr_t)_nm & ((_al)-1))/sizeof(_tp));
 
 /*
  * ENFORCE_STACK_ALIGN_2D: force 2 dimension local pData aligned in stack
@@ -90,7 +90,7 @@ _nm -= (((int32_t)_nm & ((_al)-1))/sizeof(_tp));
 assert( ((_al) && !((_al) & ((_al) - 1))) && ((_al) >= sizeof(_tp)) ); /*_al should be power-of-2 and >= sizeof(_tp)*/\
 _tp _nm ## _tEmP[(_cx)*(_cy)+(_al)/sizeof(_tp)-1]; \
 _tp *_nm ## _tEmP_al = _nm ## _tEmP + ((_al)/sizeof(_tp)-1); \
-_nm ## _tEmP_al -= (((int32_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
+_nm ## _tEmP_al -= (((intptr_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
 _tp (*_nm)[(_cy)] = (_tp (*)[(_cy)])_nm ## _tEmP_al;
 
 /*
@@ -114,7 +114,7 @@ _tp (*_nm)[(_cy)] = (_tp (*)[(_cy)])_nm ## _tEmP_al;
 assert( ((_al) && !((_al) & ((_al) - 1))) && ((_al) >= sizeof(_tp)) ); /*_al should be power-of-2 and >= sizeof(_tp)*/\
 _tp _nm ## _tEmP[(_cx)*(_cy)*(_cz)+(_al)/sizeof(_tp)-1]; \
 _tp *_nm ## _tEmP_al = _nm ## _tEmP + ((_al)/sizeof(_tp)-1); \
-_nm ## _tEmP_al -= (((int32_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
+_nm ## _tEmP_al -= (((intptr_t)_nm ## _tEmP_al & ((_al)-1))/sizeof(_tp)); \
 _tp (*_nm)[(_cy)][(_cz)] = (_tp (*)[(_cy)][(_cz)])_nm ## _tEmP_al;
 
 #endif//ARRAY_STACK_ALIGN_H__

--- a/codec/encoder/core/inc/typedefs.h
+++ b/codec/encoder/core/inc/typedefs.h
@@ -56,6 +56,11 @@ typedef int              int32_t ;
 typedef unsigned int     uint32_t;
 typedef __int64          int64_t ;
 typedef unsigned __int64 uint64_t;
+#ifdef  _WIN64
+typedef __int64          intptr_t;
+#else
+typedef int              intptr_t;
+#endif
 
 #endif // _MSC_VER defined
 

--- a/codec/encoder/core/src/memory_align.cpp
+++ b/codec/encoder/core/src/memory_align.cpp
@@ -111,7 +111,7 @@ void* CMemoryAlign::WelsMalloc (const uint32_t kuiSize, const str_t* kpTag) {
     return NULL;
 
   pAlignedBuffer = pBuf + kiAlignedBytes + kiSizeOfVoidPointer + kiSizeOfInt;
-  pAlignedBuffer -= ((int32_t) pAlignedBuffer & kiAlignedBytes);
+  pAlignedBuffer -= ((intptr_t) pAlignedBuffer & kiAlignedBytes);
   * ((void**) (pAlignedBuffer - kiSizeOfVoidPointer)) = pBuf;
   * ((int32_t*) (pAlignedBuffer - (kiSizeOfVoidPointer + kiSizeOfInt))) = kiPayloadSize;
 


### PR DESCRIPTION
This allows building (without assembly) in 64 bit mode as well.
