### PR TITLE
Fix building in MSVC 2012 by avoiding redefining the inline keyword

### DIFF
--- a/codec/common/macros.h
+++ b/codec/common/macros.h
@@ -104,7 +104,9 @@ __declspec(align(alignment)) type name[(sizex)*(sizey)]
 #endif//#if _MACH_PLATFORM
 
 #if defined(_MSC_VER)
+#if _MSC_VER < 1700
 #define inline	__inline
+#endif
 #define __FASTCALL   __fastcall
 //	#define __align8(t,v) __declspec(align(8)) t v
 #define __align16(t,v) __declspec(align(16)) t v


### PR DESCRIPTION
While building succeeds in MSVC 2008, it currently fails in 2012
due to error C1189 "The C++ standard library forbids macroizing
keywords", which is caused by doing "#define inline __inline" in
the macros.h header.

This could have been missed before since it only was triggered
if macros.h was included before some other system header was
included that contained checks against these inline defines.
