### PR TITLE
Add a missing NO_DYNAMIC_VP ifdef in the CWelsLib destructor

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -119,6 +119,7 @@ CWelsLib::CWelsLib (void* pEncCtx) {
 }
 
 CWelsLib::~CWelsLib() {
+#ifndef NO_DYNAMIC_VP
   if (m_pVpLib) {
 #if defined(WIN32)
     HMODULE shModule = (HMODULE)m_pVpLib;
@@ -134,6 +135,7 @@ CWelsLib::~CWelsLib() {
 #endif
     m_pVpLib = NULL;
   }
+#endif
 }
 
 void* CWelsLib::QueryFunction (const str_t* pName) {


### PR DESCRIPTION
Previously this would try to free a dynamically loaded library
even if none was loaded.
