### PR TITLE
Update the readme with current platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Decoder Features
 
 OS Support
 ----------
-- Windows 64-bit and 32-bit (initial release is only 32-bit, 64-bit will follow soon)
-- Mac OS X 64-bit (initial release does not include this target, will follow soon)
-- Linux 64-bit and 32-bit (initial release is only 32-bit, 64-bit will follow soon)
+- Windows 64-bit and 32-bit
+- Mac OS X 64-bit and 32-bit
+- Linux 64-bit and 32-bit
 - Android 32-bit (initial release does not include this target, will follow soon)
 - iOS 64-bit and 32-bit (not supported yet, may be added in the future)
 


### PR DESCRIPTION
Both 32 and 64 bit is supported, on windows, linux and OS X,
including x86 assembly code.
