### PR TITLE
Remove the __NO_CTYPE define

### DIFF
--- a/build/platform-linux.mk
+++ b/build/platform-linux.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS += -Werror -fPIC -DLINUX -D__NO_CTYPE
+CFLAGS += -Werror -fPIC -DLINUX
 LDFLAGS += -lpthread
 ASMFLAGS += -DNOPREFIX
 ifeq ($(ENABLE64BIT), Yes)

--- a/build/platform-mingw_nt.mk
+++ b/build/platform-mingw_nt.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS += -D__NO_CTYPE
+CFLAGS +=
 LDFLAGS +=
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f win64

--- a/codec/build/linux/dec/makefile
+++ b/codec/build/linux/dec/makefile
@@ -26,7 +26,7 @@ ASFLAGS= -f elf -DNOPREFIX -I ../../../decoder/core/asm/
 
 LIBS= -lstdc++ -ldl
 #-lm
-CFLAGS=  $(INCLUDE) -fPIC -D__GCC__ -DLINUX -D__NO_CTYPE
+CFLAGS=  $(INCLUDE) -fPIC -D__GCC__ -DLINUX
 
 ifeq ($(DBG),1)
 #SUFFIX= .dbg

--- a/codec/build/linux/enc/makefile
+++ b/codec/build/linux/enc/makefile
@@ -27,7 +27,7 @@ ASFLAGS= -f elf -DNOPREFIX -I ../../../encoder/core/asm/
 
 LIBS= -lstdc++ -ldl -lpthread -lm
 #-lm
-CFLAGS=  $(INCLUDE) -m32 -fPIC -D__GCC__ -DLINUX -D__NO_CTYPE -DWELS_TESTBED -DMT_ENABLED
+CFLAGS=  $(INCLUDE) -m32 -fPIC -D__GCC__ -DLINUX -DWELS_TESTBED -DMT_ENABLED
 
 ifeq ($(DBG),1)
 #SUFFIX= .dbg


### PR DESCRIPTION
Nothing within the project uses it, and it's not necessary to
build the project either, tested on both linux and mingw.
