### PR TITLE
Include stdbool.h in the public interface headers in C mode

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -33,6 +33,10 @@
 #ifndef WELS_VIDEO_CODEC_SVC_API_H__
 #define WELS_VIDEO_CODEC_SVC_API_H__
 
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
 #include "codec_app_def.h"
 #include "codec_def.h"
 


### PR DESCRIPTION
This avoids requiring the callers to explicitly include it before
including codec_api.h
