### PR TITLE
Use MSVC inline assembly only on (32-bit) X86

### DIFF
--- a/codec/decoder/core/src/bit_stream.cpp
+++ b/codec/decoder/core/src/bit_stream.cpp
@@ -48,7 +48,7 @@ inline uint32_t EndianFix (uint32_t uiX) {
 }
 #else //WORDS_BIGENDIAN
 
-#if defined(WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
 inline uint32_t EndianFix (uint32_t uiX) {
   __asm {
     mov   eax,  uiX

--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -708,7 +708,7 @@ static int32_t CavlcGetLevelVal (int32_t iLevel[16], SReadBitsCache* pBitsCache,
 
   for (; i < uiTotalCoeff; i++) {
     if (pBitsCache->uiRemainBits <= 16)		SHIFT_BUFFER (pBitsCache);
-#if defined(WIN32) && !defined(WIN64) && defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
     uiCache32Bit = pBitsCache->uiCache32Bit;
     WELS_GET_PREFIX_BITS (uiCache32Bit, iPrefixBits);
 #else
@@ -811,7 +811,7 @@ static int32_t	CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, 
           iRun[i] = pVlcTable->kpZeroTable[6][uiValue][0];
         } else {
           if (pBitsCache->uiRemainBits < 16) SHIFT_BUFFER (pBitsCache);
-#if defined(WIN32) && !defined(WIN64) && defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
           uiCache32Bit = pBitsCache->uiCache32Bit;
           WELS_GET_PREFIX_BITS (uiCache32Bit, iPrefixBits);
 #else

--- a/codec/encoder/core/inc/macros.h
+++ b/codec/encoder/core/inc/macros.h
@@ -273,7 +273,7 @@ return x;
 #else
 
 
-#if defined(WIN32) && !defined(WIN64) && defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
 static inline uint32_t ENDIAN_FIX (uint32_t x) {
 __asm {
   mov   eax,  x


### PR DESCRIPTION
Currently this used the _MSC_VER && !WIN64 to enable the inline
assembly, which still tried to use this code on windows on arm.
Using _MSC_VER && _M_IX86 is enough since _M_IX86 is defined only
when targeting 32 bit x86, not for x64.
