### PR TITLE
Don't load welsdec.dll at runtime in the decConsole test app on windows

### DIFF
--- a/codec/build/win32/dec/decConsole.vcproj
+++ b/codec/build/win32/dec/decConsole.vcproj
@@ -74,6 +74,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="$(OutDir)\welsdec.lib"
 				OutputFile="$(OutDir)\decConsole.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -166,6 +167,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="$(OutDir)\welsdec.lib"
 				OutputFile="$(OutDir)\decConsole.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -258,6 +260,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="$(OutDir)\welsdec.lib"
 				OutputFile="$(OutDir)\decConsoled.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -351,6 +354,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="$(OutDir)\welsdec.lib"
 				OutputFile="$(OutDir)\decConsoled.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -433,40 +433,10 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
 
 
 
-#if defined(_MSC_VER)
-
-  HMODULE hModule = LoadLibraryA (".\\welsdec.dll");
-
-  PCreateDecoderFunc  pCreateDecoderFunc				= NULL;
-  PDestroyDecoderFunc pDestroyDecoderFunc				= NULL;
-
-
-  pCreateDecoderFunc  = (PCreateDecoderFunc)::GetProcAddress (hModule, "CreateDecoder");
-  pDestroyDecoderFunc = (PDestroyDecoderFunc)::GetProcAddress (hModule, "DestroyDecoder");
-
-  if ((hModule != NULL) && (pCreateDecoderFunc != NULL) && (pDestroyDecoderFunc != NULL)) {
-    printf ("load library sw function successfully\n");
-
-    if (pCreateDecoderFunc (&pDecoder)  || (NULL == pDecoder)) {
-      printf ("Create Decoder failed.\n");
-      return 1;
-    }
-  } else {
-    printf ("load library sw function failed\n");
-    return 1;
-  }
-
-
-#else
-
-
   if (CreateDecoder (&pDecoder)  || (NULL == pDecoder)) {
     printf ("Create Decoder failed.\n");
     return 1;
   }
-
-#endif
-
 
   if (pDecoder->Initialize (&sDecParam, INIT_TYPE_PARAMETER_BASED)) {
     printf ("Decoder initialization failed.\n");
@@ -489,11 +459,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
   if (pDecoder) {
     pDecoder->Uninitialize();
 
-#if defined(_MSC_VER)
-    pDestroyDecoderFunc (pDecoder);
-#else
     DestroyDecoder (pDecoder);
-#endif
   }
 
   return 0;


### PR DESCRIPTION
Instead just link directly to it. This matches how the library is
linked/loaded in encConsole/h264enc as well.

Only the 2008 version project file is updated for now, since
the 2010 and 2012 ones are out of sync right now.
