### PR TITLE
Include the executable extension in the test rule dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ gtest-bootstrap:
 	svn co https://googletest.googlecode.com/svn/trunk/ gtest
 
 ifeq ($(HAVE_GTEST),Yes)
-test: codec_unittest
+test: codec_unittest$(EXEEXT)
 	./codec_unittest
 else
 test:


### PR DESCRIPTION
This fixes "make test" on platforms that have an executable
extension.
