### PR TITLE
Travis.32bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
 install: make gtest-bootstrap
 # libssl is not multiarch so we are building 64bit
 # and then installing the 32bit version
-script: make ENABLE64BIT=Yes && make test && make clean && make ENABLE64BIT=Yes BUILDTYPE=Release && make test && sudo apt-get install -qq libssl-dev:i386 && make clean && make && make test && make BUILDTYPE=Release clean && make BUILDTYPE=Release && make test
+script: make -B ENABLE64BIT=Yes && make test && make -B ENABLE64BIT=Yes BUILDTYPE=Release && make test && sudo apt-get install -qq libssl-dev:i386 && make -B && make test && make -B BUILDTYPE=Release && make test
 


### PR DESCRIPTION
This patch removes the gcc build since it conflicts with the install of the 32bit libssl.  The script now builds 64bit and then does an apt-get of the 32bit libssl and then builds 32bit - all on clang.
