### PR TITLE
Unify the fallback codepath for getting prefix bits into a macro

### DIFF
--- a/codec/decoder/core/inc/vlc_decoder.h
+++ b/codec/decoder/core/inc/vlc_decoder.h
@@ -102,15 +102,18 @@ extern const uint8_t g_kuiZeroLeftTable5[8][2];
 extern const uint8_t g_kuiZeroLeftTable6[8][2];
 extern const uint8_t g_kuiZeroLeftBitNumMap[16];
 
-#ifdef WIN32
+#if defined(_MSC_VER) && defined(_M_IX86)
 //TODO need linux version
 #define WELS_GET_PREFIX_BITS(inval,outval){\
+	uint32_t local = inval;\
 	__asm xor		eax,	eax\
-	__asm bsr		eax,	inval\
+	__asm bsr		eax,	local\
 	__asm sub		eax,	32\
 	__asm neg		eax\
 	__asm mov		outval,	eax\
 }
+#else
+#define WELS_GET_PREFIX_BITS(inval, outval) outval = GetPrefixBits(inval)
 #endif
 
 static inline void_t InitVlcTable (SVlcTable* pVlcTable) {

--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -537,7 +537,6 @@ static int32_t CavlcGetLevelVal (int32_t iLevel[16], SReadBitsCache* pBitsCache,
                                  uint8_t uiTrailingOnes) {
   int32_t i, iUsedBits = 0;
   int32_t iSuffixLength, iSuffixLengthSize, iLevelPrefix, iPrefixBits, iLevelCode, iThreshold;
-  uint32_t uiCache32Bit;
   for (i = 0; i < uiTrailingOnes; i++) {
     iLevel[i] = 1 - ((pBitsCache->uiCache32Bit >> (30 - i)) & 0x02);
   }
@@ -548,12 +547,7 @@ static int32_t CavlcGetLevelVal (int32_t iLevel[16], SReadBitsCache* pBitsCache,
 
   for (; i < uiTotalCoeff; i++) {
     if (pBitsCache->uiRemainBits <= 16)		SHIFT_BUFFER (pBitsCache);
-#if defined(_MSC_VER) && defined(_M_IX86)
-    uiCache32Bit = pBitsCache->uiCache32Bit;
-    WELS_GET_PREFIX_BITS (uiCache32Bit, iPrefixBits);
-#else
-    iPrefixBits = GetPrefixBits (pBitsCache->uiCache32Bit);
-#endif
+    WELS_GET_PREFIX_BITS (pBitsCache->uiCache32Bit, iPrefixBits);
     POP_BUFFER (pBitsCache, iPrefixBits);
     iUsedBits   += iPrefixBits;
     iLevelPrefix = iPrefixBits - 1;


### PR DESCRIPTION
This avoids having to know the details about when the optimized
codepath is available at the place where it's used.
