### PR TITLE
Remove pragmas for non-standard struct packing in the public API

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -161,7 +161,6 @@ typedef struct {
   unsigned int  uiIDRPicId; // distinguish request from different IDR
   int			  iLTRFrameNum; //specify current decoder frame_num
 } SLTRMarkingFeedback;
-#pragma pack(1)
 
 typedef struct {
 
@@ -277,5 +276,4 @@ typedef struct Source_Picture_s {
 } SSourcePicture;
 
 
-#pragma pack()
 #endif//WELS_VIDEO_CODEC_APPLICATION_DEFINITION_H__

--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -112,8 +112,6 @@ enum ENalPriority {
 #define FRAME_NUM_PARAM_SET		(-1)
 #define FRAME_NUM_IDR			0
 
-#pragma pack(1)
-
 /* Error Tools definition */
 typedef unsigned short ERR_TOOL;
 enum {
@@ -235,7 +233,5 @@ static const SRateThresholds ksRateThrMap[4] = {
 static const char kiKeyNumMultiple[] = {
   1, 1, 2, 4, 8, 16,
 };
-
-#pragma pack()
 
 #endif//WELS_VIDEO_CODEC_DEFINITION_H__


### PR DESCRIPTION
These pragmas specified that structs should be packed in a way
different from the normal way defined by the current platform ABI.
Since these pragmas are in headers part of the public API, and the
pragmas are nonstandard, this is a portability and compatibility
hazard (all code calling the library need to have the same support
for the nonstandard pragma).

Additionally, accessing unaligned struct members (as produced by this
tight struct packing) can give reduced performance or even lead to
crashes on platforms that require strict alignment.

The only theoretical possible benefits of using the pragma are either
matching a certain struct layout defined in some other, fixed ABI
(but since this is an interface defined by this library itself, there's
no such prior binary interface that needs to be matched), or to reduce
the memory usage by packing the structs tighter (where the reduction
would be marginal at best).

Given the lack of concrete benefit/need for these pragmas and
the number of downsides with keeping them, I suggest they should
be removed.
