### PR TITLE
Regenerate the targets makefiles

### DIFF
--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -1,58 +1,31 @@
 COMMON_PREFIX=COMMON
 COMMON_SRCDIR=codec/common
 COMMON_CPP_SRCS=\
-	$(COMMON_SRCDIR)/./logging.cpp\
-	$(COMMON_SRCDIR)/./deblocking_common.cpp\
 	$(COMMON_SRCDIR)/./cpu.cpp\
+	$(COMMON_SRCDIR)/./deblocking_common.cpp\
+	$(COMMON_SRCDIR)/./logging.cpp\
 
 COMMON_OBJS += $(COMMON_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 COMMON_ASM_SRCS=\
-	$(COMMON_SRCDIR)/./deblock.asm\
-	$(COMMON_SRCDIR)/./vaa.asm\
 	$(COMMON_SRCDIR)/./asm_inc.asm\
-	$(COMMON_SRCDIR)/./mc_luma.asm\
 	$(COMMON_SRCDIR)/./cpuid.asm\
-	$(COMMON_SRCDIR)/./mc_chroma.asm\
-	$(COMMON_SRCDIR)/./mb_copy.asm\
+	$(COMMON_SRCDIR)/./deblock.asm\
 	$(COMMON_SRCDIR)/./expand_picture.asm\
+	$(COMMON_SRCDIR)/./mb_copy.asm\
+	$(COMMON_SRCDIR)/./mc_chroma.asm\
+	$(COMMON_SRCDIR)/./mc_luma.asm\
+	$(COMMON_SRCDIR)/./vaa.asm\
 
 COMMON_OBJS += $(COMMON_ASM_SRCS:.asm=.o)
 endif
 
 OBJS += $(COMMON_OBJS)
-$(COMMON_SRCDIR)/./logging.o: $(COMMON_SRCDIR)/./logging.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c -o $(COMMON_SRCDIR)/./logging.o $(COMMON_SRCDIR)/./logging.cpp
+$(COMMON_SRCDIR)/%.o: $(COMMON_SRCDIR)/%.cpp
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c -o $@ $<
 
-$(COMMON_SRCDIR)/./deblocking_common.o: $(COMMON_SRCDIR)/./deblocking_common.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c -o $(COMMON_SRCDIR)/./deblocking_common.o $(COMMON_SRCDIR)/./deblocking_common.cpp
-
-$(COMMON_SRCDIR)/./cpu.o: $(COMMON_SRCDIR)/./cpu.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c -o $(COMMON_SRCDIR)/./cpu.o $(COMMON_SRCDIR)/./cpu.cpp
-
-$(COMMON_SRCDIR)/./deblock.o: $(COMMON_SRCDIR)/./deblock.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./deblock.o $(COMMON_SRCDIR)/./deblock.asm
-
-$(COMMON_SRCDIR)/./vaa.o: $(COMMON_SRCDIR)/./vaa.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./vaa.o $(COMMON_SRCDIR)/./vaa.asm
-
-$(COMMON_SRCDIR)/./asm_inc.o: $(COMMON_SRCDIR)/./asm_inc.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./asm_inc.o $(COMMON_SRCDIR)/./asm_inc.asm
-
-$(COMMON_SRCDIR)/./mc_luma.o: $(COMMON_SRCDIR)/./mc_luma.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./mc_luma.o $(COMMON_SRCDIR)/./mc_luma.asm
-
-$(COMMON_SRCDIR)/./cpuid.o: $(COMMON_SRCDIR)/./cpuid.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./cpuid.o $(COMMON_SRCDIR)/./cpuid.asm
-
-$(COMMON_SRCDIR)/./mc_chroma.o: $(COMMON_SRCDIR)/./mc_chroma.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./mc_chroma.o $(COMMON_SRCDIR)/./mc_chroma.asm
-
-$(COMMON_SRCDIR)/./mb_copy.o: $(COMMON_SRCDIR)/./mb_copy.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./mb_copy.o $(COMMON_SRCDIR)/./mb_copy.asm
-
-$(COMMON_SRCDIR)/./expand_picture.o: $(COMMON_SRCDIR)/./expand_picture.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $(COMMON_SRCDIR)/./expand_picture.o $(COMMON_SRCDIR)/./expand_picture.asm
+$(COMMON_SRCDIR)/%.o: $(COMMON_SRCDIR)/%.asm
+	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(COMMON_ASMFLAGS) $(COMMON_ASM_INCLUDES) -o $@ $<
 
 $(LIBPREFIX)common.$(LIBSUFFIX): $(COMMON_OBJS)
 	rm -f $(LIBPREFIX)common.$(LIBSUFFIX)

--- a/codec/console/dec/targets.mk
+++ b/codec/console/dec/targets.mk
@@ -1,9 +1,9 @@
 H264DEC_PREFIX=H264DEC
 H264DEC_SRCDIR=codec/console/dec
 H264DEC_CPP_SRCS=\
-	$(H264DEC_SRCDIR)/./src/read_config.cpp\
-	$(H264DEC_SRCDIR)/./src/h264dec.cpp\
 	$(H264DEC_SRCDIR)/./src/d3d9_utils.cpp\
+	$(H264DEC_SRCDIR)/./src/h264dec.cpp\
+	$(H264DEC_SRCDIR)/./src/read_config.cpp\
 
 H264DEC_OBJS += $(H264DEC_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
@@ -13,16 +13,13 @@ H264DEC_OBJS += $(H264DEC_ASM_SRCS:.asm=.o)
 endif
 
 OBJS += $(H264DEC_OBJS)
-$(H264DEC_SRCDIR)/./src/read_config.o: $(H264DEC_SRCDIR)/./src/read_config.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(H264DEC_CFLAGS) $(H264DEC_INCLUDES) -c -o $(H264DEC_SRCDIR)/./src/read_config.o $(H264DEC_SRCDIR)/./src/read_config.cpp
+$(H264DEC_SRCDIR)/%.o: $(H264DEC_SRCDIR)/%.cpp
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(H264DEC_CFLAGS) $(H264DEC_INCLUDES) -c -o $@ $<
 
-$(H264DEC_SRCDIR)/./src/h264dec.o: $(H264DEC_SRCDIR)/./src/h264dec.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(H264DEC_CFLAGS) $(H264DEC_INCLUDES) -c -o $(H264DEC_SRCDIR)/./src/h264dec.o $(H264DEC_SRCDIR)/./src/h264dec.cpp
+$(H264DEC_SRCDIR)/%.o: $(H264DEC_SRCDIR)/%.asm
+	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(H264DEC_ASMFLAGS) $(H264DEC_ASM_INCLUDES) -o $@ $<
 
-$(H264DEC_SRCDIR)/./src/d3d9_utils.o: $(H264DEC_SRCDIR)/./src/d3d9_utils.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(H264DEC_CFLAGS) $(H264DEC_INCLUDES) -c -o $(H264DEC_SRCDIR)/./src/d3d9_utils.o $(H264DEC_SRCDIR)/./src/d3d9_utils.cpp
-
-h264dec: $(H264DEC_OBJS) $(LIBS) $(H264DEC_LIBS)
+h264dec: $(H264DEC_OBJS) $(LIBS) $(H264DEC_LIBS) $(H264DEC_DEPS)
 	$(CXX) -o $@  $(H264DEC_OBJS) $(H264DEC_LDFLAGS) $(H264DEC_LIBS) $(LDFLAGS) $(LIBS)
 
 binaries: h264dec

--- a/codec/decoder/targets.mk
+++ b/codec/decoder/targets.mk
@@ -1,114 +1,45 @@
 DECODER_PREFIX=DECODER
 DECODER_SRCDIR=codec/decoder
 DECODER_CPP_SRCS=\
-	$(DECODER_SRCDIR)/./core/src/mc.cpp\
-	$(DECODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
-	$(DECODER_SRCDIR)/./core/src/deblocking.cpp\
 	$(DECODER_SRCDIR)/./core/src/au_parser.cpp\
-	$(DECODER_SRCDIR)/./core/src/decode_slice.cpp\
-	$(DECODER_SRCDIR)/./core/src/pic_queue.cpp\
-	$(DECODER_SRCDIR)/./core/src/utils.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder.cpp\
-	$(DECODER_SRCDIR)/./core/src/fmo.cpp\
-	$(DECODER_SRCDIR)/./core/src/mv_pred.cpp\
-	$(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder_core.cpp\
-	$(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder_data_tables.cpp\
-	$(DECODER_SRCDIR)/./core/src/mem_align.cpp\
 	$(DECODER_SRCDIR)/./core/src/bit_stream.cpp\
-	$(DECODER_SRCDIR)/./core/src/manage_dec_ref.cpp\
-	$(DECODER_SRCDIR)/./core/src/rec_mb.cpp\
-	$(DECODER_SRCDIR)/./core/src/expand_pic.cpp\
+	$(DECODER_SRCDIR)/./core/src/deblocking.cpp\
 	$(DECODER_SRCDIR)/./core/src/decode_mb_aux.cpp\
-	$(DECODER_SRCDIR)/./plus/src/welsDecoderExt.cpp\
+	$(DECODER_SRCDIR)/./core/src/decode_slice.cpp\
+	$(DECODER_SRCDIR)/./core/src/decoder.cpp\
+	$(DECODER_SRCDIR)/./core/src/decoder_core.cpp\
+	$(DECODER_SRCDIR)/./core/src/decoder_data_tables.cpp\
+	$(DECODER_SRCDIR)/./core/src/expand_pic.cpp\
+	$(DECODER_SRCDIR)/./core/src/fmo.cpp\
+	$(DECODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
+	$(DECODER_SRCDIR)/./core/src/manage_dec_ref.cpp\
+	$(DECODER_SRCDIR)/./core/src/mc.cpp\
+	$(DECODER_SRCDIR)/./core/src/mem_align.cpp\
+	$(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.cpp\
+	$(DECODER_SRCDIR)/./core/src/mv_pred.cpp\
+	$(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.cpp\
+	$(DECODER_SRCDIR)/./core/src/pic_queue.cpp\
+	$(DECODER_SRCDIR)/./core/src/rec_mb.cpp\
+	$(DECODER_SRCDIR)/./core/src/utils.cpp\
 	$(DECODER_SRCDIR)/./plus/src/welsCodecTrace.cpp\
+	$(DECODER_SRCDIR)/./plus/src/welsDecoderExt.cpp\
 
 DECODER_OBJS += $(DECODER_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 DECODER_ASM_SRCS=\
+	$(DECODER_SRCDIR)/./core/asm/block_add.asm\
 	$(DECODER_SRCDIR)/./core/asm/dct.asm\
 	$(DECODER_SRCDIR)/./core/asm/intra_pred.asm\
-	$(DECODER_SRCDIR)/./core/asm/block_add.asm\
 
 DECODER_OBJS += $(DECODER_ASM_SRCS:.asm=.o)
 endif
 
 OBJS += $(DECODER_OBJS)
-$(DECODER_SRCDIR)/./core/src/mc.o: $(DECODER_SRCDIR)/./core/src/mc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/mc.o $(DECODER_SRCDIR)/./core/src/mc.cpp
+$(DECODER_SRCDIR)/%.o: $(DECODER_SRCDIR)/%.cpp
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $@ $<
 
-$(DECODER_SRCDIR)/./core/src/get_intra_predictor.o: $(DECODER_SRCDIR)/./core/src/get_intra_predictor.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/get_intra_predictor.o $(DECODER_SRCDIR)/./core/src/get_intra_predictor.cpp
-
-$(DECODER_SRCDIR)/./core/src/deblocking.o: $(DECODER_SRCDIR)/./core/src/deblocking.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/deblocking.o $(DECODER_SRCDIR)/./core/src/deblocking.cpp
-
-$(DECODER_SRCDIR)/./core/src/au_parser.o: $(DECODER_SRCDIR)/./core/src/au_parser.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/au_parser.o $(DECODER_SRCDIR)/./core/src/au_parser.cpp
-
-$(DECODER_SRCDIR)/./core/src/decode_slice.o: $(DECODER_SRCDIR)/./core/src/decode_slice.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/decode_slice.o $(DECODER_SRCDIR)/./core/src/decode_slice.cpp
-
-$(DECODER_SRCDIR)/./core/src/pic_queue.o: $(DECODER_SRCDIR)/./core/src/pic_queue.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/pic_queue.o $(DECODER_SRCDIR)/./core/src/pic_queue.cpp
-
-$(DECODER_SRCDIR)/./core/src/utils.o: $(DECODER_SRCDIR)/./core/src/utils.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/utils.o $(DECODER_SRCDIR)/./core/src/utils.cpp
-
-$(DECODER_SRCDIR)/./core/src/decoder.o: $(DECODER_SRCDIR)/./core/src/decoder.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/decoder.o $(DECODER_SRCDIR)/./core/src/decoder.cpp
-
-$(DECODER_SRCDIR)/./core/src/fmo.o: $(DECODER_SRCDIR)/./core/src/fmo.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/fmo.o $(DECODER_SRCDIR)/./core/src/fmo.cpp
-
-$(DECODER_SRCDIR)/./core/src/mv_pred.o: $(DECODER_SRCDIR)/./core/src/mv_pred.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/mv_pred.o $(DECODER_SRCDIR)/./core/src/mv_pred.cpp
-
-$(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.o: $(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.o $(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.cpp
-
-$(DECODER_SRCDIR)/./core/src/decoder_core.o: $(DECODER_SRCDIR)/./core/src/decoder_core.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/decoder_core.o $(DECODER_SRCDIR)/./core/src/decoder_core.cpp
-
-$(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.o: $(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.o $(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.cpp
-
-$(DECODER_SRCDIR)/./core/src/decoder_data_tables.o: $(DECODER_SRCDIR)/./core/src/decoder_data_tables.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/decoder_data_tables.o $(DECODER_SRCDIR)/./core/src/decoder_data_tables.cpp
-
-$(DECODER_SRCDIR)/./core/src/mem_align.o: $(DECODER_SRCDIR)/./core/src/mem_align.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/mem_align.o $(DECODER_SRCDIR)/./core/src/mem_align.cpp
-
-$(DECODER_SRCDIR)/./core/src/bit_stream.o: $(DECODER_SRCDIR)/./core/src/bit_stream.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/bit_stream.o $(DECODER_SRCDIR)/./core/src/bit_stream.cpp
-
-$(DECODER_SRCDIR)/./core/src/manage_dec_ref.o: $(DECODER_SRCDIR)/./core/src/manage_dec_ref.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/manage_dec_ref.o $(DECODER_SRCDIR)/./core/src/manage_dec_ref.cpp
-
-$(DECODER_SRCDIR)/./core/src/rec_mb.o: $(DECODER_SRCDIR)/./core/src/rec_mb.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/rec_mb.o $(DECODER_SRCDIR)/./core/src/rec_mb.cpp
-
-$(DECODER_SRCDIR)/./core/src/expand_pic.o: $(DECODER_SRCDIR)/./core/src/expand_pic.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/expand_pic.o $(DECODER_SRCDIR)/./core/src/expand_pic.cpp
-
-$(DECODER_SRCDIR)/./core/src/decode_mb_aux.o: $(DECODER_SRCDIR)/./core/src/decode_mb_aux.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./core/src/decode_mb_aux.o $(DECODER_SRCDIR)/./core/src/decode_mb_aux.cpp
-
-$(DECODER_SRCDIR)/./plus/src/welsDecoderExt.o: $(DECODER_SRCDIR)/./plus/src/welsDecoderExt.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./plus/src/welsDecoderExt.o $(DECODER_SRCDIR)/./plus/src/welsDecoderExt.cpp
-
-$(DECODER_SRCDIR)/./plus/src/welsCodecTrace.o: $(DECODER_SRCDIR)/./plus/src/welsCodecTrace.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(DECODER_CFLAGS) $(DECODER_INCLUDES) -c -o $(DECODER_SRCDIR)/./plus/src/welsCodecTrace.o $(DECODER_SRCDIR)/./plus/src/welsCodecTrace.cpp
-
-$(DECODER_SRCDIR)/./core/asm/dct.o: $(DECODER_SRCDIR)/./core/asm/dct.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(DECODER_ASMFLAGS) $(DECODER_ASM_INCLUDES) -o $(DECODER_SRCDIR)/./core/asm/dct.o $(DECODER_SRCDIR)/./core/asm/dct.asm
-
-$(DECODER_SRCDIR)/./core/asm/intra_pred.o: $(DECODER_SRCDIR)/./core/asm/intra_pred.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(DECODER_ASMFLAGS) $(DECODER_ASM_INCLUDES) -o $(DECODER_SRCDIR)/./core/asm/intra_pred.o $(DECODER_SRCDIR)/./core/asm/intra_pred.asm
-
-$(DECODER_SRCDIR)/./core/asm/block_add.o: $(DECODER_SRCDIR)/./core/asm/block_add.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(DECODER_ASMFLAGS) $(DECODER_ASM_INCLUDES) -o $(DECODER_SRCDIR)/./core/asm/block_add.o $(DECODER_SRCDIR)/./core/asm/block_add.asm
+$(DECODER_SRCDIR)/%.o: $(DECODER_SRCDIR)/%.asm
+	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(DECODER_ASMFLAGS) $(DECODER_ASM_INCLUDES) -o $@ $<
 
 $(LIBPREFIX)decoder.$(LIBSUFFIX): $(DECODER_OBJS)
 	rm -f $(LIBPREFIX)decoder.$(LIBSUFFIX)

--- a/codec/encoder/targets.mk
+++ b/codec/encoder/targets.mk
@@ -1,170 +1,59 @@
 ENCODER_PREFIX=ENCODER
 ENCODER_SRCDIR=codec/encoder
 ENCODER_CPP_SRCS=\
-	$(ENCODER_SRCDIR)/./core/src/mc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/slice_multi_threading.cpp\
-	$(ENCODER_SRCDIR)/./core/src/wels_preprocess.cpp\
-	$(ENCODER_SRCDIR)/./core/src/ratectl.cpp\
-	$(ENCODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encoder_ext.cpp\
-	$(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.cpp\
+	$(ENCODER_SRCDIR)/./core/src/au_set.cpp\
 	$(ENCODER_SRCDIR)/./core/src/deblocking.cpp\
-	$(ENCODER_SRCDIR)/./core/src/picture_handle.cpp\
+	$(ENCODER_SRCDIR)/./core/src/decode_mb_aux.cpp\
+	$(ENCODER_SRCDIR)/./core/src/encode_mb_aux.cpp\
 	$(ENCODER_SRCDIR)/./core/src/encoder.cpp\
 	$(ENCODER_SRCDIR)/./core/src/encoder_data_tables.cpp\
-	$(ENCODER_SRCDIR)/./core/src/property.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encode_mb_aux.cpp\
-	$(ENCODER_SRCDIR)/./core/src/memory_align.cpp\
-	$(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/utils.cpp\
-	$(ENCODER_SRCDIR)/./core/src/mv_pred.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_encode_slice.cpp\
-	$(ENCODER_SRCDIR)/./core/src/au_set.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_encode_mb.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.cpp\
-	$(ENCODER_SRCDIR)/./core/src/md.cpp\
-	$(ENCODER_SRCDIR)/./core/src/sample.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_mode_decision.cpp\
-	$(ENCODER_SRCDIR)/./core/src/nal_encap.cpp\
+	$(ENCODER_SRCDIR)/./core/src/encoder_ext.cpp\
 	$(ENCODER_SRCDIR)/./core/src/expand_pic.cpp\
-	$(ENCODER_SRCDIR)/./core/src/decode_mb_aux.cpp\
-	$(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.cpp\
+	$(ENCODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
+	$(ENCODER_SRCDIR)/./core/src/mc.cpp\
+	$(ENCODER_SRCDIR)/./core/src/md.cpp\
+	$(ENCODER_SRCDIR)/./core/src/memory_align.cpp\
+	$(ENCODER_SRCDIR)/./core/src/mv_pred.cpp\
+	$(ENCODER_SRCDIR)/./core/src/nal_encap.cpp\
+	$(ENCODER_SRCDIR)/./core/src/picture_handle.cpp\
+	$(ENCODER_SRCDIR)/./core/src/property.cpp\
+	$(ENCODER_SRCDIR)/./core/src/ratectl.cpp\
+	$(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.cpp\
+	$(ENCODER_SRCDIR)/./core/src/sample.cpp\
+	$(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.cpp\
+	$(ENCODER_SRCDIR)/./core/src/slice_multi_threading.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_encode_mb.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_encode_slice.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_mode_decision.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.cpp\
+	$(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.cpp\
+	$(ENCODER_SRCDIR)/./core/src/utils.cpp\
+	$(ENCODER_SRCDIR)/./core/src/wels_preprocess.cpp\
 	$(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.cpp\
+	$(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.cpp\
 
 ENCODER_OBJS += $(ENCODER_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 ENCODER_ASM_SRCS=\
-	$(ENCODER_SRCDIR)/./core/asm/quant.asm\
-	$(ENCODER_SRCDIR)/./core/asm/score.asm\
 	$(ENCODER_SRCDIR)/./core/asm/coeff.asm\
 	$(ENCODER_SRCDIR)/./core/asm/dct.asm\
-	$(ENCODER_SRCDIR)/./core/asm/satd_sad.asm\
-	$(ENCODER_SRCDIR)/./core/asm/memzero.asm\
 	$(ENCODER_SRCDIR)/./core/asm/intra_pred.asm\
+	$(ENCODER_SRCDIR)/./core/asm/memzero.asm\
+	$(ENCODER_SRCDIR)/./core/asm/quant.asm\
+	$(ENCODER_SRCDIR)/./core/asm/satd_sad.asm\
+	$(ENCODER_SRCDIR)/./core/asm/score.asm\
 
 ENCODER_OBJS += $(ENCODER_ASM_SRCS:.asm=.o)
 endif
 
 OBJS += $(ENCODER_OBJS)
-$(ENCODER_SRCDIR)/./core/src/mc.o: $(ENCODER_SRCDIR)/./core/src/mc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/mc.o $(ENCODER_SRCDIR)/./core/src/mc.cpp
+$(ENCODER_SRCDIR)/%.o: $(ENCODER_SRCDIR)/%.cpp
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $@ $<
 
-$(ENCODER_SRCDIR)/./core/src/slice_multi_threading.o: $(ENCODER_SRCDIR)/./core/src/slice_multi_threading.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/slice_multi_threading.o $(ENCODER_SRCDIR)/./core/src/slice_multi_threading.cpp
-
-$(ENCODER_SRCDIR)/./core/src/wels_preprocess.o: $(ENCODER_SRCDIR)/./core/src/wels_preprocess.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/wels_preprocess.o $(ENCODER_SRCDIR)/./core/src/wels_preprocess.cpp
-
-$(ENCODER_SRCDIR)/./core/src/ratectl.o: $(ENCODER_SRCDIR)/./core/src/ratectl.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/ratectl.o $(ENCODER_SRCDIR)/./core/src/ratectl.cpp
-
-$(ENCODER_SRCDIR)/./core/src/get_intra_predictor.o: $(ENCODER_SRCDIR)/./core/src/get_intra_predictor.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/get_intra_predictor.o $(ENCODER_SRCDIR)/./core/src/get_intra_predictor.cpp
-
-$(ENCODER_SRCDIR)/./core/src/encoder_ext.o: $(ENCODER_SRCDIR)/./core/src/encoder_ext.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/encoder_ext.o $(ENCODER_SRCDIR)/./core/src/encoder_ext.cpp
-
-$(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.o: $(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.o $(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.cpp
-
-$(ENCODER_SRCDIR)/./core/src/deblocking.o: $(ENCODER_SRCDIR)/./core/src/deblocking.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/deblocking.o $(ENCODER_SRCDIR)/./core/src/deblocking.cpp
-
-$(ENCODER_SRCDIR)/./core/src/picture_handle.o: $(ENCODER_SRCDIR)/./core/src/picture_handle.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/picture_handle.o $(ENCODER_SRCDIR)/./core/src/picture_handle.cpp
-
-$(ENCODER_SRCDIR)/./core/src/encoder.o: $(ENCODER_SRCDIR)/./core/src/encoder.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/encoder.o $(ENCODER_SRCDIR)/./core/src/encoder.cpp
-
-$(ENCODER_SRCDIR)/./core/src/encoder_data_tables.o: $(ENCODER_SRCDIR)/./core/src/encoder_data_tables.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/encoder_data_tables.o $(ENCODER_SRCDIR)/./core/src/encoder_data_tables.cpp
-
-$(ENCODER_SRCDIR)/./core/src/property.o: $(ENCODER_SRCDIR)/./core/src/property.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/property.o $(ENCODER_SRCDIR)/./core/src/property.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.o: $(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.o $(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.cpp
-
-$(ENCODER_SRCDIR)/./core/src/encode_mb_aux.o: $(ENCODER_SRCDIR)/./core/src/encode_mb_aux.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/encode_mb_aux.o $(ENCODER_SRCDIR)/./core/src/encode_mb_aux.cpp
-
-$(ENCODER_SRCDIR)/./core/src/memory_align.o: $(ENCODER_SRCDIR)/./core/src/memory_align.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/memory_align.o $(ENCODER_SRCDIR)/./core/src/memory_align.cpp
-
-$(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.o: $(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.o $(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.cpp
-
-$(ENCODER_SRCDIR)/./core/src/utils.o: $(ENCODER_SRCDIR)/./core/src/utils.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/utils.o $(ENCODER_SRCDIR)/./core/src/utils.cpp
-
-$(ENCODER_SRCDIR)/./core/src/mv_pred.o: $(ENCODER_SRCDIR)/./core/src/mv_pred.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/mv_pred.o $(ENCODER_SRCDIR)/./core/src/mv_pred.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_encode_slice.o: $(ENCODER_SRCDIR)/./core/src/svc_encode_slice.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_encode_slice.o $(ENCODER_SRCDIR)/./core/src/svc_encode_slice.cpp
-
-$(ENCODER_SRCDIR)/./core/src/au_set.o: $(ENCODER_SRCDIR)/./core/src/au_set.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/au_set.o $(ENCODER_SRCDIR)/./core/src/au_set.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.o: $(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.o $(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_encode_mb.o: $(ENCODER_SRCDIR)/./core/src/svc_encode_mb.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_encode_mb.o $(ENCODER_SRCDIR)/./core/src/svc_encode_mb.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.o: $(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.o $(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.cpp
-
-$(ENCODER_SRCDIR)/./core/src/md.o: $(ENCODER_SRCDIR)/./core/src/md.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/md.o $(ENCODER_SRCDIR)/./core/src/md.cpp
-
-$(ENCODER_SRCDIR)/./core/src/sample.o: $(ENCODER_SRCDIR)/./core/src/sample.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/sample.o $(ENCODER_SRCDIR)/./core/src/sample.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.o: $(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.o $(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.cpp
-
-$(ENCODER_SRCDIR)/./core/src/svc_mode_decision.o: $(ENCODER_SRCDIR)/./core/src/svc_mode_decision.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/svc_mode_decision.o $(ENCODER_SRCDIR)/./core/src/svc_mode_decision.cpp
-
-$(ENCODER_SRCDIR)/./core/src/nal_encap.o: $(ENCODER_SRCDIR)/./core/src/nal_encap.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/nal_encap.o $(ENCODER_SRCDIR)/./core/src/nal_encap.cpp
-
-$(ENCODER_SRCDIR)/./core/src/expand_pic.o: $(ENCODER_SRCDIR)/./core/src/expand_pic.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/expand_pic.o $(ENCODER_SRCDIR)/./core/src/expand_pic.cpp
-
-$(ENCODER_SRCDIR)/./core/src/decode_mb_aux.o: $(ENCODER_SRCDIR)/./core/src/decode_mb_aux.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./core/src/decode_mb_aux.o $(ENCODER_SRCDIR)/./core/src/decode_mb_aux.cpp
-
-$(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.o: $(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.o $(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.cpp
-
-$(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.o: $(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(ENCODER_CFLAGS) $(ENCODER_INCLUDES) -c -o $(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.o $(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.cpp
-
-$(ENCODER_SRCDIR)/./core/asm/quant.o: $(ENCODER_SRCDIR)/./core/asm/quant.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/quant.o $(ENCODER_SRCDIR)/./core/asm/quant.asm
-
-$(ENCODER_SRCDIR)/./core/asm/score.o: $(ENCODER_SRCDIR)/./core/asm/score.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/score.o $(ENCODER_SRCDIR)/./core/asm/score.asm
-
-$(ENCODER_SRCDIR)/./core/asm/coeff.o: $(ENCODER_SRCDIR)/./core/asm/coeff.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/coeff.o $(ENCODER_SRCDIR)/./core/asm/coeff.asm
-
-$(ENCODER_SRCDIR)/./core/asm/dct.o: $(ENCODER_SRCDIR)/./core/asm/dct.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/dct.o $(ENCODER_SRCDIR)/./core/asm/dct.asm
-
-$(ENCODER_SRCDIR)/./core/asm/satd_sad.o: $(ENCODER_SRCDIR)/./core/asm/satd_sad.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/satd_sad.o $(ENCODER_SRCDIR)/./core/asm/satd_sad.asm
-
-$(ENCODER_SRCDIR)/./core/asm/memzero.o: $(ENCODER_SRCDIR)/./core/asm/memzero.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/memzero.o $(ENCODER_SRCDIR)/./core/asm/memzero.asm
-
-$(ENCODER_SRCDIR)/./core/asm/intra_pred.o: $(ENCODER_SRCDIR)/./core/asm/intra_pred.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $(ENCODER_SRCDIR)/./core/asm/intra_pred.o $(ENCODER_SRCDIR)/./core/asm/intra_pred.asm
+$(ENCODER_SRCDIR)/%.o: $(ENCODER_SRCDIR)/%.asm
+	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(ENCODER_ASMFLAGS) $(ENCODER_ASM_INCLUDES) -o $@ $<
 
 $(LIBPREFIX)encoder.$(LIBSUFFIX): $(ENCODER_OBJS)
 	rm -f $(LIBPREFIX)encoder.$(LIBSUFFIX)

--- a/codec/processing/targets.mk
+++ b/codec/processing/targets.mk
@@ -1,110 +1,44 @@
 PROCESSING_PREFIX=PROCESSING
 PROCESSING_SRCDIR=codec/processing
 PROCESSING_CPP_SRCS=\
-	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.cpp\
-	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.cpp\
-	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.cpp\
-	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/util.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/memory.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/cpu.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/thread.cpp\
-	$(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.cpp\
-	$(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.cpp\
-	$(PROCESSING_SRCDIR)/./src/denoise/denoise.cpp\
 	$(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.cpp\
+	$(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/cpu.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/memory.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/thread.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/util.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.cpp\
+	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.cpp\
+	$(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.cpp\
+	$(PROCESSING_SRCDIR)/./src/denoise/denoise.cpp\
+	$(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.cpp\
 	$(PROCESSING_SRCDIR)/./src/downsample/downsample.cpp\
 	$(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.cpp\
+	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.cpp\
+	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.cpp\
+	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.cpp\
+	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.cpp\
+	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.cpp\
+	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.cpp\
 
 PROCESSING_OBJS += $(PROCESSING_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 PROCESSING_ASM_SRCS=\
+	$(PROCESSING_SRCDIR)/./src/asm/denoisefilter.asm\
+	$(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.asm\
+	$(PROCESSING_SRCDIR)/./src/asm/intra_pred.asm\
 	$(PROCESSING_SRCDIR)/./src/asm/sad.asm\
 	$(PROCESSING_SRCDIR)/./src/asm/vaa.asm\
-	$(PROCESSING_SRCDIR)/./src/asm/denoisefilter.asm\
-	$(PROCESSING_SRCDIR)/./src/asm/intra_pred.asm\
-	$(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.asm\
 
 PROCESSING_OBJS += $(PROCESSING_ASM_SRCS:.asm=.o)
 endif
 
 OBJS += $(PROCESSING_OBJS)
-$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.o: $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.o $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.cpp
+$(PROCESSING_SRCDIR)/%.o: $(PROCESSING_SRCDIR)/%.cpp
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $@ $<
 
-$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.o: $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.o $(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.cpp
-
-$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.o: $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.o $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.cpp
-
-$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.o: $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.o $(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.cpp
-
-$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.o: $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.o $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.cpp
-
-$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.o: $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.o $(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.o: $(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.o $(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/util.o: $(PROCESSING_SRCDIR)/./src/common/util.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/util.o $(PROCESSING_SRCDIR)/./src/common/util.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/memory.o: $(PROCESSING_SRCDIR)/./src/common/memory.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/memory.o $(PROCESSING_SRCDIR)/./src/common/memory.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.o: $(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.o $(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/cpu.o: $(PROCESSING_SRCDIR)/./src/common/cpu.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/cpu.o $(PROCESSING_SRCDIR)/./src/common/cpu.cpp
-
-$(PROCESSING_SRCDIR)/./src/common/thread.o: $(PROCESSING_SRCDIR)/./src/common/thread.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/common/thread.o $(PROCESSING_SRCDIR)/./src/common/thread.cpp
-
-$(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.o: $(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.o $(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.cpp
-
-$(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.o: $(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.o $(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.cpp
-
-$(PROCESSING_SRCDIR)/./src/denoise/denoise.o: $(PROCESSING_SRCDIR)/./src/denoise/denoise.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/denoise/denoise.o $(PROCESSING_SRCDIR)/./src/denoise/denoise.cpp
-
-$(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.o: $(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.o $(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.cpp
-
-$(PROCESSING_SRCDIR)/./src/downsample/downsample.o: $(PROCESSING_SRCDIR)/./src/downsample/downsample.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/downsample/downsample.o $(PROCESSING_SRCDIR)/./src/downsample/downsample.cpp
-
-$(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.o: $(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.o $(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.cpp
-
-$(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.o: $(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.cpp
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(PROCESSING_CFLAGS) $(PROCESSING_INCLUDES) -c -o $(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.o $(PROCESSING_SRCDIR)/./src/backgounddetection/BackgroundDetection.cpp
-
-$(PROCESSING_SRCDIR)/./src/asm/sad.o: $(PROCESSING_SRCDIR)/./src/asm/sad.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $(PROCESSING_SRCDIR)/./src/asm/sad.o $(PROCESSING_SRCDIR)/./src/asm/sad.asm
-
-$(PROCESSING_SRCDIR)/./src/asm/vaa.o: $(PROCESSING_SRCDIR)/./src/asm/vaa.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $(PROCESSING_SRCDIR)/./src/asm/vaa.o $(PROCESSING_SRCDIR)/./src/asm/vaa.asm
-
-$(PROCESSING_SRCDIR)/./src/asm/denoisefilter.o: $(PROCESSING_SRCDIR)/./src/asm/denoisefilter.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $(PROCESSING_SRCDIR)/./src/asm/denoisefilter.o $(PROCESSING_SRCDIR)/./src/asm/denoisefilter.asm
-
-$(PROCESSING_SRCDIR)/./src/asm/intra_pred.o: $(PROCESSING_SRCDIR)/./src/asm/intra_pred.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $(PROCESSING_SRCDIR)/./src/asm/intra_pred.o $(PROCESSING_SRCDIR)/./src/asm/intra_pred.asm
-
-$(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.o: $(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.asm
-	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.o $(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.asm
+$(PROCESSING_SRCDIR)/%.o: $(PROCESSING_SRCDIR)/%.asm
+	$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(PROCESSING_ASMFLAGS) $(PROCESSING_ASM_INCLUDES) -o $@ $<
 
 $(LIBPREFIX)processing.$(LIBSUFFIX): $(PROCESSING_OBJS)
 	rm -f $(LIBPREFIX)processing.$(LIBSUFFIX)


### PR DESCRIPTION
Commit f38111d76ba127b4045e6a9899cbb753457c7384 updated these files
manually (based on older versions of them) to something not generated
by the current mktargets.py/sh, losing the compact pattern rules.
