### PR TITLE
Remove code for dynamically loading a trace library

### DIFF
--- a/codec/build/win32/dec/WelsDecCore.vcproj
+++ b/codec/build/win32/dec/WelsDecCore.vcproj
@@ -931,6 +931,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\..\common\logging.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\..\..\decoder\core\src\manage_dec_ref.cpp"
 					>
 				</File>

--- a/codec/build/win32/enc/WelsEncCore.vcproj
+++ b/codec/build/win32/enc/WelsEncCore.vcproj
@@ -724,6 +724,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\common\logging.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\encoder\core\src\mc.cpp"
 				>
 				<FileConfiguration

--- a/codec/decoder/plus/inc/welsCodecTrace.h
+++ b/codec/decoder/plus/inc/welsCodecTrace.h
@@ -148,7 +148,6 @@ int32_t  LoadWelsTraceModule();
 int32_t  UnloadWelsTraceModule();
 
  private:
-void_t*   m_hTraceHandle;
 
 CM_WELS_TRACE m_fpDebugTrace;
 CM_WELS_TRACE m_fpInfoTrace;

--- a/codec/decoder/plus/src/welsCodecTrace.cpp
+++ b/codec/decoder/plus/src/welsCodecTrace.cpp
@@ -45,90 +45,10 @@
 #include "welsCodecTrace.h"
 #include "utils.h"
 #include "logging.h"
-#if defined LINUX || defined SOLARIS || defined UNIX || defined MACOS //LINUX/SOLARIS/UNIX
-#include <dlfcn.h>
-#endif
-
-#if defined(MACOS)
-#include <carbon/carbon.h>
-#include <CoreFoundation/CFBundle.h>
-#endif//MACOS
 
 //using namespace WelsDec;
 
 namespace WelsDec {
-
-#ifdef MACOS
-static CFBundleRef LoadLibrary (const char* lpszbundle) {
-  // 1.get bundle path
-  char cBundlePath[PATH_MAX];
-  memset (cBundlePath, 0, PATH_MAX);
-
-  Dl_info 	dlInfo;
-  static int  sDummy;
-  dladdr ((void_t*)&sDummy, &dlInfo);
-
-  strlcpy (cBundlePath, dlInfo.dli_fname, PATH_MAX);
-
-  char* pPath = NULL;
-  for (int i = 4; i > 0; i--) {
-    pPath = strrchr (cBundlePath, '/'); //confirmed_safe_unsafe_usage
-    if (pPath) {
-      *pPath = 0;
-    } else {
-      break;
-    }
-  }
-  if (pPath) {
-    strlcat (cBundlePath, "/", PATH_MAX);
-  } else {
-    return NULL;
-  }
-
-  strlcat (cBundlePath, lpszbundle, PATH_MAX);
-
-  FSRef bundlePath;
-  OSStatus iStatus = FSPathMakeRef ((unsigned char*)cBundlePath, &bundlePath, NULL);
-  if (noErr != iStatus)
-    return NULL;
-
-  CFURLRef bundleURL = CFURLCreateFromFSRef (kCFAllocatorSystemDefault, &bundlePath);
-  if (NULL == bundleURL)
-    return NULL;
-
-  // 2.get bundle ref
-  CFBundleRef bundleRef = CFBundleCreate (kCFAllocatorSystemDefault, bundleURL);
-  CFRelease (bundleURL);
-
-//	Boolean bReturn = FALSE;
-  if (NULL != bundleRef) {
-    //	bReturn = CFBundleLoadExecutable(bundleRef);
-  }
-
-  return bundleRef;
-}
-
-static Boolean FreeLibrary (CFBundleRef bundle) {
-  if (NULL != bundle) {
-    //	CFBundleUnloadExecutable(bundle);
-    CFRelease (bundle);
-  }
-
-  return TRUE;
-}
-
-static void_t* GetProcessAddress (CFBundleRef bundle, const char* lpszprocname) {
-  if (NULL == bundle)
-    return NULL;
-
-  CFStringRef cfprocname = CFStringCreateWithCString (NULL, lpszprocname, CFStringGetSystemEncoding());
-  void_t* processAddress = CFBundleGetFunctionPointerForName (bundle, cfprocname);
-  CFRelease (cfprocname);
-
-  return processAddress;
-}
-#endif
-
 
 
 int32_t  CWelsTraceBase::SetTraceLevel (int iLevel) {
@@ -191,7 +111,6 @@ int32_t CWelsTraceWinDgb::WriteString (int32_t iLevel, const str_t* pStr) {
 #endif
 
 CWelsCodecTrace::CWelsCodecTrace() {
-  m_hTraceHandle = NULL;
   m_fpDebugTrace = NULL;
   m_fpInfoTrace = NULL;
   m_fpWarnTrace = NULL;
@@ -205,111 +124,14 @@ CWelsCodecTrace::~CWelsCodecTrace() {
 }
 
 int32_t  CWelsCodecTrace::LoadWelsTraceModule() {
-#ifdef NO_DYNAMIC_VP
   m_fpDebugTrace = welsStderrTrace<WELS_LOG_DEBUG>;
   m_fpInfoTrace = welsStderrTrace<WELS_LOG_INFO>;
   m_fpWarnTrace = welsStderrTrace<WELS_LOG_WARNING>;
   m_fpErrorTrace = welsStderrTrace<WELS_LOG_ERROR>;
-#else
-#if defined _WIN32
-  HMODULE hHandle = ::LoadLibrary ("welstrace.dll");
-//	HMODULE handle = ::LoadLibrary("contrace.dll");  // for c7 trace
-  if (NULL == hHandle)
-    return -1;
-
-  CHAR chPath[ _MAX_PATH] = {0};
-  GetModuleFileName ((HMODULE)hHandle, chPath, _MAX_PATH);
-
-  m_hTraceHandle = ::LoadLibrary (chPath);
-
-  OutputDebugStringA (chPath);
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSDEBUGA");
-    m_fpInfoTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSINFOA");
-    m_fpWarnTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSWARNA");
-    m_fpErrorTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSERRORA");
-  }
-
-  // coverity scan uninitial
-  if (hHandle != NULL) {
-    ::FreeLibrary (hHandle);
-    hHandle = NULL;
-  }
-#elif defined MACOS
-  m_hTraceHandle = LoadLibrary ("welstrace.bundle");
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSDEBUG2");
-    m_fpInfoTrace = (CM_WELS_TRACE)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSINFO2");
-    m_fpWarnTrace = (CM_WELS_TRACE)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSWARN2");
-    m_fpErrorTrace = (CM_WELS_TRACE)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSERROR2");
-  }
-#elif defined LINUX || defined SOLARIS || defined UNIX
-//#else
-//	CCmString	cmPath;
-  str_t chPath[255] = {0};
-  Dl_info		sDlInfo;
-  static int	iMmTPAddress;
-  dladdr (&iMmTPAddress, &sDlInfo);
-
-  if (NULL == sDlInfo.dli_fname)
-    return -1;
-  WelsStrncpy (chPath, 255, (const str_t*)sDlInfo.dli_fname, WelsStrnlen ((const str_t*)sDlInfo.dli_fname, 255));
-  str_t* p = strrchr (chPath, '/'); //confirmed_safe_unsafe_usage
-  if (NULL == p)
-    return -1;
-  const int iLenTraceName = WelsStrnlen ((const str_t*)"/libwelstrace.so", 15);
-  const int iCurPos = p - chPath;
-  if (iCurPos + iLenTraceName < 255)
-    WelsStrncpy (p, 254 - iCurPos, (const str_t*)"/libwelstrace.so", iLenTraceName);
-  else
-    return -1;
-
-  m_hTraceHandle = dlopen (chPath, RTLD_LAZY);
-  if (m_hTraceHandle == NULL) {
-    WelsFileHandle* fp = WelsFopen ((const str_t*)"/tmp/trace.txt", (const str_t*)"a");
-    if (fp) {
-      fprintf (fp, "welsCodecTrace::welsCodecTrace ===> dlopen %s fail, %s\n", chPath, dlerror());
-      WelsFclose (fp);
-    }
-    return -1;
-  }
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE)dlsym (m_hTraceHandle, "WELSDEBUG2");
-    m_fpInfoTrace = (CM_WELS_TRACE)dlsym (m_hTraceHandle, "WELSINFO2");
-    m_fpWarnTrace = (CM_WELS_TRACE)dlsym (m_hTraceHandle, "WELSWARN2");
-    m_fpErrorTrace = (CM_WELS_TRACE)dlsym (m_hTraceHandle, "WELSERROR2");
-    if (m_fpDebugTrace == NULL) {
-      WelsFileHandle* fp = WelsFopen ((const str_t*)"/tmp/trace.txt", (const str_t*)"a");
-      if (fp) {
-        printf ("welsCodecTrace::welsCodecTrace ===> dlsym failed (WELSDEBUG2) , dlerror = %s\n", dlerror());
-        WelsFclose (fp);
-      }
-      return -1;
-    }
-  }
-#endif
-#endif  // NO_DYNAMIC_VP
   return 0;
 }
 
 int32_t  CWelsCodecTrace::UnloadWelsTraceModule() {
-#ifndef NO_DYNAMIC_VP
-#if defined _WIN32
-  if (m_hTraceHandle) {
-    ::FreeLibrary ((HMODULE)m_hTraceHandle);
-  }
-#elif defined MACOS
-  if (m_hTraceHandle) {
-    FreeLibrary ((CFBundleRef)m_hTraceHandle);
-  }
-#elif defined LINUX || defined SOLARIS || defined UNIX
-  if (m_hTraceHandle) {
-    ::dlclose (m_hTraceHandle);
-  }
-#endif
-#endif
-
-  m_hTraceHandle = NULL;
   m_fpDebugTrace = NULL;
   m_fpInfoTrace = NULL;
   m_fpWarnTrace = NULL;
@@ -318,9 +140,6 @@ int32_t  CWelsCodecTrace::UnloadWelsTraceModule() {
 }
 
 int32_t  CWelsCodecTrace::WriteString (int32_t iLevel, const str_t* pStr) {
-#ifndef NO_DYNAMIC_VP
-  if (m_hTraceHandle)
-#endif
   {
 #ifdef _WIN32
     switch (iLevel) {

--- a/codec/encoder/plus/inc/welsCodecTrace.h
+++ b/codec/encoder/plus/inc/welsCodecTrace.h
@@ -56,7 +56,6 @@ class welsCodecTrace {
  private:
 
   int32_t m_WelsTraceExistFlag;
-  void* m_hTraceHandle;
 
  public:
   static int32_t	m_iTraceLevel;

--- a/codec/encoder/plus/src/welsCodecTrace.cpp
+++ b/codec/encoder/plus/src/welsCodecTrace.cpp
@@ -43,18 +43,6 @@
 
 #include "welsCodecTrace.h"
 #include "utils.h"
-#if defined LINUX || defined SOLARIS || defined UNIX || defined MACOS //LINUX/SOLARIS/UNIX
-#include <dlfcn.h>
-#endif
-
-#if defined(MACOS)
-#include <carbon/carbon.h>
-#include <CoreFoundation/CFBundle.h>
-#endif//MACOS
-
-#ifdef _WIN32
-extern HANDLE g_hInstDll;
-#endif
 
 #include "logging.h"
 
@@ -64,77 +52,6 @@ extern HANDLE g_hInstDll;
 //#define CODEC_TRACE_DEDBUG 3
 
 using namespace WelsSVCEnc;
-
-#ifdef MACOS
-static CFBundleRef LoadLibrary (const str_t* lpszbundle) {
-  // 1.get bundle path
-  str_t cBundlePath[PATH_MAX];
-  memset (cBundlePath, 0, PATH_MAX);
-
-  Dl_info 	dlInfo;
-  static int32_t  sDummy;
-  dladdr ((void*)&sDummy, &dlInfo);
-
-  strlcpy (cBundlePath, dlInfo.dli_fname, PATH_MAX);	// confirmed_safe_unsafe_usage
-
-  str_t* pPath = NULL;
-  for (int32_t i = 4; i > 0; i--) {
-    pPath = strrchr (cBundlePath, '/');	// confirmed_safe_unsafe_usage
-    if (pPath) {
-      *pPath = 0;
-    } else {
-      break;
-    }
-  }
-  if (pPath) {
-    strlcat (cBundlePath, "/", PATH_MAX);	// confirmed_safe_unsafe_usage
-  } else {
-    return NULL;
-  }
-
-  strlcat (cBundlePath, lpszbundle, PATH_MAX);	// confirmed_safe_unsafe_usage
-
-  FSRef bundlePath;
-  OSStatus iStatus = FSPathMakeRef ((uint8_t*)cBundlePath, &bundlePath, NULL);
-  if (noErr != iStatus)
-    return NULL;
-
-  CFURLRef bundleURL = CFURLCreateFromFSRef (kCFAllocatorSystemDefault, &bundlePath);
-  if (NULL == bundleURL)
-    return NULL;
-
-  // 2.get bundle pRef
-  CFBundleRef bundleRef = CFBundleCreate (kCFAllocatorSystemDefault, bundleURL);
-  CFRelease (bundleURL);
-
-//	Boolean bReturn = FALSE;
-  if (NULL != bundleRef) {
-    //	bReturn = CFBundleLoadExecutable(bundleRef);
-  }
-
-  return bundleRef;
-}
-
-static Boolean FreeLibrary (CFBundleRef bundle) {
-  if (NULL != bundle) {
-    //	CFBundleUnloadExecutable(bundle);
-    CFRelease (bundle);
-  }
-
-  return TRUE;
-}
-
-static void* GetProcessAddress (CFBundleRef bundle, const str_t* lpszprocname) {
-  if (NULL == bundle)
-    return NULL;
-
-  CFStringRef cfprocname = CFStringCreateWithCString (NULL, lpszprocname, CFStringGetSystemEncoding());
-  void* processAddress = CFBundleGetFunctionPointerForName (bundle, cfprocname);
-  CFRelease (cfprocname);
-
-  return processAddress;
-}
-#endif
 
 int32_t	welsCodecTrace::m_iTraceLevel			= WELS_LOG_DEFAULT;
 #if defined(_WIN32)
@@ -150,115 +67,20 @@ CM_WELS_TRACE2 welsCodecTrace::m_fpErrorTrace   = NULL;
 #endif//WIN32
 
 welsCodecTrace::welsCodecTrace() {
-  m_hTraceHandle = NULL;
   m_fpDebugTrace = NULL;
   m_fpInfoTrace = NULL;
   m_fpWarnTrace = NULL;
   m_fpErrorTrace = NULL;
   m_WelsTraceExistFlag	= false;
-#ifdef NO_DYNAMIC_VP
   m_fpDebugTrace = welsStderrTrace<WELS_LOG_DEBUG>;
   m_fpInfoTrace = welsStderrTrace<WELS_LOG_INFO>;
   m_fpWarnTrace = welsStderrTrace<WELS_LOG_WARNING>;
   m_fpErrorTrace = welsStderrTrace<WELS_LOG_ERROR>;
 
   m_WelsTraceExistFlag = true;
-#else
-#if defined _WIN32
-  HMODULE handle = ::GetModuleHandle ("welstrace.dll");
-//	HMODULE handle = ::GetModuleHandle("contrace.dll"); // for c7
-  if (NULL == handle)
-    return;
-
-  CHAR achPath[ _MAX_PATH] = {0};
-  GetModuleFileName ((HMODULE)handle, achPath, _MAX_PATH);
-
-  m_hTraceHandle = ::LoadLibrary (achPath);
-
-  OutputDebugStringA (achPath);
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSDEBUGA");
-    m_fpInfoTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSINFOA");
-    m_fpWarnTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSWARNA");
-    m_fpErrorTrace = (CM_WELS_TRACE)::GetProcAddress ((HMODULE)m_hTraceHandle, "WELSERRORA");
-  }
-#elif defined MACOS
-  m_hTraceHandle = LoadLibrary ("welstrace.bundle");
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE2)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSDEBUG2");
-    m_fpInfoTrace = (CM_WELS_TRACE2)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSINFO2");
-    m_fpWarnTrace = (CM_WELS_TRACE2)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSWARN2");
-    m_fpErrorTrace = (CM_WELS_TRACE2)GetProcessAddress ((CFBundleRef)m_hTraceHandle, "WELSERROR2");
-  }
-#elif defined LINUX || defined SOLARIS || defined UNIX
-//#else
-//	CCmString	cmPath;
-  str_t achPath[255] = {0};
-  Dl_info		DlInfo;
-  static int32_t	nMmTPAddress;
-  dladdr (&nMmTPAddress, &DlInfo);
-
-  if (NULL == DlInfo.dli_fname)
-    return;
-  STRNCPY (achPath, 255, DlInfo.dli_fname, STRNLEN (DlInfo.dli_fname, 255));	// confirmed_safe_unsafe_usage
-  str_t* p = strrchr (achPath, '/');	// confirmed_safe_unsafe_usage
-  if (NULL == p)
-    return;
-  const int32_t kiLenTraceName = STRNLEN ("/libwelstrace.so", 15);	// confirmed_safe_unsafe_usage
-  const int32_t kiCurPos = p - achPath;
-  if (kiCurPos + kiLenTraceName < 255)
-    STRNCPY (p, 254 - kiCurPos, "/libwelstrace.so", kiLenTraceName);	// confirmed_safe_unsafe_usage
-  else
-    return;
-
-  m_hTraceHandle = dlopen (achPath, RTLD_LAZY);
-  if (m_hTraceHandle == NULL) {
-    FILE* fp = fopen ("/tmp/trace.txt", "a");
-    if (fp) {
-      fprintf (fp, "welsCodecTrace::welsCodecTrace ===> dlopen %s fail, %s\n", achPath, dlerror());
-      fclose (fp);
-    }
-    return;
-  }
-  if (m_hTraceHandle) {
-    m_fpDebugTrace = (CM_WELS_TRACE2)dlsym (m_hTraceHandle, "WELSDEBUG2");
-    m_fpInfoTrace = (CM_WELS_TRACE2)dlsym (m_hTraceHandle, "WELSINFO2");
-    m_fpWarnTrace = (CM_WELS_TRACE2)dlsym (m_hTraceHandle, "WELSWARN2");
-    m_fpErrorTrace = (CM_WELS_TRACE2)dlsym (m_hTraceHandle, "WELSERROR2");
-    if (m_fpDebugTrace == NULL) {
-      FILE* fp = fopen ("/tmp/trace.txt", "a");
-      if (fp) {
-        printf ("welsCodecTrace::welsCodecTrace ===> dlsym failed (WELSDEBUG2) , dlerror = %s\n", dlerror());
-        fclose (fp);
-      }
-      return;
-    }
-  }
-#endif
-  if (m_hTraceHandle != NULL) {
-    m_WelsTraceExistFlag	= true;
-  }
-#endif
 }
 
 welsCodecTrace::~welsCodecTrace() {
-#ifndef NO_DYNAMIC_VP
-#if defined _WIN32
-  if (m_hTraceHandle) {
-    ::FreeLibrary ((HMODULE)m_hTraceHandle);
-  }
-#elif defined MACOS
-  if (m_hTraceHandle) {
-    FreeLibrary ((CFBundleRef)m_hTraceHandle);
-  }
-#elif defined LINUX || defined SOLARIS || defined UNIX
-  if (m_hTraceHandle) {
-    ::dlclose (m_hTraceHandle);
-  }
-#endif
-#endif
-
-  m_hTraceHandle = NULL;
   m_fpDebugTrace = NULL;
   m_fpInfoTrace = NULL;
   m_fpWarnTrace = NULL;


### PR DESCRIPTION
No code exists within the project for building such a trace library.

This also fixes building on OS X with -Wno-deprecated-declarations
removed, since this code contained calls to deprecated functions
within #ifdef MACOS, which now are enabled when building on OS X.
