### PR TITLE
Simplify ifdefs in measure_time.h

### DIFF
--- a/codec/decoder/core/inc/measure_time.h
+++ b/codec/decoder/core/inc/measure_time.h
@@ -42,17 +42,14 @@
 
 #include <stdlib.h>
 
-#if !(defined(_MSC_VER) || defined(__MINGW32__))
+#ifndef _WIN32
 #include <sys/time.h>
 #else
 #include "typedefs.h"
-//#include <sys/types.h>
+#include <windows.h>
 #include <sys/timeb.h>
 #endif
 #include <time.h>
-#if defined(_WIN32)
-#include <windows.h>
-#endif//#if _WIN32
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,13 +62,12 @@ extern "C" {
  */
 
 int64_t WelsTime (void_t) {
-#if !(defined(_MSC_VER) || defined(__MINGW32__))
+#ifndef _WIN32
   struct timeval tv_date;
 
   gettimeofday (&tv_date, NULL);
   return ((int64_t) tv_date.tv_sec * 1000000 + (int64_t) tv_date.tv_usec);
 #else
-#if defined (_WIN32)
   static int64_t iMtimeFreq = 0;
   int64_t iMtimeCur = 0;
   int64_t iResult = 0;
@@ -83,13 +79,7 @@ int64_t WelsTime (void_t) {
   QueryPerformanceCounter ((LARGE_INTEGER*)&iMtimeCur);
   iResult = (int64_t) ((double)iMtimeCur * 1e6 / (double)iMtimeFreq + 0.5);
   return iResult;
-#else
-  struct _timeb sTime;
-
-  _ftime (&sTime);
-  return ((int64_t)sTime.time * (1000) + (int64_t)sTime.millitm) * (1000);
-#endif//#if _WIN32
-#endif//!(defined(_MSC_VER) || defined(__MINGW32__))
+#endif//WIN32
 }
 
 #ifdef __cplusplus

--- a/codec/encoder/core/inc/measure_time.h
+++ b/codec/encoder/core/inc/measure_time.h
@@ -42,18 +42,14 @@
 
 #include <stdlib.h>
 
-#if !(defined(_MSC_VER) || defined(__MINGW32__))
+#ifndef _WIN32
 #include <sys/time.h>
 #else
 #include "typedefs.h"
-//#include <sys/types.h>
+#include <windows.h>
 #include <sys/timeb.h>
 #endif
 #include <time.h>
-#if defined(_WIN32)
-#include <windows.h>
-//#include <mmsystem.h>	// need static lib winmm.lib for link for such windows 95/98 mm timer
-#endif//#if _WIN32
 
 /*!
  * \brief	time cost measure utilization
@@ -62,13 +58,12 @@
  */
 
 static inline int64_t WelsTime() {
-#if !(defined(_MSC_VER) || defined(__MINGW32__))
+#ifndef _WIN32
 struct timeval tv_date;
 
 gettimeofday (&tv_date, NULL);
 return ((int64_t) tv_date.tv_sec * 1000000 + (int64_t) tv_date.tv_usec);
 #else
-#if defined (_WIN32)
 static int64_t iMeasureTimeFreq = 0;
 //	static BOOL_T support_high_resolution_perf_flag = TRUE;
 int64_t iMeasureTimeCur = 0;
@@ -94,13 +89,7 @@ iResult = (int64_t) ((double)iMeasureTimeCur * 1e6 / (double)iMeasureTimeFreq + 
 //	}
 return iResult;
 
-#else
-struct _timeb tb;
-
-_ftime (&tb);
-return ((int64_t)tb.time * (1000) + (int64_t)tb.millitm) * (1000);
 #endif//#if _WIN32
-#endif//!(defined(_MSC_VER) || defined(__MINGW32__))
 }
 
 #endif//WELS_TIME_COST_MEASURE_UTIL_H__


### PR DESCRIPTION
Instead of using "defined(MSC_VER) || defined(**MINGW32**)" to
indicate the windows platform, just check for the _WIN32 define
instead.

Also remove an unused codepath - the removed codepath would
only be used under the condition
"(defined(MSC_VER) || defined(**MINGW32**)) && !defined(_WIN32)",
and I'm not aware of any environment with MSVC or MinGW that
doesn't define _WIN32, thus this codepath never was used.
