### PR TITLE
Consistently use the compat wrappers for file IO

### DIFF
--- a/codec/common/crt_util_safe_x.cpp
+++ b/codec/common/crt_util_safe_x.cpp
@@ -270,6 +270,10 @@ uint16_t WelsGetMillisecond (const SWelsTime* kpTp) {
   return kpTp->millitm;
 }
 
+int32_t WelsFseek (WelsFileHandle* fp, int32_t offset, int32_t origin) {
+  return fseek(fp, offset, origin);
+}
+
 int32_t WelsFflush (WelsFileHandle* pFp) {
   return fflush (pFp);
 }

--- a/codec/encoder/core/inc/encoder_context.h
+++ b/codec/encoder/core/inc/encoder_context.h
@@ -52,6 +52,7 @@
 #include "as264_common.h"
 #include "wels_preprocess.h"
 #include "wels_func_ptr_def.h"
+#include "crt_util_safe_x.h"
 
 #ifdef MT_ENABLED
 #include "mt_defs.h"	// for multiple threadin,
@@ -214,7 +215,7 @@ typedef struct TagWelsEncCtx {
   CMemoryAlign*				pMemAlign;
 
 #ifdef ENABLE_TRACE_FILE
-  FILE*						pFileLog;		// log file for wels encoder
+  WelsFileHandle*				pFileLog;		// log file for wels encoder
   uint32_t					uiSizeLog;		// size of log have been written in file
 
 #endif//ENABLE_TRACE_FILE

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -315,7 +315,7 @@ EFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum) {
  */
 
 extern "C" void DumpDependencyRec (SPicture* pCurPicture, const str_t* kpFileName, const int8_t kiDid) {
-  FILE* pDumpRecFile											= NULL;
+  WelsFileHandle* pDumpRecFile = NULL;
   static bool_t bDependencyRecFlag[MAX_DEPENDENCY_LAYER]	= {0};
   int32_t iWrittenSize											= 0;
 
@@ -331,7 +331,7 @@ extern "C" void DumpDependencyRec (SPicture* pCurPicture, const str_t* kpFileNam
       pDumpRecFile	= WelsFopen (sDependencyRecFileName, "ab");
     }
     if (NULL != pDumpRecFile)
-      fseek (pDumpRecFile, 0, SEEK_END);
+      WelsFseek (pDumpRecFile, 0, SEEK_END);
   } else {
     if (STRNLEN (kpFileName, MAX_FNAME_LEN) > 0) {	// confirmed_safe_unsafe_usage
       pDumpRecFile	= WelsFopen (kpFileName, "wb");
@@ -353,27 +353,27 @@ extern "C" void DumpDependencyRec (SPicture* pCurPicture, const str_t* kpFileNam
     const int32_t kiChromaHeight	= kiLumaHeight >> 1;
 
     for (j = 0; j < kiLumaHeight; ++ j) {
-      iWrittenSize = fwrite (&pCurPicture->pData[0][j * kiStrideY], 1, kiLumaWidth, pDumpRecFile);
+      iWrittenSize = WelsFwrite (&pCurPicture->pData[0][j * kiStrideY], 1, kiLumaWidth, pDumpRecFile);
       assert (iWrittenSize == kiLumaWidth);
       if (iWrittenSize < kiLumaWidth) {
         assert (0);	// make no sense for us if writing failed
-        fclose (pDumpRecFile);
+        WelsFclose (pDumpRecFile);
         return;
       }
     }
     for (i = 1; i < I420_PLANES; ++ i) {
       const int32_t kiStrideUV = pCurPicture->iLineSize[i];
       for (j = 0; j < kiChromaHeight; ++ j) {
-        iWrittenSize = fwrite (&pCurPicture->pData[i][j * kiStrideUV], 1, kiChromaWidth, pDumpRecFile);
+        iWrittenSize = WelsFwrite (&pCurPicture->pData[i][j * kiStrideUV], 1, kiChromaWidth, pDumpRecFile);
         assert (iWrittenSize == kiChromaWidth);
         if (iWrittenSize < kiChromaWidth) {
           assert (0);	// make no sense for us if writing failed
-          fclose (pDumpRecFile);
+          WelsFclose (pDumpRecFile);
           return;
         }
       }
     }
-    fclose (pDumpRecFile);
+    WelsFclose (pDumpRecFile);
     pDumpRecFile = NULL;
   }
 }
@@ -383,7 +383,7 @@ extern "C" void DumpDependencyRec (SPicture* pCurPicture, const str_t* kpFileNam
  */
 
 void DumpRecFrame (SPicture* pCurPicture, const str_t* kpFileName) {
-  FILE* pDumpRecFile				= NULL;
+  WelsFileHandle* pDumpRecFile				= NULL;
   static bool_t bRecFlag	= false;
   int32_t iWrittenSize			= 0;
 
@@ -397,7 +397,7 @@ void DumpRecFrame (SPicture* pCurPicture, const str_t* kpFileName) {
       pDumpRecFile	= WelsFopen ("rec.yuv", "ab");
     }
     if (NULL != pDumpRecFile)
-      fseek (pDumpRecFile, 0, SEEK_END);
+      WelsFseek (pDumpRecFile, 0, SEEK_END);
   } else {
     if (STRNLEN (kpFileName, MAX_FNAME_LEN) > 0) {	// confirmed_safe_unsafe_usage
       pDumpRecFile	= WelsFopen (kpFileName, "wb");
@@ -417,27 +417,27 @@ void DumpRecFrame (SPicture* pCurPicture, const str_t* kpFileName) {
     const int32_t kiChromaHeight	= kiLumaHeight >> 1;
 
     for (j = 0; j < kiLumaHeight; ++ j) {
-      iWrittenSize = fwrite (&pCurPicture->pData[0][j * kiStrideY], 1, kiLumaWidth, pDumpRecFile);
+      iWrittenSize = WelsFwrite (&pCurPicture->pData[0][j * kiStrideY], 1, kiLumaWidth, pDumpRecFile);
       assert (iWrittenSize == kiLumaWidth);
       if (iWrittenSize < kiLumaWidth) {
         assert (0);	// make no sense for us if writing failed
-        fclose (pDumpRecFile);
+        WelsFclose (pDumpRecFile);
         return;
       }
     }
     for (i = 1; i < I420_PLANES; ++ i) {
       const int32_t kiStrideUV = pCurPicture->iLineSize[i];
       for (j = 0; j < kiChromaHeight; ++ j) {
-        iWrittenSize = fwrite (&pCurPicture->pData[i][j * kiStrideUV], 1, kiChromaWidth, pDumpRecFile);
+        iWrittenSize = WelsFwrite (&pCurPicture->pData[i][j * kiStrideUV], 1, kiChromaWidth, pDumpRecFile);
         assert (iWrittenSize == kiChromaWidth);
         if (iWrittenSize < kiChromaWidth) {
           assert (0);	// make no sense for us if writing failed
-          fclose (pDumpRecFile);
+          WelsFclose (pDumpRecFile);
           return;
         }
       }
     }
-    fclose (pDumpRecFile);
+    WelsFclose (pDumpRecFile);
     pDumpRecFile = NULL;
   }
 }

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -1789,7 +1789,7 @@ void FreeMemorySvc (sWelsEncCtx** ppCtx) {
 
 #ifdef ENABLE_TRACE_FILE
     if (NULL != pCtx->pFileLog) {
-      fclose (pCtx->pFileLog);
+      WelsFclose (pCtx->pFileLog);
       pCtx->pFileLog	= NULL;
     }
     pCtx->uiSizeLog	= 0;

--- a/codec/encoder/core/src/utils.cpp
+++ b/codec/encoder/core/src/utils.cpp
@@ -227,12 +227,12 @@ void WelsLogDefault (void* pCtx, const int32_t kiLevel, const str_t* kpFmtStr, v
 #ifdef ENABLE_TRACE_FILE
     if (NULL != pEncCtx && NULL != pEncCtx->pFileLog) {
       if (pEncCtx->uiSizeLog > MAX_TRACE_LOG_SIZE) {
-        if (0 == fseek (pEncCtx->pFileLog, 0L, SEEK_SET))
+        if (0 == WelsFseek (pEncCtx->pFileLog, 0L, SEEK_SET))
           pEncCtx->uiSizeLog = 0;
       }
       if (iBufUsed > 0 && iBufUsed < WELS_LOG_BUF_SIZE) {
-        iCurUsed = fwrite (pBuf, 1, iBufUsed, pEncCtx->pFileLog);
-        fflush (pEncCtx->pFileLog);
+        iCurUsed = WelsFwrite (pBuf, 1, iBufUsed, pEncCtx->pFileLog);
+        WelsFflush (pEncCtx->pFileLog);
         if (iCurUsed == iBufUsed)
           pEncCtx->uiSizeLog += iBufUsed;
       }
@@ -267,7 +267,7 @@ void WelsReopenTraceFile (void* pCtx, str_t* pCurPath) {
     str_t strTraceFile[MAX_FNAME_LEN] = {0};
     int32_t len = 0;
     if (pEncCtx->pFileLog != NULL) {
-      fclose (pEncCtx->pFileLog);
+      WelsFclose (pEncCtx->pFileLog);
       pEncCtx->pFileLog = NULL;
     }
     pEncCtx->uiSizeLog	= 0;

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -164,11 +164,11 @@ CWelsH264SVCEncoder::~CWelsH264SVCEncoder() {
 
 #ifdef OUTPUT_BIT_STREAM
   if (m_pFileBs) {
-    fclose (m_pFileBs);
+    WelsFclose (m_pFileBs);
     m_pFileBs = NULL;
   }
   if (m_pFileBsSize) {
-    fclose (m_pFileBsSize);
+    WelsFclose (m_pFileBsSize);
     m_pFileBsSize = NULL;
   }
   m_bSwitch	= FALSE;
@@ -585,11 +585,11 @@ int CWelsH264SVCEncoder::EncodeFrame2 (const SSourcePicture**   pSrcPicList, int
 
     if (m_bSwitch) {
       if (m_pFileBs) {
-        fclose (m_pFileBs);
+        WelsFclose (m_pFileBs);
         m_pFileBs = NULL;
       }
       if (m_pFileBsSize) {
-        fclose (m_pFileBsSize);
+        WelsFclose (m_pFileBsSize);
         m_pFileBsSize = NULL;
       }
       str_t strStreamFileName[128] = {0};
@@ -613,11 +613,11 @@ int CWelsH264SVCEncoder::EncodeFrame2 (const SSourcePicture**   pSrcPicList, int
       }
       total_bits += iCurLayerBits;
       if (m_pFileBs != NULL)
-        fwrite (pLayer->pBsBuf, 1, iCurLayerBits, m_pFileBs);
+        WelsFwrite (pLayer->pBsBuf, 1, iCurLayerBits, m_pFileBs);
     }
 
     if (m_pFileBsSize != NULL)
-      fwrite (&total_bits, sizeof (int32_t), 1, m_pFileBsSize);
+      WelsFwrite (&total_bits, sizeof (int32_t), 1, m_pFileBsSize);
   }
 #endif //OUTPUT_BIT_STREAM
 #ifdef DUMP_SRC_PICTURE


### PR DESCRIPTION
As long as WelsFileHandle\* is equal to FILE\* this doesn't matter,
but for consistency use the WelsF\* functions for all handles
opened by WelsFopen, and use WelsFileHandle\* as type for it
instead of FILE*.
