### PR TITLE
Remove spaces from the argument to LINK_LIB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ CODEC_UNITTEST_INCLUDES = \
     -Igtest/include
 
 H264DEC_INCLUDES = $(DECODER_INCLUDES) -Icodec/console/dec/inc
-H264DEC_LDFLAGS = -L. $(call LINK_LIB, decoder) $(call LINK_LIB, common)
+H264DEC_LDFLAGS = -L. $(call LINK_LIB,decoder) $(call LINK_LIB,common)
 H264DEC_DEPS = $(LIBPREFIX)decoder.$(LIBSUFFIX) $(LIBPREFIX)common.$(LIBSUFFIX)
 
 H264ENC_INCLUDES = $(ENCODER_INCLUDES) -Icodec/console/enc/inc
-H264ENC_LDFLAGS = -L. $(call LINK_LIB, encoder) $(call LINK_LIB, processing) $(call LINK_LIB, common)
+H264ENC_LDFLAGS = -L. $(call LINK_LIB,encoder) $(call LINK_LIB,processing) $(call LINK_LIB,common)
 H264ENC_DEPS = $(LIBPREFIX)encoder.$(LIBSUFFIX) $(LIBPREFIX)processing.$(LIBSUFFIX) $(LIBPREFIX)common.$(LIBSUFFIX)
 
 CODEC_UNITTEST_LDFLAGS = -L. -lgtest -ldecoder -lcrypto -lencoder -lprocessing -lcommon


### PR DESCRIPTION
In make on some platforms, this ended up as passing -l <lib>
with a space inbetween. This wasn't an error, but wasn't what
was intended either.
