### PR TITLE
Update the description of the directories in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ Usage information can be found in testbin/CmdLineReadMe
 Using the Source
 ----------------
 codec - encoder, decoder, console (test app), build (makefile, vcproj)
-processing - raw pixel processing (used by encoder)
 build - scripts for Makefile build system.
 test - GTest unittest files.
-testbin - autobuild scripts, test app config files, yuv test files
-bin - binaries for library and test app
+testbin - autobuild scripts, test app config files
+res - yuv and bitstream test files
 
 Known Issues
 ------------


### PR DESCRIPTION
The processing directory has been moved under codec, and the
main recommended build process doesn't produce anything under bin.

Additionally mention the res directory which is where the test
sequences have been moved.
