### PR TITLE
Automatically track per-file dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.o
 *.ko
 
+# Dependency files
+*.d
+
 # Libraries
 *.lib
 *.a

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ CODEC_UNITTEST_DEPS = $(LIBPREFIX)gtest.$(LIBSUFFIX) $(LIBPREFIX)decoder.$(LIBSU
 all:	libraries binaries
 
 clean:
-	rm -f $(OBJS) $(LIBRARIES) $(BINARIES)
+	rm -f $(OBJS) $(OBJS:.o=.d) $(LIBRARIES) $(BINARIES)
 
 gtest-bootstrap:
 	svn co https://googletest.googlecode.com/svn/trunk/ gtest
@@ -119,3 +119,5 @@ ifeq ($(HAVE_GTEST),Yes)
 include build/gtest-targets.mk
 include test/targets.mk
 endif
+
+-include $(OBJS:.o=.d)

--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -1,6 +1,6 @@
 
 ASM = nasm
-CFLAGS += -Wno-deprecated-declarations -Werror -fPIC -DMACOS -DMT_ENABLED
+CFLAGS += -Wno-deprecated-declarations -Werror -fPIC -DMACOS -DMT_ENABLED -MMD -MP
 LDFLAGS += -lpthread
 ASMFLAGS += --prefix _ -DNOPREFIX
 ifeq ($(ENABLE64BIT), Yes)

--- a/build/platform-linux.mk
+++ b/build/platform-linux.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS += -Werror -fPIC -DLINUX -DMT_ENABLED
+CFLAGS += -Werror -fPIC -DLINUX -DMT_ENABLED -MMD -MP
 LDFLAGS += -lpthread
 ASMFLAGS += -DNOPREFIX
 ifeq ($(ENABLE64BIT), Yes)

--- a/build/platform-mingw_nt.mk
+++ b/build/platform-mingw_nt.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS += -DMT_ENABLED
+CFLAGS += -DMT_ENABLED -MMD -MP
 LDFLAGS +=
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f win64


### PR DESCRIPTION
This is enabled for platforms/compilers that support the -MMD
option, which creates a dependency file named out.d when compiling
to a file named out.o, only including local, not system headers.

This makes sure that all the right files are rebuilt if a header
is changed, avoiding the need for a full rebuild if only a few
files are affected.
