### PR TITLE
Remove accidentally added const for plain non-pointer function parameters

### DIFF
--- a/codec/encoder/core/inc/encode_mb_aux.h
+++ b/codec/encoder/core/inc/encode_mb_aux.h
@@ -107,7 +107,7 @@ void WelsHadamardT4Dc_sse2 (int16_t* pLumaDc, int16_t* pDct);
 int32_t WelsHadamardQuant2x2Skip_mmx (int16_t* pRes, int16_t iFF,  int16_t iMF);
 
 void WelsQuant4x4_sse2 (int16_t* pDct, const int16_t* pFF, const int16_t* pMF);
-void WelsQuant4x4Dc_sse2 (int16_t* pDct, const int16_t iFF, const int16_t iMF);
+void WelsQuant4x4Dc_sse2 (int16_t* pDct, int16_t iFF, int16_t iMF);
 void WelsQuantFour4x4_sse2 (int16_t* pDct, const int16_t* pFF, const int16_t* pMF);
 void WelsQuantFour4x4Max_sse2 (int16_t* pDct, const int16_t* pFF, const int16_t* pMF, int16_t* pMax);
 


### PR DESCRIPTION
This was accidentally added in 61117c85 when the pointer
parameters were made const.
