### PR TITLE
Remove redundant /./ parts from pathnames in makefiles

### DIFF
--- a/build/gtest-targets.mk
+++ b/build/gtest-targets.mk
@@ -1,6 +1,6 @@
 GTEST_SRCDIR=gtest
 GTEST_CPP_SRCS=\
-	$(GTEST_SRCDIR)/./src/gtest-all.cc\
+	$(GTEST_SRCDIR)/src/gtest-all.cc\
 
 GTEST_OBJS += $(GTEST_CPP_SRCS:.cc=.o)
 OBJS += $(GTEST_OBJS)

--- a/build/mktargets.py
+++ b/build/mktargets.py
@@ -47,9 +47,9 @@ def find_sources():
         for file in dir[2]:
             if (len(INCLUDE) == 0 and not file in EXCLUDE) or file in INCLUDE:
                 if os.path.splitext(file)[1] == CPP_SUFFIX:
-                    cpp_files.append(os.path.join(dir[0], file))
+                    cpp_files.append(os.path.join(dir[0].strip('./'), file))
                 if os.path.splitext(file)[1] == '.asm':
-                    asm_files.append(os.path.join(dir[0], file))
+                    asm_files.append(os.path.join(dir[0].strip('./'), file))
     return [cpp_files, asm_files]
 
 

--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -1,23 +1,23 @@
 COMMON_SRCDIR=codec/common
 COMMON_CPP_SRCS=\
-	$(COMMON_SRCDIR)/./cpu.cpp\
-	$(COMMON_SRCDIR)/./crt_util_safe_x.cpp\
-	$(COMMON_SRCDIR)/./deblocking_common.cpp\
-	$(COMMON_SRCDIR)/./logging.cpp\
-	$(COMMON_SRCDIR)/./WelsThreadLib.cpp\
+	$(COMMON_SRCDIR)/cpu.cpp\
+	$(COMMON_SRCDIR)/crt_util_safe_x.cpp\
+	$(COMMON_SRCDIR)/deblocking_common.cpp\
+	$(COMMON_SRCDIR)/logging.cpp\
+	$(COMMON_SRCDIR)/WelsThreadLib.cpp\
 
 COMMON_OBJS += $(COMMON_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 COMMON_ASM_SRCS=\
-	$(COMMON_SRCDIR)/./asm_inc.asm\
-	$(COMMON_SRCDIR)/./cpuid.asm\
-	$(COMMON_SRCDIR)/./deblock.asm\
-	$(COMMON_SRCDIR)/./expand_picture.asm\
-	$(COMMON_SRCDIR)/./mb_copy.asm\
-	$(COMMON_SRCDIR)/./mc_chroma.asm\
-	$(COMMON_SRCDIR)/./mc_luma.asm\
-	$(COMMON_SRCDIR)/./satd_sad.asm\
-	$(COMMON_SRCDIR)/./vaa.asm\
+	$(COMMON_SRCDIR)/asm_inc.asm\
+	$(COMMON_SRCDIR)/cpuid.asm\
+	$(COMMON_SRCDIR)/deblock.asm\
+	$(COMMON_SRCDIR)/expand_picture.asm\
+	$(COMMON_SRCDIR)/mb_copy.asm\
+	$(COMMON_SRCDIR)/mc_chroma.asm\
+	$(COMMON_SRCDIR)/mc_luma.asm\
+	$(COMMON_SRCDIR)/satd_sad.asm\
+	$(COMMON_SRCDIR)/vaa.asm\
 
 COMMON_OBJS += $(COMMON_ASM_SRCS:.asm=.o)
 endif

--- a/codec/console/dec/targets.mk
+++ b/codec/console/dec/targets.mk
@@ -1,8 +1,8 @@
 H264DEC_SRCDIR=codec/console/dec
 H264DEC_CPP_SRCS=\
-	$(H264DEC_SRCDIR)/./src/d3d9_utils.cpp\
-	$(H264DEC_SRCDIR)/./src/h264dec.cpp\
-	$(H264DEC_SRCDIR)/./src/read_config.cpp\
+	$(H264DEC_SRCDIR)/src/d3d9_utils.cpp\
+	$(H264DEC_SRCDIR)/src/h264dec.cpp\
+	$(H264DEC_SRCDIR)/src/read_config.cpp\
 
 H264DEC_OBJS += $(H264DEC_CPP_SRCS:.cpp=.o)
 OBJS += $(H264DEC_OBJS)

--- a/codec/console/enc/targets.mk
+++ b/codec/console/enc/targets.mk
@@ -1,7 +1,7 @@
 H264ENC_SRCDIR=codec/console/enc
 H264ENC_CPP_SRCS=\
-	$(H264ENC_SRCDIR)/./src/read_config.cpp\
-	$(H264ENC_SRCDIR)/./src/welsenc.cpp\
+	$(H264ENC_SRCDIR)/src/read_config.cpp\
+	$(H264ENC_SRCDIR)/src/welsenc.cpp\
 
 H264ENC_OBJS += $(H264ENC_CPP_SRCS:.cpp=.o)
 OBJS += $(H264ENC_OBJS)

--- a/codec/decoder/targets.mk
+++ b/codec/decoder/targets.mk
@@ -1,34 +1,34 @@
 DECODER_SRCDIR=codec/decoder
 DECODER_CPP_SRCS=\
-	$(DECODER_SRCDIR)/./core/src/au_parser.cpp\
-	$(DECODER_SRCDIR)/./core/src/bit_stream.cpp\
-	$(DECODER_SRCDIR)/./core/src/deblocking.cpp\
-	$(DECODER_SRCDIR)/./core/src/decode_mb_aux.cpp\
-	$(DECODER_SRCDIR)/./core/src/decode_slice.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder_core.cpp\
-	$(DECODER_SRCDIR)/./core/src/decoder_data_tables.cpp\
-	$(DECODER_SRCDIR)/./core/src/expand_pic.cpp\
-	$(DECODER_SRCDIR)/./core/src/fmo.cpp\
-	$(DECODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
-	$(DECODER_SRCDIR)/./core/src/manage_dec_ref.cpp\
-	$(DECODER_SRCDIR)/./core/src/mc.cpp\
-	$(DECODER_SRCDIR)/./core/src/mem_align.cpp\
-	$(DECODER_SRCDIR)/./core/src/memmgr_nal_unit.cpp\
-	$(DECODER_SRCDIR)/./core/src/mv_pred.cpp\
-	$(DECODER_SRCDIR)/./core/src/parse_mb_syn_cavlc.cpp\
-	$(DECODER_SRCDIR)/./core/src/pic_queue.cpp\
-	$(DECODER_SRCDIR)/./core/src/rec_mb.cpp\
-	$(DECODER_SRCDIR)/./core/src/utils.cpp\
-	$(DECODER_SRCDIR)/./plus/src/welsCodecTrace.cpp\
-	$(DECODER_SRCDIR)/./plus/src/welsDecoderExt.cpp\
+	$(DECODER_SRCDIR)/core/src/au_parser.cpp\
+	$(DECODER_SRCDIR)/core/src/bit_stream.cpp\
+	$(DECODER_SRCDIR)/core/src/deblocking.cpp\
+	$(DECODER_SRCDIR)/core/src/decode_mb_aux.cpp\
+	$(DECODER_SRCDIR)/core/src/decode_slice.cpp\
+	$(DECODER_SRCDIR)/core/src/decoder.cpp\
+	$(DECODER_SRCDIR)/core/src/decoder_core.cpp\
+	$(DECODER_SRCDIR)/core/src/decoder_data_tables.cpp\
+	$(DECODER_SRCDIR)/core/src/expand_pic.cpp\
+	$(DECODER_SRCDIR)/core/src/fmo.cpp\
+	$(DECODER_SRCDIR)/core/src/get_intra_predictor.cpp\
+	$(DECODER_SRCDIR)/core/src/manage_dec_ref.cpp\
+	$(DECODER_SRCDIR)/core/src/mc.cpp\
+	$(DECODER_SRCDIR)/core/src/mem_align.cpp\
+	$(DECODER_SRCDIR)/core/src/memmgr_nal_unit.cpp\
+	$(DECODER_SRCDIR)/core/src/mv_pred.cpp\
+	$(DECODER_SRCDIR)/core/src/parse_mb_syn_cavlc.cpp\
+	$(DECODER_SRCDIR)/core/src/pic_queue.cpp\
+	$(DECODER_SRCDIR)/core/src/rec_mb.cpp\
+	$(DECODER_SRCDIR)/core/src/utils.cpp\
+	$(DECODER_SRCDIR)/plus/src/welsCodecTrace.cpp\
+	$(DECODER_SRCDIR)/plus/src/welsDecoderExt.cpp\
 
 DECODER_OBJS += $(DECODER_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 DECODER_ASM_SRCS=\
-	$(DECODER_SRCDIR)/./core/asm/block_add.asm\
-	$(DECODER_SRCDIR)/./core/asm/dct.asm\
-	$(DECODER_SRCDIR)/./core/asm/intra_pred.asm\
+	$(DECODER_SRCDIR)/core/asm/block_add.asm\
+	$(DECODER_SRCDIR)/core/asm/dct.asm\
+	$(DECODER_SRCDIR)/core/asm/intra_pred.asm\
 
 DECODER_OBJS += $(DECODER_ASM_SRCS:.asm=.o)
 endif

--- a/codec/encoder/targets.mk
+++ b/codec/encoder/targets.mk
@@ -1,47 +1,47 @@
 ENCODER_SRCDIR=codec/encoder
 ENCODER_CPP_SRCS=\
-	$(ENCODER_SRCDIR)/./core/src/au_set.cpp\
-	$(ENCODER_SRCDIR)/./core/src/deblocking.cpp\
-	$(ENCODER_SRCDIR)/./core/src/decode_mb_aux.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encode_mb_aux.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encoder.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encoder_data_tables.cpp\
-	$(ENCODER_SRCDIR)/./core/src/encoder_ext.cpp\
-	$(ENCODER_SRCDIR)/./core/src/expand_pic.cpp\
-	$(ENCODER_SRCDIR)/./core/src/get_intra_predictor.cpp\
-	$(ENCODER_SRCDIR)/./core/src/mc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/md.cpp\
-	$(ENCODER_SRCDIR)/./core/src/memory_align.cpp\
-	$(ENCODER_SRCDIR)/./core/src/mv_pred.cpp\
-	$(ENCODER_SRCDIR)/./core/src/nal_encap.cpp\
-	$(ENCODER_SRCDIR)/./core/src/picture_handle.cpp\
-	$(ENCODER_SRCDIR)/./core/src/property.cpp\
-	$(ENCODER_SRCDIR)/./core/src/ratectl.cpp\
-	$(ENCODER_SRCDIR)/./core/src/ref_list_mgr_svc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/sample.cpp\
-	$(ENCODER_SRCDIR)/./core/src/set_mb_syn_cavlc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/slice_multi_threading.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_base_layer_md.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_enc_slice_segment.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_encode_mb.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_encode_slice.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_mode_decision.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_motion_estimate.cpp\
-	$(ENCODER_SRCDIR)/./core/src/svc_set_mb_syn_cavlc.cpp\
-	$(ENCODER_SRCDIR)/./core/src/utils.cpp\
-	$(ENCODER_SRCDIR)/./core/src/wels_preprocess.cpp\
-	$(ENCODER_SRCDIR)/./plus/src/welsCodecTrace.cpp\
-	$(ENCODER_SRCDIR)/./plus/src/welsEncoderExt.cpp\
+	$(ENCODER_SRCDIR)/core/src/au_set.cpp\
+	$(ENCODER_SRCDIR)/core/src/deblocking.cpp\
+	$(ENCODER_SRCDIR)/core/src/decode_mb_aux.cpp\
+	$(ENCODER_SRCDIR)/core/src/encode_mb_aux.cpp\
+	$(ENCODER_SRCDIR)/core/src/encoder.cpp\
+	$(ENCODER_SRCDIR)/core/src/encoder_data_tables.cpp\
+	$(ENCODER_SRCDIR)/core/src/encoder_ext.cpp\
+	$(ENCODER_SRCDIR)/core/src/expand_pic.cpp\
+	$(ENCODER_SRCDIR)/core/src/get_intra_predictor.cpp\
+	$(ENCODER_SRCDIR)/core/src/mc.cpp\
+	$(ENCODER_SRCDIR)/core/src/md.cpp\
+	$(ENCODER_SRCDIR)/core/src/memory_align.cpp\
+	$(ENCODER_SRCDIR)/core/src/mv_pred.cpp\
+	$(ENCODER_SRCDIR)/core/src/nal_encap.cpp\
+	$(ENCODER_SRCDIR)/core/src/picture_handle.cpp\
+	$(ENCODER_SRCDIR)/core/src/property.cpp\
+	$(ENCODER_SRCDIR)/core/src/ratectl.cpp\
+	$(ENCODER_SRCDIR)/core/src/ref_list_mgr_svc.cpp\
+	$(ENCODER_SRCDIR)/core/src/sample.cpp\
+	$(ENCODER_SRCDIR)/core/src/set_mb_syn_cavlc.cpp\
+	$(ENCODER_SRCDIR)/core/src/slice_multi_threading.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_base_layer_md.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_enc_slice_segment.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_encode_mb.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_encode_slice.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_mode_decision.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_motion_estimate.cpp\
+	$(ENCODER_SRCDIR)/core/src/svc_set_mb_syn_cavlc.cpp\
+	$(ENCODER_SRCDIR)/core/src/utils.cpp\
+	$(ENCODER_SRCDIR)/core/src/wels_preprocess.cpp\
+	$(ENCODER_SRCDIR)/plus/src/welsCodecTrace.cpp\
+	$(ENCODER_SRCDIR)/plus/src/welsEncoderExt.cpp\
 
 ENCODER_OBJS += $(ENCODER_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 ENCODER_ASM_SRCS=\
-	$(ENCODER_SRCDIR)/./core/asm/coeff.asm\
-	$(ENCODER_SRCDIR)/./core/asm/dct.asm\
-	$(ENCODER_SRCDIR)/./core/asm/intra_pred.asm\
-	$(ENCODER_SRCDIR)/./core/asm/memzero.asm\
-	$(ENCODER_SRCDIR)/./core/asm/quant.asm\
-	$(ENCODER_SRCDIR)/./core/asm/score.asm\
+	$(ENCODER_SRCDIR)/core/asm/coeff.asm\
+	$(ENCODER_SRCDIR)/core/asm/dct.asm\
+	$(ENCODER_SRCDIR)/core/asm/intra_pred.asm\
+	$(ENCODER_SRCDIR)/core/asm/memzero.asm\
+	$(ENCODER_SRCDIR)/core/asm/quant.asm\
+	$(ENCODER_SRCDIR)/core/asm/score.asm\
 
 ENCODER_OBJS += $(ENCODER_ASM_SRCS:.asm=.o)
 endif

--- a/codec/processing/targets.mk
+++ b/codec/processing/targets.mk
@@ -1,29 +1,29 @@
 PROCESSING_SRCDIR=codec/processing
 PROCESSING_CPP_SRCS=\
-	$(PROCESSING_SRCDIR)/./src/adaptivequantization/AdaptiveQuantization.cpp\
-	$(PROCESSING_SRCDIR)/./src/backgrounddetection/BackgroundDetection.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/memory.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/thread.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWork.cpp\
-	$(PROCESSING_SRCDIR)/./src/common/WelsFrameWorkEx.cpp\
-	$(PROCESSING_SRCDIR)/./src/complexityanalysis/ComplexityAnalysis.cpp\
-	$(PROCESSING_SRCDIR)/./src/denoise/denoise.cpp\
-	$(PROCESSING_SRCDIR)/./src/denoise/denoise_filter.cpp\
-	$(PROCESSING_SRCDIR)/./src/downsample/downsample.cpp\
-	$(PROCESSING_SRCDIR)/./src/downsample/downsamplefuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotate.cpp\
-	$(PROCESSING_SRCDIR)/./src/imagerotate/imagerotatefuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetection.cpp\
-	$(PROCESSING_SRCDIR)/./src/scenechangedetection/SceneChangeDetectionCommon.cpp\
-	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalcfuncs.cpp\
-	$(PROCESSING_SRCDIR)/./src/vaacalc/vaacalculation.cpp\
+	$(PROCESSING_SRCDIR)/src/adaptivequantization/AdaptiveQuantization.cpp\
+	$(PROCESSING_SRCDIR)/src/backgrounddetection/BackgroundDetection.cpp\
+	$(PROCESSING_SRCDIR)/src/common/memory.cpp\
+	$(PROCESSING_SRCDIR)/src/common/thread.cpp\
+	$(PROCESSING_SRCDIR)/src/common/WelsFrameWork.cpp\
+	$(PROCESSING_SRCDIR)/src/common/WelsFrameWorkEx.cpp\
+	$(PROCESSING_SRCDIR)/src/complexityanalysis/ComplexityAnalysis.cpp\
+	$(PROCESSING_SRCDIR)/src/denoise/denoise.cpp\
+	$(PROCESSING_SRCDIR)/src/denoise/denoise_filter.cpp\
+	$(PROCESSING_SRCDIR)/src/downsample/downsample.cpp\
+	$(PROCESSING_SRCDIR)/src/downsample/downsamplefuncs.cpp\
+	$(PROCESSING_SRCDIR)/src/imagerotate/imagerotate.cpp\
+	$(PROCESSING_SRCDIR)/src/imagerotate/imagerotatefuncs.cpp\
+	$(PROCESSING_SRCDIR)/src/scenechangedetection/SceneChangeDetection.cpp\
+	$(PROCESSING_SRCDIR)/src/scenechangedetection/SceneChangeDetectionCommon.cpp\
+	$(PROCESSING_SRCDIR)/src/vaacalc/vaacalcfuncs.cpp\
+	$(PROCESSING_SRCDIR)/src/vaacalc/vaacalculation.cpp\
 
 PROCESSING_OBJS += $(PROCESSING_CPP_SRCS:.cpp=.o)
 ifeq ($(USE_ASM), Yes)
 PROCESSING_ASM_SRCS=\
-	$(PROCESSING_SRCDIR)/./src/asm/denoisefilter.asm\
-	$(PROCESSING_SRCDIR)/./src/asm/downsample_bilinear.asm\
-	$(PROCESSING_SRCDIR)/./src/asm/vaa.asm\
+	$(PROCESSING_SRCDIR)/src/asm/denoisefilter.asm\
+	$(PROCESSING_SRCDIR)/src/asm/downsample_bilinear.asm\
+	$(PROCESSING_SRCDIR)/src/asm/vaa.asm\
 
 PROCESSING_OBJS += $(PROCESSING_ASM_SRCS:.asm=.o)
 endif

--- a/test/targets.mk
+++ b/test/targets.mk
@@ -1,11 +1,11 @@
 CODEC_UNITTEST_SRCDIR=test
 CODEC_UNITTEST_CPP_SRCS=\
-	$(CODEC_UNITTEST_SRCDIR)/./BaseDecoderTest.cpp\
-	$(CODEC_UNITTEST_SRCDIR)/./encoder_test.cpp\
-	$(CODEC_UNITTEST_SRCDIR)/./decode_encode_test.cpp\
-	$(CODEC_UNITTEST_SRCDIR)/./simple_test.cpp\
-	$(CODEC_UNITTEST_SRCDIR)/./decoder_test.cpp\
-	$(CODEC_UNITTEST_SRCDIR)/./BaseEncoderTest.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/BaseDecoderTest.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/BaseEncoderTest.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/decode_encode_test.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/decoder_test.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/encoder_test.cpp\
+	$(CODEC_UNITTEST_SRCDIR)/simple_test.cpp\
 
 CODEC_UNITTEST_OBJS += $(CODEC_UNITTEST_CPP_SRCS:.cpp=.o)
 OBJS += $(CODEC_UNITTEST_OBJS)


### PR DESCRIPTION
This is mostly a cosmetic improvement for the quiet make output.
