### PR TITLE
Check the return value from fread

### DIFF
--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -141,7 +141,10 @@ void_t H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, co
     goto label_exit;
   }
 
-  fread (pBuf, 1, iFileSize, pH264File);
+  if (fread (pBuf, 1, iFileSize, pH264File) != iFileSize) {
+    fprintf (stderr, "fread failed!\n");
+    goto label_exit;
+  }
   memcpy (pBuf + iFileSize, &uiStartCode[0], 4); //confirmed_safe_unsafe_usage
 
   if (pDecoder->SetOption (DECODER_OPTION_DATAFORMAT,  &iColorFormat)) {


### PR DESCRIPTION
This fixes build failures on linux due to building with -Werror,
since fread is marked with the warn_unused_result attribute
in certain glibc versions.
