### PR TITLE
Enable threading when building for most platforms

### DIFF
--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -1,6 +1,6 @@
 
 ASM = nasm
-CFLAGS += -Wno-deprecated-declarations -Werror -fPIC -DMACOS
+CFLAGS += -Wno-deprecated-declarations -Werror -fPIC -DMACOS -DMT_ENABLED
 LDFLAGS += -lpthread
 ASMFLAGS += --prefix _ -DNOPREFIX
 ifeq ($(ENABLE64BIT), Yes)

--- a/build/platform-linux.mk
+++ b/build/platform-linux.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS += -Werror -fPIC -DLINUX
+CFLAGS += -Werror -fPIC -DLINUX -DMT_ENABLED
 LDFLAGS += -lpthread
 ASMFLAGS += -DNOPREFIX
 ifeq ($(ENABLE64BIT), Yes)

--- a/build/platform-mingw_nt.mk
+++ b/build/platform-mingw_nt.mk
@@ -1,5 +1,5 @@
 ASM = nasm
-CFLAGS +=
+CFLAGS += -DMT_ENABLED
 LDFLAGS +=
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f win64

--- a/build/platform-msvc.mk
+++ b/build/platform-msvc.mk
@@ -1,5 +1,6 @@
 include build/platform-msvc-common.mk
 ASM = nasm
+CFLAGS += -DMT_ENABLED
 LDFLAGS += user32.lib
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f win64


### PR DESCRIPTION
Don't enable threading globally since the MSVC/ARM build target
(neither windows phone nor windows rt) doesn't support the normal
windows threading functions.
