### PR TITLE
Exempt gh-pages from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: cpp
 compiler:
   - gcc
   - clang
-# Change this to your needs
+branches:
+  except:
+    - gh-pages
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq g++-4.6-multilib gcc-multilib libc6-dev-i386 lib32z1-dev
-script: make gtest-bootstrap && make && make test
+install: make gtest-bootstrap
+script: make && make test
 


### PR DESCRIPTION
Also moved gtest-bootstrap to the install phase so it doesn't fill up the screen.
