### PR TITLE
Add a "make install" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CFLAGS_M32=-m32
 CFLAGS_M64=-m64
 BUILDTYPE=Release
 V=Yes
+PREFIX=/usr/local
 
 ifeq (, $(ENABLE64BIT))
 ifeq ($(ARCH), x86_64)
@@ -136,6 +137,11 @@ $(LIBPREFIX)wels.$(LIBSUFFIX): $(ENCODER_OBJS) $(DECODER_OBJS) $(PROCESSING_OBJS
 	rm -f $@
 	$(AR) $(AR_OPTS) $+
 
+install: $(LIBPREFIX)wels.$(LIBSUFFIX)
+	mkdir -p $(PREFIX)/lib
+	mkdir -p $(PREFIX)/include/wels
+	install -m 644 $(LIBPREFIX)wels.$(LIBSUFFIX) $(PREFIX)/lib
+	install -m 644 codec/api/svc/codec*.h $(PREFIX)/include/wels
 
 ifeq ($(HAVE_GTEST),Yes)
 include build/gtest-targets.mk


### PR DESCRIPTION
This installs the headers into $PREFIX/include/wels and the library into $PREFIX/lib/libwels.a. This simplifies using the library from other code bases, giving it a canonical name and header namespace/directory.

Is this the desired name for the library? Will the upcoming blessed binaries be named libwels\* or something with OpenH264 in the name?
