### PR TITLE
Disable frame skipping in the encoder by default

### DIFF
--- a/codec/encoder/core/inc/rc.h
+++ b/codec/encoder/core/inc/rc.h
@@ -52,7 +52,7 @@ namespace WelsSVCEnc {
 //trace
 #define GOM_TRACE_FLAG 1
 //skip frame
-#define SKIP_FRAME_FLAG      1
+#define SKIP_FRAME_FLAG      0
 
 #define    WELS_RC_DISABLE        0
 #define    WELS_RC_GOM            1


### PR DESCRIPTION
Frame skipping seems to be triggered quite often in actual video
content (e.g. skipping almost 10% of frames in some situations).
Even if the frame skipping is disabled, the rest of the rate control
seems to be able to constrain the output pretty well to the target
bitrate, so the frame skipping feels unnecessary.

Alternatively, the frame skipping should be made a runtime option
if others think this should be kept enabled by default.
