### PR TITLE
Fix parsing of the -drec option if ENABLE_FRAME_DUMP isn't set

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -562,8 +562,9 @@ int ParseCommandLine (int argc, char** argv, SWelsSvcCodingParam& pSvcParam, SFi
 #ifdef ENABLE_FRAME_DUMP
       SDLayerParam* pDLayer = &pSvcParam.sDependencyLayers[iLayer];
       pDLayer->sRecFileName[iLen] = '\0';
-      strncpy (pDLayer->sRecFileName, argv[n++], iLen);	// confirmed_safe_unsafe_usage
+      strncpy (pDLayer->sRecFileName, argv[n], iLen);	// confirmed_safe_unsafe_usage
 #endif//ENABLE_FRAME_DUMP
+      n++;
     }
 
     else if (!strcmp (pCommand, "-sw") && (n + 1 < argc)) {


### PR DESCRIPTION
If the define wasn't set, the argument iterator didn't skip
the file name argument.
