### PR TITLE
Makefile modifications for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 include build/platform-$(UNAME).mk
 
 ifeq ($(USE_ASM),Yes)
-  CFLAGS += -DX86_ASM
+CFLAGS += -DX86_ASM
 endif
 
 CFLAGS += -DNO_DYNAMIC_VP
@@ -48,7 +48,7 @@ ASMFLAGS += $(ASMFLAGS_PLATFORM) -DNO_DYNAMIC_VP
 
 
 #### No user-serviceable parts below this line
-INCLUDES = -Icodec/api/svc  -Icodec/common -Igtest/include
+INCLUDES = -Icodec/api/svc -Icodec/common -Igtest/include
 #ASM_INCLUDES = -Iprocessing/src/asm/
 ASM_INCLUDES = -Icodec/common/
 
@@ -79,19 +79,24 @@ H264ENC_DEPS = $(LIBPREFIX)encoder.$(LIBSUFFIX) $(LIBPREFIX)processing.$(LIBSUFF
 CODEC_UNITTEST_LDFLAGS = -L. -lgtest -ldecoder -lcrypto -lencoder -lprocessing -lcommon
 CODEC_UNITTEST_DEPS = $(LIBPREFIX)gtest.$(LIBSUFFIX) $(LIBPREFIX)decoder.$(LIBSUFFIX) $(LIBPREFIX)encoder.$(LIBSUFFIX) $(LIBPREFIX)processing.$(LIBSUFFIX) $(LIBPREFIX)common.$(LIBSUFFIX)
 
-.PHONY: test
+.PHONY: test gtest-bootstrap clean
 
 all:	libraries binaries
 
 clean:
 	rm -f $(OBJS) $(LIBRARIES) $(BINARIES)
-	echo $(HAVE_GTEST)
 
 gtest-bootstrap:
 	svn co https://googletest.googlecode.com/svn/trunk/ gtest
 
-test: codec_unittest
+test:
+ifeq ($(HAVE_GTEST),Yes)
+	$(MAKE) codec_unittest
 	./codec_unittest
+else
+	$(MAKE) gtest-bootstrap
+	$(MAKE) test
+endif
 
 include codec/common/targets.mk
 include codec/decoder/targets.mk
@@ -104,9 +109,3 @@ ifeq ($(HAVE_GTEST),Yes)
 include build/gtest-targets.mk
 include test/targets.mk
 endif
-
-
-
-
-
-


### PR DESCRIPTION
On fresh clone of repo, "make test" used to give,
"make: **\* No rule to make target `codec_unittest', needed by`test'.  Stop."
because gtest was not available. Now, tries to get gtest if not already available
before making test target.
