### PR TITLE
Use $(AR) instead of explicitly calling 'ar'

### DIFF
--- a/build/gtest-targets.mk
+++ b/build/gtest-targets.mk
@@ -13,7 +13,7 @@ $(GTEST_SRCDIR)/src/gtest-all.o: $(GTEST_SRCDIR)/src/gtest-all.cc
 
 $(LIBPREFIX)gtest.$(LIBSUFFIX): $(GTEST_OBJS)
 	rm -f $(LIBPREFIX)gtest.$(LIBSUFFIX)
-	ar cr $@ $(GTEST_OBJS)
+	$(AR) cr $@ $(GTEST_OBJS)
 
 libraries: $(LIBPREFIX)gtest.$(LIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)gtest.$(LIBSUFFIX)

--- a/build/mktargets.py
+++ b/build/mktargets.py
@@ -92,7 +92,7 @@ for a in asm:
 if args.library is not None:
     f.write("$(LIBPREFIX)%s.$(LIBSUFFIX): $(%s_OBJS)\n"%(args.library, PREFIX));
     f.write("\trm -f $(LIBPREFIX)%s.$(LIBSUFFIX)\n"%args.library)
-    f.write("\tar cr $@ $(%s_OBJS)\n"%PREFIX);
+    f.write("\t$(AR) cr $@ $(%s_OBJS)\n"%PREFIX);
     f.write("\n");
     f.write("libraries: $(LIBPREFIX)%s.$(LIBSUFFIX)\n"%args.library);
     f.write("LIBRARIES += $(LIBPREFIX)%s.$(LIBSUFFIX)\n"%args.library);

--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -16,7 +16,7 @@ $(COMMON_SRCDIR)/./logging.o: $(COMMON_SRCDIR)/./logging.cpp
 
 $(LIBPREFIX)common.$(LIBSUFFIX): $(COMMON_OBJS)
 	rm -f $(LIBPREFIX)common.$(LIBSUFFIX)
-	ar cr $@ $(COMMON_OBJS)
+	$(AR) cr $@ $(COMMON_OBJS)
 
 libraries: $(LIBPREFIX)common.$(LIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)common.$(LIBSUFFIX)

--- a/codec/decoder/targets.mk
+++ b/codec/decoder/targets.mk
@@ -148,7 +148,7 @@ $(DECODER_SRCDIR)/./core/asm/memzero.o: $(DECODER_SRCDIR)/./core/asm/memzero.asm
 
 $(LIBPREFIX)decoder.$(LIBSUFFIX): $(DECODER_OBJS)
 	rm -f $(LIBPREFIX)decoder.$(LIBSUFFIX)
-	ar cr $@ $(DECODER_OBJS)
+	$(AR) cr $@ $(DECODER_OBJS)
 
 libraries: $(LIBPREFIX)decoder.$(LIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)decoder.$(LIBSUFFIX)

--- a/codec/encoder/targets.mk
+++ b/codec/encoder/targets.mk
@@ -208,7 +208,7 @@ $(ENCODER_SRCDIR)/./core/asm/vaa.o: $(ENCODER_SRCDIR)/./core/asm/vaa.asm
 
 $(LIBPREFIX)encoder.$(LIBSUFFIX): $(ENCODER_OBJS)
 	rm -f $(LIBPREFIX)encoder.$(LIBSUFFIX)
-	ar cr $@ $(ENCODER_OBJS)
+	$(AR) cr $@ $(ENCODER_OBJS)
 
 libraries: $(LIBPREFIX)encoder.$(LIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)encoder.$(LIBSUFFIX)

--- a/processing/targets.mk
+++ b/processing/targets.mk
@@ -120,7 +120,7 @@ $(PROCESSING_SRCDIR)/./src/asm/vaa.o: $(PROCESSING_SRCDIR)/./src/asm/vaa.asm
 
 $(LIBPREFIX)processing.$(LIBSUFFIX): $(PROCESSING_OBJS)
 	rm -f $(LIBPREFIX)processing.$(LIBSUFFIX)
-	ar cr $@ $(PROCESSING_OBJS)
+	$(AR) cr $@ $(PROCESSING_OBJS)
 
 libraries: $(LIBPREFIX)processing.$(LIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)processing.$(LIBSUFFIX)


### PR DESCRIPTION
This simplifies overriding the command used, e.g. for cross
compilation.
