### PR TITLE
Unify the codepaths for WELS_GET_PERFIX_BITS at the second place

### DIFF
--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -620,7 +620,7 @@ static int32_t CavlcGetTotalZeros (int32_t& iZerosLeft, SReadBitsCache* pBitsCac
 static int32_t	CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, uint8_t uiTotalCoeff,
                                    SVlcTable* pVlcTable, int32_t iZerosLeft) {
   int32_t i, iUsedBits = 0;
-  uint32_t uiCount, uiValue, uiCache32Bit, iPrefixBits;
+  uint32_t uiCount, uiValue, iPrefixBits;
 
   for (i = 0; i < uiTotalCoeff - 1; i++) {
     if (iZerosLeft > 0) {
@@ -639,12 +639,7 @@ static int32_t	CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, 
           iRun[i] = pVlcTable->kpZeroTable[6][uiValue][0];
         } else {
           if (pBitsCache->uiRemainBits < 16) SHIFT_BUFFER (pBitsCache);
-#if defined(_MSC_VER) && defined(_M_IX86)
-          uiCache32Bit = pBitsCache->uiCache32Bit;
-          WELS_GET_PREFIX_BITS (uiCache32Bit, iPrefixBits);
-#else
-          iPrefixBits = GetPrefixBits (pBitsCache->uiCache32Bit);
-#endif
+          WELS_GET_PREFIX_BITS (pBitsCache->uiCache32Bit, iPrefixBits);
           iRun[i] = iPrefixBits + 6;
           if (iRun[i] > iZerosLeft)
             return -1;


### PR DESCRIPTION
This changes a second use of the macro which was missed in
60e0255677.

This avoids warnings about unused local variables in 64 bit
builds in MSVC.
