### PR TITLE
Improve handling of help switch in enc test app

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -455,7 +455,6 @@ void PrintHelp() {
   printf (" Syntax: welsenc.exe welsenc.cfg [options]\n");
 
   printf ("\n Supported Options:\n");
-  printf ("  -h      Print Help\n");
   printf ("  -bf     Bit Stream File\n");
   printf ("  -frms   Number of total frames to be encoded\n");
   printf ("  -gop    GOPSize - GOP size (2,4,8,16,32,64, default: 1)\n");
@@ -497,10 +496,6 @@ int ParseCommandLine (int argc, char** argv, SWelsSvcCodingParam& pSvcParam, SFi
 
   while (n < argc) {
     pCommand = argv[n++];
-    if (!strcmp (pCommand, "-h")) {	// confirmed_safe_unsafe_usage
-      PrintHelp();
-      continue;
-    }
     if (!strcmp (pCommand, "-bf")) {	// confirmed_safe_unsafe_usage
       sFileSet.strBsFile.assign (argv[n]);
       ++ n;
@@ -1420,14 +1415,17 @@ int main (int argc, char** argv)
   } else {
     string	strCfgFileName = argv[1];
     basic_string <char>::size_type index;
-    static const basic_string <char>::size_type npos = size_t (-1);
     index = strCfgFileName.rfind (".cfg");	// check configuration type (like .cfg?)
-    if (index == npos) {
+    if (index == std::string::npos) {
       if (argc > 2) {
         iRet = ProcessEncodingSvcWithParam (pSVCEncoder, argc, argv);
         if (iRet != 0)
           goto exit;
-      } else {
+      } else if (argc == 2 && ! strcmp(argv[1], "-h")) {
+        PrintHelp();
+        return 0;
+      }
+      else {
         cout << "You specified pCommand is invalid!!" << endl;
         goto exit;
       }


### PR DESCRIPTION
welsenc.exe -h is now a valid command which returns success.
So, no longer need to specify a cfg file just to get help on how to use this command.

No longer prints help text twice in the case when the -h switch
is given along with a wrong cfg. Earlier ParseCommandLine used to print help when it saw -h option.
And, when the parsing of config file failed, there was another print help.
