### PR TITLE
Add FreeBSD platform makefile

### DIFF
--- a/build/platform-freebsd.mk
+++ b/build/platform-freebsd.mk
@@ -1,0 +1,5 @@
+ASM = nasm
+CFLAGS += -fPIC
+LDFLAGS += -lpthread
+ASMFLAGS += -f elf
+


### PR DESCRIPTION
Add platform-freebsd.mk makefile to allow building on FreeBSD.

OpenH264 builds and runs successfully on FreeBSD 9.2-RELEASE amd64, with both
the gcc and clang compilers.

Note that building i386 binaries with the native toolchain using the -m32 flag
on amd64 FreeBSD is unsupported and will not work, so ENABLE64BIT should always
be set to Yes when compiling on a FreeBSD amd64 system.
