### PR TITLE
Fix casting of the return value integer to a pointer in the thread lib

### DIFF
--- a/codec/WelsThreadLib/api/WelsThreadLib.h
+++ b/codec/WelsThreadLib/api/WelsThreadLib.h
@@ -84,7 +84,7 @@ typedef   pthread_mutex_t           WELS_MUTEX;
 typedef   sem_t                     WELS_EVENT;
 
 #define   WELS_THREAD_ROUTINE_TYPE         void *
-#define   WELS_THREAD_ROUTINE_RETURN(rc)   return (void*)rc;
+#define   WELS_THREAD_ROUTINE_RETURN(rc)   return (void*)(intptr_t)rc;
 
 #endif//__GNUC__
 


### PR DESCRIPTION
This fixes building of the thread lib on 64 bit unix.
