### PR TITLE
Take the missed WelsDecoderI4x4LumaPredH_sse2 function into use

### DIFF
--- a/codec/decoder/core/inc/get_intra_predictor.h
+++ b/codec/decoder/core/inc/get_intra_predictor.h
@@ -98,6 +98,7 @@ void_t WelsDecoderIChromaPredDcNA_mmx (uint8_t* pPred, const int32_t kiStride);
 
 
 
+void_t WelsDecoderI4x4LumaPredH_sse2(uint8_t *pPred, const int32_t kiStride);
 void_t WelsDecoderI4x4LumaPredDDR_mmx (uint8_t* pPred, const int32_t kiStride);
 void_t WelsDecoderI4x4LumaPredHD_mmx (uint8_t* pPred, const int32_t kiStride);
 void_t WelsDecoderI4x4LumaPredHU_mmx (uint8_t* pPred, const int32_t kiStride);

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -723,6 +723,7 @@ void_t AssignFuncPointerForRec (PWelsDecoderContext pCtx) {
     pCtx->pGetIChromaPredFunc[C_PRED_P ]      = WelsDecoderIChromaPredPlane_sse2;
     pCtx->pGetIChromaPredFunc[C_PRED_DC]      = WelsDecoderIChromaPredDc_sse2;
     pCtx->pGetIChromaPredFunc[C_PRED_DC_T]    = WelsDecoderIChromaPredDcTop_sse2;
+    pCtx->pGetI4x4LumaPredFunc[I4_PRED_H]     = WelsDecoderI4x4LumaPredH_sse2;
   }
 #endif
   DeblockingInit (&pCtx->sDeblockingFunc, pCtx->uiCpuFlag);


### PR DESCRIPTION
Previously this function was never used.

Tested on both OS X and win64.
