### PR TITLE
remove MEMORY_REQUEST_ALIGN_BYTES

### DIFF
--- a/codec/encoder/core/inc/memory_align.h
+++ b/codec/encoder/core/inc/memory_align.h
@@ -41,8 +41,6 @@
 
 namespace WelsSVCEnc {
 
-#define MEMORY_REQUEST_ALIGN_BYTES	0 // or (1^n), i.e, 0x04
-
 class CMemoryAlign {
  public:
 CMemoryAlign (const uint32_t kuiCacheLineSize);

--- a/codec/encoder/core/src/memory_align.cpp
+++ b/codec/encoder/core/src/memory_align.cpp
@@ -83,15 +83,8 @@ void* CMemoryAlign::WelsMalloc (const uint32_t kuiSize, const str_t* kpTag) {
   const int32_t kiSizeOfInt				= sizeof (int32_t);
   const int32_t kiAlignedBytes		= m_nCacheLineSize - 1;
   const int32_t kiTrialRequestedSize	= kuiSize + kiAlignedBytes + kiSizeOfVoidPointer + kiSizeOfInt;
-#if MEMORY_REQUEST_ALIGN_BYTES
-  // ensure 4 bytes boundary aligned memory request, unused extra bytes padding in pData payload
-  const int32_t kiActualRequestedSize	= WELS_ALIGN (kiTrialRequestedSize, MEMORY_REQUEST_ALIGN_BYTES);
-  const uint32_t kiPayloadSize			= kuiSize + MEMORY_REQUEST_ALIGN_BYTES - (kiTrialRequestedSize &
-                                      (MEMORY_REQUEST_ALIGN_BYTES - 1));
-#else
   const int32_t kiActualRequestedSize	= kiTrialRequestedSize;
   const uint32_t kiPayloadSize			= kuiSize;
-#endif//MEMORY_REQUEST_ALIGN_BYTES
 
   uint8_t* pBuf		= (uint8_t*) malloc (kiActualRequestedSize);
 #ifdef MEMORY_CHECK


### PR DESCRIPTION
the code make no sense here.   if one want to add padding bytes at end,  it can request (iSize + iPaddingSize).

review:  https://rbcommons.com/s/OpenH264/r/63/
