### PR TITLE
Add an encoder method for encoding the SPS/PPS without encoding a frame

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -55,6 +55,11 @@ class ISVCEncoder {
   /*
    * return: 0 - success; otherwise - failed;
    */
+  virtual int EncodeParameterSets (SFrameBSInfo* pBsInfo) = 0;
+
+  /*
+   * return: 0 - success; otherwise - failed;
+   */
   virtual int PauseFrame (const unsigned char* kpSrc, SFrameBSInfo* pBsInfo) = 0;
 
   /*

--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -98,6 +98,8 @@ void WelsUninitEncoderExt (sWelsEncCtx** ppCtx);
 int32_t WelsEncoderEncodeExt (sWelsEncCtx*, void* pDst, const SSourcePicture** kppSrcList,
                               const int32_t kiConfiguredLayerNum);
 
+int32_t WelsEncoderEncodeParameterSets (sWelsEncCtx* pCtx, void* pDst);
+
 /*
  * Force coding IDR as follows
  */

--- a/codec/encoder/plus/inc/welsEncoderExt.h
+++ b/codec/encoder/plus/inc/welsEncoderExt.h
@@ -79,6 +79,11 @@ class CWelsH264SVCEncoder : public ISVCEncoder {
   /*
    * return: 0 - success; otherwise - failed;
    */
+  virtual int EncodeParameterSets (SFrameBSInfo* pBsInfo);
+
+  /*
+   * return: 0 - success; otherwise - failed;
+   */
   virtual int PauseFrame (const unsigned char* pSrc, SFrameBSInfo* pBsInfo);
 
   /*

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -730,6 +730,10 @@ int CWelsH264SVCEncoder::EncodeFrame (const SSourcePicture**   pSrcPicList, int 
 
 }
 
+int CWelsH264SVCEncoder::EncodeParameterSets (SFrameBSInfo* pBsInfo) {
+    return WelsEncoderEncodeParameterSets (m_pEncContext, pBsInfo);
+}
+
 /*
  * return: 0 - success; otherwise - failed;
  */


### PR DESCRIPTION
This is useful if using a muxer that requires the SPS/PPS to be
available before the first frame is encoded.
