### PR TITLE
Avoid all calls to libdl (or equivalent) if NO_DYNAMIC_VP is defined

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -141,6 +141,7 @@ CWelsLib::~CWelsLib() {
 void* CWelsLib::QueryFunction (const str_t* pName) {
   void* pFunc = NULL;
 
+#ifndef NO_DYNAMIC_VP
   if (m_pVpLib) {
 #if defined(WIN32)
     HMODULE shModule = (HMODULE)m_pVpLib;
@@ -157,6 +158,7 @@ void* CWelsLib::QueryFunction (const str_t* pName) {
       printf ("dlsym %s iRet=%p, err=%s\n", shModule, pFunc, dlerror());
 #endif
   }
+#endif
   return pFunc;
 }
 

--- a/codec/encoder/plus/src/welsCodecTrace.cpp
+++ b/codec/encoder/plus/src/welsCodecTrace.cpp
@@ -242,6 +242,7 @@ welsCodecTrace::welsCodecTrace() {
 }
 
 welsCodecTrace::~welsCodecTrace() {
+#ifndef NO_DYNAMIC_VP
 #if defined WIN32
   if (m_hTraceHandle) {
     ::FreeLibrary ((HMODULE)m_hTraceHandle);
@@ -254,6 +255,7 @@ welsCodecTrace::~welsCodecTrace() {
   if (m_hTraceHandle) {
     ::dlclose (m_hTraceHandle);
   }
+#endif
 #endif
 
   m_hTraceHandle = NULL;


### PR DESCRIPTION
The same ifdefs are already used in the corresponding constructors, so this just avoids a runtime/link time library dependency which is practically unused in this build setup.

I'm not sure if others see this as desired, or if it's better to reduce the amount of ifdefs, since linking to -ldl isn't too much of an extra burden.
