### PR TITLE
Readd a removed include

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -43,6 +43,7 @@
 #include "wels_preprocess.h"
 #include "picture_handle.h"
 #include "encoder_context.h"
+#include "utils.h"
 
 #ifdef NO_DYNAMIC_VP
 EResult WELSAPI CreateVpInterface (void** ppCtx, int iVersion);


### PR DESCRIPTION
This fixes builds without NO_DYNAMIC_VP (such as with the MSVC
project files), the include was removed in d809b7e9.
