### PR TITLE
Consistently use inline instead of __inline

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -63,7 +63,7 @@ extern const uint8_t   g_kuiTemporalIdListTable[MAX_TEMPORAL_LEVEL][MAX_GOP_SIZE
 * \param	upper	input upper value
 * \return	2 based scaling factor
 */
-static __inline uint32_t GetLogFactor (real32_t base, real32_t upper) {
+static inline uint32_t GetLogFactor (real32_t base, real32_t upper) {
 const double dLog2factor	= log10 (1.0 * upper / base) / log10 (2.0);
 const double dEpsilon		= 0.0001;
 const double dRound		= floor (dLog2factor + 0.5);


### PR DESCRIPTION
This seemed to have been missed in 109fecc.
