### PR TITLE
Rerun astyle on the C++ source files

### DIFF
--- a/CODING_STYLE
+++ b/CODING_STYLE
@@ -4,5 +4,5 @@ Try to follow the style of the existing code.
 
 Please do not add tabs, trailing whitespace, or Windows-style line endings (CRLF).
 
-The C++ code was pretty-printed with astyle on 12/12/2013 using the configuration found in build/astyle.cfg
+The C++ code was pretty-printed with astyle on 05/01/2014 using the configuration found in build/astyle.cfg
 

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -905,13 +905,13 @@ int ProcessEncodingSvcWithParam (ISVCEncoder* pPtrEnc, int argc, char** argv) {
   int iParsedNum = 3;
   if (ParseCommandLine (argc - iParsedNum, argv + iParsedNum, sSvcParam) != 0) {
     printf ("parse pCommand line failed\n");
-    fclose(pFpSrc);
+    fclose (pFpSrc);
     return 1;
   }
 
   if (cmResultSuccess != pPtrEnc->Initialize (&sSvcParam, INIT_TYPE_PARAMETER_BASED)) {
     fprintf (stderr, "Encoder Initialization failed!\n");
-    fclose(pFpSrc);
+    fclose (pFpSrc);
     return 1;
   }
 
@@ -1416,12 +1416,12 @@ int main (int argc, char** argv)
   if (argc < 2) {
     goto exit;
   } else {
-    if (!strstr(argv[1], ".cfg")) { // check configuration type (like .cfg?)
+    if (!strstr (argv[1], ".cfg")) { // check configuration type (like .cfg?)
       if (argc > 2) {
         iRet = ProcessEncodingSvcWithParam (pSVCEncoder, argc, argv);
         if (iRet != 0)
           goto exit;
-      } else if (argc == 2 && ! strcmp(argv[1], "-h"))
+      } else if (argc == 2 && ! strcmp (argv[1], "-h"))
         PrintHelp();
       else {
         cout << "You specified pCommand is invalid!!" << endl;

--- a/codec/encoder/core/src/deblocking.cpp
+++ b/codec/encoder/core/src/deblocking.cpp
@@ -994,7 +994,7 @@ void  DeblockingInit (DeblockingFunc*   pFunc,  int32_t iCpu) {
 
 
 #ifdef X86_ASM
-  if (iCpu & WELS_CPU_SSE2) {	  
+  if (iCpu & WELS_CPU_SSE2) {
     pFunc->pfLumaDeblockingLT4Ver	= DeblockLumaLt4V_sse2;
     pFunc->pfLumaDeblockingEQ4Ver	= DeblockLumaEq4V_sse2;
     pFunc->pfLumaDeblockingLT4Hor       = DeblockLumaLt4H_sse2;
@@ -1002,7 +1002,7 @@ void  DeblockingInit (DeblockingFunc*   pFunc,  int32_t iCpu) {
     pFunc->pfChromaDeblockingLT4Ver	= DeblockChromaLt4V_sse2;
     pFunc->pfChromaDeblockingEQ4Ver	= DeblockChromaEq4V_sse2;
     pFunc->pfChromaDeblockingLT4Hor	= DeblockChromaLt4H_sse2;
-    pFunc->pfChromaDeblockinEQ4Hor	= DeblockChromaEq4H_sse2; 
+    pFunc->pfChromaDeblockinEQ4Hor	= DeblockChromaEq4H_sse2;
   }
 #endif
 }

--- a/codec/encoder/core/src/decode_mb_aux.cpp
+++ b/codec/encoder/core/src/decode_mb_aux.cpp
@@ -261,15 +261,15 @@ void WelsInitReconstructionFuncs (SWelsFuncPtrList* pFuncList, uint32_t  uiCpuFl
 
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_MMXEXT) {
-  //  pFuncList->pfIDctT4		= WelsIDctT4Rec_mmx;
+    //  pFuncList->pfIDctT4		= WelsIDctT4Rec_mmx;
   }
   if (uiCpuFlag & WELS_CPU_SSE2) {
-   /* pFuncList->pfDequantization4x4			= WelsDequant4x4_sse2;
-    pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_sse2;
-    pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_sse2;
+    /* pFuncList->pfDequantization4x4			= WelsDequant4x4_sse2;
+     pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_sse2;
+     pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_sse2;
 
-    pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_sse2;
-    pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_sse2;*/
+     pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_sse2;
+     pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_sse2;*/
   }
 #endif//X86_ASM
 }

--- a/codec/encoder/core/src/encode_mb_aux.cpp
+++ b/codec/encoder/core/src/encode_mb_aux.cpp
@@ -569,7 +569,7 @@ void WelsInitEncodingFuncs (SWelsFuncPtrList* pFuncList, uint32_t  uiCpuFlag) {
   }
 //#ifndef MACOS
   if (uiCpuFlag & WELS_CPU_SSSE3) {
-  //  pFuncList->pfScan4x4				= WelsScan4x4DcAc_ssse3;
+    //  pFuncList->pfScan4x4				= WelsScan4x4DcAc_ssse3;
   }
 
 //#endif//MACOS

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2124,8 +2124,8 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
 
 #if defined(MEMORY_MONITOR)
   WelsLog (pCtx, WELS_LOG_INFO, "WelsInitEncoderExt() exit, overall memory usage: %llu bytes\n",
-           static_cast<unsigned long long>(sizeof (sWelsEncCtx) /* requested size from malloc() or new operator */
-           + pCtx->pMemAlign->WelsGetMemoryUsage())	/* requested size from CMemoryAlign::WelsMalloc() */
+           static_cast<unsigned long long> (sizeof (sWelsEncCtx) /* requested size from malloc() or new operator */
+               + pCtx->pMemAlign->WelsGetMemoryUsage())	/* requested size from CMemoryAlign::WelsMalloc() */
           );
 #endif//MEMORY_MONITOR
 
@@ -2944,7 +2944,7 @@ int32_t WritePadding (sWelsEncCtx* pCtx, int32_t iLen) {
 #if GOM_TRACE_FLAG
     WelsLog (pCtx, WELS_LOG_ERROR,
              "[RC] paddingcal pBuffer overflow, bufferlen=%lld, paddinglen=%d, iNalIdx= %d, iCountNals= %d\n",
-             static_cast<long long int>(pBs->pBufEnd - pBs->pBufPtr), iLen, iNal, pCtx->pOut->iCountNals);
+             static_cast<long long int> (pBs->pBufEnd - pBs->pBufPtr), iLen, iNal, pCtx->pOut->iCountNals);
 #endif
     return 0;
   }

--- a/codec/encoder/core/src/expand_pic.cpp
+++ b/codec/encoder/core/src/expand_pic.cpp
@@ -34,7 +34,7 @@
 #include "cpu_core.h"
 #include "wels_func_ptr_def.h"
 
-namespace WelsSVCEnc{
+namespace WelsSVCEnc {
 // rewrite it (split into luma & chroma) that is helpful for mmx/sse2 optimization perform, 9/27/2009
 static inline void ExpandPictureLuma_c (uint8_t* pDst, const int32_t kiStride, const int32_t kiPicW,
                                         const int32_t kiPicH) {

--- a/codec/encoder/core/src/get_intra_predictor.cpp
+++ b/codec/encoder/core/src/get_intra_predictor.cpp
@@ -80,13 +80,13 @@ void WelsInitFillingPredFuncs (const uint32_t kuiCpuFlag) {
 
 #if defined(X86_ASM)
   if (kuiCpuFlag & WELS_CPU_MMXEXT) {
-  //  WelsFillingPred8to16		= WelsFillingPred8to16_mmx;
-  //  WelsFillingPred8x2to16	    = WelsFillingPred8x2to16_mmx;
-  //  WelsFillingPred1to16		= WelsFillingPred1to16_mmx;
+    //  WelsFillingPred8to16		= WelsFillingPred8to16_mmx;
+    //  WelsFillingPred8x2to16	    = WelsFillingPred8x2to16_mmx;
+    //  WelsFillingPred1to16		= WelsFillingPred1to16_mmx;
   }
   if (kuiCpuFlag & WELS_CPU_SSE2) {
-   // WelsFillingPred8x2to16	    = WelsFillingPred8x2to16_sse2;
-   // WelsFillingPred1to16		= WelsFillingPred1to16_sse2;
+    // WelsFillingPred8x2to16	    = WelsFillingPred8x2to16_sse2;
+    // WelsFillingPred1to16		= WelsFillingPred1to16_sse2;
   }
 #endif//X86_ASM
 }

--- a/codec/encoder/core/src/mc.cpp
+++ b/codec/encoder/core/src/mc.cpp
@@ -441,8 +441,9 @@ static inline void McHorVer22WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, 
   McHorVer22WidthEq8_sse2 (pSrc,     iSrcStride, pDst,     iDstStride, iHeight);
   McHorVer22WidthEq8_sse2 (&pSrc[8], iSrcStride, &pDst[8], iDstStride, iHeight);
 }
-void McHorVer22Width9Or17Height9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
-                      int32_t iHeight) {
+void McHorVer22Width9Or17Height9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+    int32_t iWidth,
+    int32_t iHeight) {
   ENFORCE_STACK_ALIGN_2D (int16_t, pTap, 22, 24, 16)
   int32_t tmp1 = 2 * (iWidth - 8);
   McHorVer22HorFirst_sse2 (pSrc - 2, iSrcStride, (uint8_t*)pTap, 48, iWidth, iHeight + 5);

--- a/codec/encoder/core/src/set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cavlc.cpp
@@ -207,7 +207,7 @@ void InitCoeffFunc (const uint32_t uiCpuFlag) {
 
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_SSE2) {
-   // sCoeffFunc.pfCavlcParamCal = CavlcParamCal_sse2;
+    // sCoeffFunc.pfCavlcParamCal = CavlcParamCal_sse2;
   }
 #endif
 }

--- a/codec/encoder/core/src/utils.cpp
+++ b/codec/encoder/core/src/utils.cpp
@@ -252,7 +252,7 @@ void WelsLogDefault (void* pCtx, const int32_t kiLevel, const str_t* kpFmtStr, v
 #endif//_MSC_VER
 #elif defined (__GNUC__)
         iCurUsed = SNPRINTF (&pBuf[iBufUsed], iBufLeft, ".%3.3u]: ",
-            static_cast<unsigned int>(tv.tv_usec / 1000));	// confirmed_safe_unsafe_usage
+                             static_cast<unsigned int> (tv.tv_usec / 1000));	// confirmed_safe_unsafe_usage
 #endif//WIN32
         if (iCurUsed >= 0) {
           iBufUsed += iCurUsed;

--- a/codec/processing/src/adaptivequantization/AdaptiveQuantization.cpp
+++ b/codec/processing/src/adaptivequantization/AdaptiveQuantization.cpp
@@ -223,7 +223,7 @@ void CAdaptiveQuantization::WelsInitVarFunc (PVarFunc& pfVar,  int32_t iCpuFlag)
 
 #ifdef X86_ASM
   if (iCpuFlag & WELS_CPU_SSE2) {
-   // pfVar = SampleVariance16x16_sse2;
+    // pfVar = SampleVariance16x16_sse2;
   }
 #endif
 }

--- a/codec/processing/src/downsample/downsample.cpp
+++ b/codec/processing/src/downsample/downsample.cpp
@@ -57,21 +57,21 @@ void CDownsampling::InitDownsampleFuncs (SDownsampleFuncs& sDownsampleFunc,  int
   sDownsampleFunc.pfGeneralRatioLuma	 = GeneralBilinearFastDownsampler_c;
 #if defined(X86_ASM)
   if (iCpuFlag & WELS_CPU_SSE) {
-  /*  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse;
-    sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse;
-    sDownsampleFunc.pfHalfAverage[2]	= DyadicBilinearDownsamplerWidthx8_sse;*/
+    /*  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse;
+      sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse;
+      sDownsampleFunc.pfHalfAverage[2]	= DyadicBilinearDownsamplerWidthx8_sse;*/
   }
   if (iCpuFlag & WELS_CPU_SSE2) {
-  //  sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsamplerWrap_sse2;
-  //  sDownsampleFunc.pfGeneralRatioLuma   = GeneralBilinearFastDownsamplerWrap_sse2;
+    //  sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsamplerWrap_sse2;
+    //  sDownsampleFunc.pfGeneralRatioLuma   = GeneralBilinearFastDownsamplerWrap_sse2;
   }
   if (iCpuFlag & WELS_CPU_SSSE3) {
-  //  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_ssse3;
-  //  sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_ssse3;
+    //  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_ssse3;
+    //  sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_ssse3;
   }
   if (iCpuFlag & WELS_CPU_SSE41) {
-  //  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse4;
-  //  sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse4;
+    //  sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse4;
+    //  sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse4;
   }
 #endif//X86_ASM
 

--- a/codec/processing/src/vaacalc/vaacalculation.cpp
+++ b/codec/processing/src/vaacalc/vaacalculation.cpp
@@ -58,11 +58,11 @@ void CVAACalculation::InitVaaFuncs (SVaaFuncs& sVaaFuncs, int32_t iCpuFlag) {
   sVaaFuncs.pfVAACalcSadVar			= VAACalcSadVar_c;
 #ifdef X86_ASM
   if ((iCpuFlag & WELS_CPU_SSE2) == WELS_CPU_SSE2) {
-   /* sVaaFuncs.pfVAACalcSad			= VAACalcSad_sse2;
-    sVaaFuncs.pfVAACalcSadBgd		= VAACalcSadBgd_sse2;
-    sVaaFuncs.pfVAACalcSadSsd		= VAACalcSadSsd_sse2;
-    sVaaFuncs.pfVAACalcSadSsdBgd = VAACalcSadSsdBgd_sse2;
-    sVaaFuncs.pfVAACalcSadVar		= VAACalcSadVar_sse2;*/
+    /* sVaaFuncs.pfVAACalcSad			= VAACalcSad_sse2;
+     sVaaFuncs.pfVAACalcSadBgd		= VAACalcSadBgd_sse2;
+     sVaaFuncs.pfVAACalcSadSsd		= VAACalcSadSsd_sse2;
+     sVaaFuncs.pfVAACalcSadSsdBgd = VAACalcSadSsdBgd_sse2;
+     sVaaFuncs.pfVAACalcSadVar		= VAACalcSadVar_sse2;*/
   }
 #endif//X86_ASM
 }


### PR DESCRIPTION
astyle was only run on .cpp files this time - already in
ff6b66917 where the style cleanup was done initially, not all
.h files seem to have gotten the same styling (rerunning astyle
on .h files at that commit produces a huge diff).
