### PR TITLE
Remove trailing whitespace in comments

### DIFF
--- a/codec/console/dec/inc/d3d9_utils.h
+++ b/codec/console/dec/inc/d3d9_utils.h
@@ -49,7 +49,7 @@
 #include "codec_def.h"
 
 #if defined(_MSC_VER) && (_MSC_VER>=1500) // vs2008 and upper
-#define ENABLE_DISPLAY_MODULE // enable/disable the render feature 
+#define ENABLE_DISPLAY_MODULE // enable/disable the render feature
 #endif
 
 #ifdef ENABLE_DISPLAY_MODULE

--- a/codec/decoder/core/inc/cpu_core.h
+++ b/codec/decoder/core/inc/cpu_core.h
@@ -58,7 +58,7 @@
 /* CPU features application extensive */
 #define WELS_CPU_AVX		0x00000800	/* Advanced Vector eXtentions */
 #define WELS_CPU_FPU		0x00001000	/* x87-FPU on chip */
-#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature: 
+#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature:
 										   physical processor package is capable of supporting more than one logic processor
 										*/
 #define WELS_CPU_CMOV		0x00004000	/* Conditional Move Instructions,

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -246,7 +246,7 @@ typedef struct TagWelsDecoderContext {
   int32_t             iSpsTotalNum;  //the number of SPS in current IDR interval
   int32_t             iSubspsTotalNum; //the number of subsps in current IDR interval
   int32_t             iPpsTotalNum; //the number of PPS in current IDR interval.
-#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID	
+#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
 
   SSps				sSpsBuffer[MAX_SPS_COUNT];
   SPps				sPpsBuffer[MAX_PPS_COUNT];

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -672,7 +672,7 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
     pCtx->iSpsTotalNum    = 0;
     pCtx->iSubspsTotalNum = 0;
     pCtx->iPpsTotalNum    = 0;
-#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID		
+#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
   }
 
   uiProfileIdc	= BsGetBits (pBs, 8);
@@ -705,7 +705,7 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
     pSubsetSps	= &pCtx->sSubsetSpsBuffer[iSpsId];
     pSps		= &pSubsetSps->sSps;
     pCtx->bSubspsAvailFlags[iSpsId]	= true; // added for EC, 10/28/2009
-#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID			
+#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
   } else {
 #ifdef MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
     pSps = &pCtx->sSpsBuffer[pCtx->iSpsTotalNum];
@@ -716,7 +716,7 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
 #else
     pSps = &pCtx->sSpsBuffer[iSpsId];
     pCtx->bSpsAvailFlags[iSpsId] = true; // added for EC, 10/28/2009
-#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID		
+#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
   }
 
   // syntax elements in default
@@ -858,7 +858,7 @@ int32_t ParsePps (PWelsDecoderContext pCtx, PPps pPpsList, PBitStringAux pBsAux)
   pPps = &pPpsList[pCtx->iPpsTotalNum];
 #else
   pPps = &pPpsList[uiPpsId];
-#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID	
+#endif //MOSAIC_AVOID_BASED_ON_SPS_PPS_ID
 
 
   pPps->iPpsId = uiPpsId;

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -176,7 +176,7 @@ void_t WelsDecoderDefaults (PWelsDecoderContext pCtx) {
     g_uiCacheLineSize	= 32;
   }
 #endif//HAVE_CACHE_LINE_ALIGN
-#endif//X86_ASM	
+#endif//X86_ASM
 
   pCtx->iImgWidthInPixel		= 0;
   pCtx->iImgHeightInPixel		= 0;		// alloc picture data when picture size is available

--- a/codec/decoder/core/src/mc.cpp
+++ b/codec/decoder/core/src/mc.cpp
@@ -664,7 +664,7 @@ void_t InitMcFunc (SMcFunc* pMcFunc, int32_t iCpu) {
     pMcFunc->pMcLumaFunc   = McLuma_sse2;
     pMcFunc->pMcChromaFunc = McChroma_sse2;
   }
-#endif //(X86_ASM)	
+#endif //(X86_ASM)
 }
 
 } // namespace WelsDec

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -94,7 +94,7 @@ CWelsDecoder::CWelsDecoder (void_t)
   str_t chFileNameSize[1024] = { 0 }; //for .len
   int iBufUsedSize = 0;
   int iBufLeftSize = 1023;
-#endif//OUTPUT_BIT_STREAM 
+#endif//OUTPUT_BIT_STREAM
 
   m_pTrace = CreateWelsTrace (Wels_Trace_Type);
 

--- a/codec/encoder/core/inc/as264_common.h
+++ b/codec/encoder/core/inc/as264_common.h
@@ -50,7 +50,7 @@ $(TargetPath)
 /****************************************************************************
  * Options for algorithm, usually change bitrate
  ****************************************************************************/
-#define DISABLE_FMO_FEATURE	// 
+#define DISABLE_FMO_FEATURE	//
 
 /****************************************************************************
  * Options for optimization, not change bitrate

--- a/codec/encoder/core/inc/cpu_core.h
+++ b/codec/encoder/core/inc/cpu_core.h
@@ -58,7 +58,7 @@
 /* CPU features application extensive */
 #define WELS_CPU_AVX		0x00000800	/* Advanced Vector eXtentions */
 #define WELS_CPU_FPU		0x00001000	/* x87-FPU on chip */
-#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature: 
+#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature:
 										   physical processor package is capable of supporting more than one logic processor
 										*/
 #define WELS_CPU_CMOV		0x00004000	/* Conditional Move Instructions,

--- a/codec/encoder/core/inc/encoder_context.h
+++ b/codec/encoder/core/inc/encoder_context.h
@@ -54,7 +54,7 @@
 #include "wels_func_ptr_def.h"
 
 #ifdef MT_ENABLED
-#include "mt_defs.h"	// for multiple threadin, 
+#include "mt_defs.h"	// for multiple threadin,
 #include "WelsThreadLib.h"
 #endif//MT_ENALBED
 
@@ -223,7 +223,7 @@ typedef struct TagWelsEncCtx {
   // overall stat pData, refer to SStatData in stat.h, in case avc to use stat[0][0]
   SStatData					sStatData [ MAX_DEPENDENCY_LAYER ] [ MAX_QUALITY_LEVEL ];
   SStatSliceInfo				sPerInfo;
-#endif//STAT_OUTPUT	
+#endif//STAT_OUTPUT
 
 } sWelsEncCtx/*, *PWelsEncCtx*/;
 }

--- a/codec/encoder/core/inc/macros.h
+++ b/codec/encoder/core/inc/macros.h
@@ -86,7 +86,7 @@ namespace WelsSVCEnc {
 #define __FASTCALL    __attribute__ ((fastcall))
 #else
 #define __FASTCALL	// mean NULL for mac ppc
-#endif//MAC_POWERPC    
+#endif//MAC_POWERPC
 #define ALIGNED_DECLARE( type, var, n ) type var __attribute__((aligned(n)))
 #define __align8(t,v) t v __attribute__ ((aligned (8)))
 #define __align16(t,v) t v __attribute__ ((aligned (16)))

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -103,7 +103,7 @@ float		fOutputFrameRate;		// output frame rate
 
 #ifdef ENABLE_FRAME_DUMP
 str_t		sRecFileName[MAX_FNAME_LEN];	// file to be constructed
-#endif//ENABLE_FRAME_DUMP	
+#endif//ENABLE_FRAME_DUMP
 } SDLayerParam;
 
 /*

--- a/codec/encoder/core/inc/svc_enc_slice_segment.h
+++ b/codec/encoder/core/inc/svc_enc_slice_segment.h
@@ -68,7 +68,7 @@ SM_RESERVED				= 5
 // fine solution for MAX_SLICES_NUM, need us use the variable instead of MACRO for any resolution combining any multiple-slice mode adaptive
 #define SAVED_NALUNIT_NUM			( (MAX_SPATIAL_LAYER_NUM*MAX_QUALITY_LAYER_NUM) + 1 + MAX_SPATIAL_LAYER_NUM ) // SPS/PPS + SEI/SSEI + PADDING_NAL
 #define MAX_SLICES_NUM				( ( MAX_NAL_UNITS_IN_LAYER - SAVED_NALUNIT_NUM ) / 3 )	// Also MAX_SLICES_NUM need constrained by implementation: uiSliceIdc allocated in SSliceCtx.pOverallMbMap need a byte range as expected
-#define AVERSLICENUM_CONSTRAINT		(MAX_SLICES_NUM)			// used in sNalList initialization, 
+#define AVERSLICENUM_CONSTRAINT		(MAX_SLICES_NUM)			// used in sNalList initialization,
 
 #define MIN_NUM_MB_PER_SLICE		48							// (128/16 * 96/16), addressing the lowest resolution for multiple slicing is 128x96 above
 

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -498,7 +498,7 @@ int32_t RequestMtResource (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPara
 #ifdef PACKING_ONE_SLICE_PER_LAYER
   pSmt->pCountBsSizeInPartition	= (uint32_t*)pMa->WelsMalloc (sizeof (uint32_t) * iThreadNum, "pCountBsSizeInPartition");
   WELS_VERIFY_RETURN_PROC_IF (1, (NULL == pSmt->pCountBsSizeInPartition), FreeMemorySvc (ppCtx))
-#endif//PACKING_ONE_SLICE_PER_LAYER	
+#endif//PACKING_ONE_SLICE_PER_LAYER
 
   WelsMutexInit (&pSmt->mutexSliceNumUpdate);
 
@@ -592,7 +592,7 @@ void ReleaseMtResource (sWelsEncCtx** ppCtx) {
     ename[used_len] = '\0';
     WelsEventClose (pSmt->pFinUpdateMbListEvent[iIdx], ename);
 #endif//DYNAMIC_SLICE_ASSIGN && TRY_SLICING_BALANCE
-#endif//_WIN32		
+#endif//_WIN32
 
     ++ iIdx;
   }
@@ -930,7 +930,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
   pEventsList[iEventCount++]	= pEncPEncCtx->pSliceThreading->pExitEncodeEvent[iEventIdx];
 #if defined(DYNAMIC_SLICE_ASSIGN) && defined(TRY_SLICING_BALANCE)
   pEventsList[iEventCount++] = pEncPEncCtx->pSliceThreading->pUpdateMbListEvent[iEventIdx];
-#endif//#if defined(DYNAMIC_SLICE_ASSIGN) && defined(TRY_SLICING_BALANCE)	
+#endif//#if defined(DYNAMIC_SLICE_ASSIGN) && defined(TRY_SLICING_BALANCE)
 #endif//_WIN32
 
   do {
@@ -945,7 +945,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
              iEventIdx, (void*) (pEncPEncCtx->pReadySliceCodingEvent[iEventIdx]), (void*)pEncPEncCtx);
 #endif
     iWaitRet = WelsEventWait (pEncPEncCtx->pSliceThreading->pReadySliceCodingEvent[iEventIdx]);
-#endif//WIN32		
+#endif//WIN32
     if (WELS_THREAD_ERROR_WAIT_OBJECT_0 == iWaitRet) {	// start pSlice coding signal waited
       SLayerBSInfo* pLbi = pPrivateData->pLayerBs;
       const int32_t kiCurDid			= pEncPEncCtx->uiDependencyId;
@@ -1052,7 +1052,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
                  eNalRefIdc,
                  iSliceSize
                 );
-#endif//SLICE_INFO_OUTPUT				
+#endif//SLICE_INFO_OUTPUT
 
 #if MT_DEBUG_BS_WR
         pSliceBs->bSliceCodedFlag	= TRUE;
@@ -1063,7 +1063,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
           &pEncPEncCtx->pSliceThreading->pSliceCodedEvent[iEventIdx]);	// mean finished coding current pSlice
 #else
         WelsEventSignal (pEncPEncCtx->pSliceThreading->pSliceCodedEvent[iEventIdx]);	// mean finished coding current pSlice
-#endif//WIN32				
+#endif//WIN32
       } else {	// for SM_DYN_SLICE parallelization
 #ifdef PACKING_ONE_SLICE_PER_LAYER
         SLayerBSInfo* pLbiPacking			= NULL;
@@ -1158,7 +1158,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
                    eNalRefIdc,
                    iSliceSize
                   );
-#endif//SLICE_INFO_OUTPUT					
+#endif//SLICE_INFO_OUTPUT
 
 #if defined(ENABLE_TRACE_MT)
           WelsLog (pEncPEncCtx, WELS_LOG_INFO,
@@ -1196,7 +1196,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
         &pEncPEncCtx->pSliceThreading->pFinUpdateMbListEvent[iEventIdx]);	// mean finished update pMb list for this pSlice
     }
 #endif//#if defined(DYNAMIC_SLICE_ASSIGN) && defined(TRY_SLICING_BALANCE)
-#endif//WIN32		
+#endif//WIN32
     else { // WELS_THREAD_ERROR_WAIT_TIMEOUT, or WELS_THREAD_ERROR_WAIT_FAILED
       WelsLog (pEncPEncCtx, WELS_LOG_WARNING,
                "[MT] CodingSliceThreadProc(), waiting pReadySliceCodingEvent[%d] failed(%d) and thread%d terminated!\n", iEventIdx,

--- a/codec/encoder/core/src/svc_encode_slice.cpp
+++ b/codec/encoder/core/src/svc_encode_slice.cpp
@@ -869,7 +869,7 @@ BOOL_T DynSlcJudgeSliceBoundaryStepBack (void* pCtx, void* pSlice, SSliceCtx* pS
     && (kbSliceNumNotExceedConstraint
 #ifdef MT_ENABLED
         && ((pCurSlice->uiSliceIdx + kiActiveThreadsNum) < pSliceCtx->iMaxSliceNumConstraint)
-#endif//MT_ENABLED	
+#endif//MT_ENABLED
        )//able to add new pSlice
 
   ) {
@@ -974,7 +974,7 @@ void WelsMdInterMbLoop (sWelsEncCtx* pEncCtx, SSlice* pSlice, void* pWelsMd, con
 
 #if defined(MB_TYPES_CHECK)
     WelsCountMbType (pEncCtx->sPerInfo.iMbCount, P_SLICE, pCurMb);
-#endif//MB_TYPES_CHECK			
+#endif//MB_TYPES_CHECK
 
     //step (8): update status and other parameters
     pEncCtx->pFuncList->pfRc.pfWelsRcMbInfoUpdate (pEncCtx, pCurMb, pMd->iCostLuma, pSlice);
@@ -1096,7 +1096,7 @@ void WelsMdInterMbLoopOverDynamicSlice (sWelsEncCtx* pEncCtx, SSlice* pSlice, vo
 
 #if defined(MB_TYPES_CHECK)
     WelsCountMbType (pEncCtx->sPerInfo.iMbCount, P_SLICE, pCurMb);
-#endif//MB_TYPES_CHECK			
+#endif//MB_TYPES_CHECK
 
     //step (8): update status and other parameters
     pEncCtx->pFuncList->pfRc.pfWelsRcMbInfoUpdate (pEncCtx, pCurMb, pMd->iCostLuma, pSlice);

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -113,7 +113,7 @@ CWelsH264SVCEncoder::CWelsH264SVCEncoder()
   time (&tTime);
   tTimeNow = (struct tm*)localtime (&tTime);
   gettimeofday (&tTimev, NULL);
-#endif//WIN32	
+#endif//WIN32
 
 #ifdef _WIN32
 #if defined(_MSC_VER)
@@ -144,7 +144,7 @@ CWelsH264SVCEncoder::CWelsH264SVCEncoder()
                              tTimeNow
 #endif//_MSC_VER>=1500
                             );
-#endif//_MSC_VER			
+#endif//_MSC_VER
 #endif//__GNUC__
     iBufferLeft -= iBufferUsed;
   }
@@ -608,11 +608,11 @@ int CWelsH264SVCEncoder::EncodeFrame (const unsigned char* pSrc, SFrameBSInfo* p
   ++ m_uiCountFrameNum;
   WelsLog (m_pEncContext, WELS_LOG_INFO,
            "CWelsH264SVCEncoder::EncodeFrame(), m_uiCountFrameNum= %d, m_iCspInternal= 0x%x\n", m_uiCountFrameNum, m_iCspInternal);
-#endif//REC_FRAME_COUNT		
+#endif//REC_FRAME_COUNT
 
 #ifdef DUMP_SRC_PICTURE
   DumpSrcPicture (pSrc);
-#endif // DUMP_SRC_PICTURE	
+#endif // DUMP_SRC_PICTURE
 
   return uiFrameType;
 }
@@ -724,7 +724,7 @@ int CWelsH264SVCEncoder::EncodeFrame (const SSourcePicture**   pSrcPicList, int 
 #endif //OUTPUT_BIT_STREAM
 #ifdef DUMP_SRC_PICTURE
   DumpSrcPicture (pSrcPicList[0]->pData[0]);
-#endif // DUMP_SRC_PICTURE	
+#endif // DUMP_SRC_PICTURE
 
   return iFrameType;
 
@@ -1125,7 +1125,7 @@ void CWelsH264SVCEncoder::DumpSrcPicture (const uint8_t* pSrc) {
 #else
     pFile = FOPEN (strFileName, "ab+");
 #endif//_MSC_VER>=1500
-#endif//_MSC_VER			
+#endif//_MSC_VER
 #endif//__GNUC__
     //				WelsLog( m_pEncContext, WELS_LOG_INFO, "WELS_CSP_I420, m_iCspInternal= 0x%x\n", m_iCspInternal);
     if (NULL != pFile) {
@@ -1145,7 +1145,7 @@ void CWelsH264SVCEncoder::DumpSrcPicture (const uint8_t* pSrc) {
 #else
     pFile = FOPEN (strFileName, "ab+");
 #endif//_MSC_VER>=1500
-#endif//_MSC_VER			
+#endif//_MSC_VER
 #endif//__GNUC__
     if (NULL != pFile) {
       fwrite (pSrc, sizeof (uint8_t), iDataLength * 3, pFile);
@@ -1163,7 +1163,7 @@ void CWelsH264SVCEncoder::DumpSrcPicture (const uint8_t* pSrc) {
 #else
     pFile = FOPEN (strFileName, "ab+");
 #endif//_MSC_VER>=1500
-#endif//_MSC_VER			
+#endif//_MSC_VER
 #endif//__GNUC__
     //				WelsLog( m_pEncContext, WELS_LOG_INFO, "WELS_CSP_BGR, m_iCspInternal= 0x%x\n", m_iCspInternal);
     if (NULL != pFile) {
@@ -1183,7 +1183,7 @@ void CWelsH264SVCEncoder::DumpSrcPicture (const uint8_t* pSrc) {
 #else
     pFile = FOPEN (strFileName, "ab+");
 #endif//_MSC_VER>=1500
-#endif//_MSC_VER			
+#endif//_MSC_VER
 #endif//__GNUC__
     if (NULL != pFile) {
       fwrite (pSrc, sizeof (uint8_t), (CALC_BI_STRIDE (m_iMaxPicWidth,  16)) * m_iMaxPicHeight, pFile);

--- a/codec/processing/src/common/cpu.h
+++ b/codec/processing/src/common/cpu.h
@@ -62,7 +62,7 @@ WELSVP_NAMESPACE_BEGIN
 /* CPU features application extensive */
 #define WELS_CPU_AVX		0x00000800	/* Advanced Vector eXtentions */
 #define WELS_CPU_FPU		0x00001000	/* x87-FPU on chip */
-#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature: 
+#define WELS_CPU_HTT		0x00002000	/* Hyper-Threading Technology (HTT), Multi-threading enabled feature:
 										   physical processor package is capable of supporting more than one logic processor
 										*/
 #define WELS_CPU_CMOV		0x00004000	/* Conditional Move Instructions,


### PR DESCRIPTION
The astyle cleanup keeps trailing whitespace within comments,
but the whitespace here is not significant nor intentional
and thus should be removed.
