### PR TITLE
Remove system header/define hackery in welsenc.cpp

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -45,16 +45,6 @@
 
 //#define STICK_STREAM_SIZE
 
-#if defined(__GNUC__)
-#if !defined(MACOS)
-#if !defined(_MATH_H_MATHDEF)
-#define _MATH_H_MATHDEF
-//#else
-//#error "warning: have defined _MATH_H_MATHDEF!!"	// to check
-#endif//_MATH_H_MATHDEF
-#endif//MACOS
-#endif//__GNUC__
-
 #include "measure_time.h"
 #include "param_svc.h"
 //#include "layered_pic_buffer.h"


### PR DESCRIPTION
There doesn't seem to be any actual need for this, building
on linux still works just fine.
