### PR TITLE
Remove fallback defines for NULL

### DIFF
--- a/codec/common/typedefs.h
+++ b/codec/common/typedefs.h
@@ -35,6 +35,7 @@
 #define WELS_TYPE_DEFINES_H__
 
 #include <limits.h>
+#include <stddef.h>
 
 ////////////////////////////////////////////////////////////////////////////
 // NOTICE : ALL internal implement MUST use the data type defined as below
@@ -66,10 +67,6 @@ typedef float     real32_t;
 #undef EPSN
 #endif//EPSN
 #define EPSN	  (0.000001f) // (1e-6)	// desired float precision
-
-#ifndef NULL
-#define NULL 0
-#endif
 
 typedef bool bool_t;
 typedef int32_t BOOL_T;

--- a/codec/processing/src/common/typedef.h
+++ b/codec/processing/src/common/typedef.h
@@ -50,9 +50,8 @@
 #define WELSVP_NAMESPACE_BEGIN      namespace nsWelsVP {
 #define WELSVP_NAMESPACE_END        }
 
-#ifdef _MSC_VER
 #include <stddef.h>
-#else
+#ifndef _MSC_VER
 #include <stdint.h>
 #endif
 
@@ -80,10 +79,6 @@ typedef bool    bool_t   ;
 #if defined(_WIN32) || defined(_MACH_PLATFORM) || defined(__GNUC__)
 typedef float   float_t  ;
 typedef double  double_t ;
-#endif
-
-#ifndef NULL
-#define NULL    0
 #endif
 
 enum {


### PR DESCRIPTION
No actual (supported) compiler lacks a definition for NULL, and it
is mandated to be present in stddef.h according to the C89 standard.
