### PR TITLE
Remove stub interfaces for hw decoding

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -97,13 +97,10 @@ typedef enum {
   DECODER_OPTION_END_OF_STREAM,	/* Indicate bitstream of the final frame to be decoded */
   DECODER_OPTION_VCL_NAL,        //feedback whether or not have VCL NAL in current AU for application layer
   DECODER_OPTION_TEMPORAL_ID,      //feedback temporal id for application layer
-  DECODER_OPTION_MODE,             // indicates the decoding mode
-  DECODER_OPTION_OUTPUT_PROPERTY,
   DECODER_OPTION_FRAME_NUM,	//feedback current decoded frame number
   DECODER_OPTION_IDR_PIC_ID,	// feedback current frame belong to which IDR period
   DECODER_OPTION_LTR_MARKING_FLAG,	// feedback wether current frame mark a LTR
   DECODER_OPTION_LTR_MARKED_FRAME_NUM,	// feedback frame num marked by current Frame
-  DECODER_OPTION_DEVICE_INFO,
 
 } DECODER_OPTION;
 typedef enum { //feedback that whether or not have VCL NAL in current AU

--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -160,32 +160,6 @@ typedef struct {
   int iSkipFrameStep;	//how many frames to skip
 } SRateThresholds, *PRateThresholds;
 
-/*new interface*/
-typedef struct WelsDeviceInfo {
-  int  bSupport;          /* a logic flag provided by decoder which indicates whether GPU decoder can work based on the following device info. */
-  char Vendor[128];   // vendor name
-  char Device[128];    // device name
-  char Driver[128];     // driver version
-  char DriverDate[128]; //  driver release date
-} Device_Info;
-
-typedef enum TagBufferProperty {
-  BUFFER_HOST	   = 0,   // host memory
-  BUFFER_DEVICE  = 1,	  // device memory including surface and shared handle
-  // for DXVA: shared handle
-  // for VDA : iosurface
-
-  //SURFACE_DEVICE ,	 // surface
-  //SHARED_HANDLE      // shared handle
-} EBufferProperty;
-
-typedef enum TagDecodeMode {
-  AUTO_MODE = 0,   // decided by decoder itself, dynamic mode switch, delayed switch
-  SW_MODE = 1,		// decoded by CPU, instant switch
-  GPU_MODE = 2,	// decoded by GPU, instant switch
-  SWITCH_MODE = 3	// switch to the other mode, forced mode switch, delayed switch
-} EDecodeMode;
-
 typedef struct TagSysMemBuffer {
   int	iWidth;			//width of decoded pic for display
   int iHeight;			//height of decoded pic for display
@@ -193,24 +167,10 @@ typedef struct TagSysMemBuffer {
   int iStride[2];		//stride of 2 component
 } SSysMEMBuffer;
 
-typedef struct TagVideoMemBuffer {
-  int iSurfaceWidth;   // used for surface create
-  int iSurfaceHeight;
-  int D3Dformat;  //type is "D3DFORMAT"
-  int D3DPool; // type is "D3DPOOL";
-  int iLeftTopX;
-  int iLeftTopY;
-  int iRightBottomX;
-  int iRightBottomY;
-} SVideoMemBuffer;
-
 typedef struct TagBufferInfo {
-  EBufferProperty eBufferProperty;	//0: host memory; 1: device memory;
   int iBufferStatus;  // 0: one frame data is not ready; 1: one frame data is ready
-  EDecodeMode eWorkMode;				//indicate what the real working mode in decoder
   union {
     SSysMEMBuffer sSystemBuffer;
-    SVideoMemBuffer sVideoBuffer;
   } UsrData;
 } SBufferInfo;
 

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -81,9 +81,6 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
   int32_t iColorFormat = videoFormatInternal;
   static int32_t iFrameNum = 0;
 
-  EDecodeMode     eDecoderMode    = SW_MODE;
-  EBufferProperty	eOutputProperty = BUFFER_DEVICE;
-
   CUtils cOutputModule;
   double dElapsed = 0;
 
@@ -150,16 +147,6 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
     goto label_exit;
   }
 
-  if (pDecoder->SetOption (DECODER_OPTION_MODE,  &eDecoderMode)) {
-    fprintf (stderr, "SetOption() failed, opt_id : %d  ..\n", DECODER_OPTION_MODE);
-    goto label_exit;
-  }
-
-  // set the output buffer property
-  if (pYuvFile) {
-    pDecoder->SetOption (DECODER_OPTION_OUTPUT_PROPERTY,  &eOutputProperty);
-  }
-
 #if defined ( STICK_STREAM_SIZE )
   FILE* fpTrack = fopen ("3.len", "rb");
 
@@ -205,10 +192,6 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
     pDecoder->GetOption (DECODER_OPTION_VCL_NAL, &iFeedbackVclNalInAu);
     int32_t iFeedbackTidInAu;
     pDecoder->GetOption (DECODER_OPTION_TEMPORAL_ID, &iFeedbackTidInAu);
-    int32_t iSetMode;
-    pDecoder->GetOption (DECODER_OPTION_MODE, &iSetMode);
-    int32_t iDeviceInfo;
-    pDecoder->GetOption (DECODER_OPTION_DEVICE_INFO, &iDeviceInfo);
 //~end for
 
     iStart = WelsTime();
@@ -229,13 +212,8 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
     if (sDstBufInfo.iBufferStatus == 1) {
       iFrameNum++;
       cOutputModule.Process ((void**)pDst, &sDstBufInfo, pYuvFile);
-      if (sDstBufInfo.eBufferProperty == BUFFER_HOST) {
-        iWidth  = sDstBufInfo.UsrData.sSystemBuffer.iWidth;
-        iHeight = sDstBufInfo.UsrData.sSystemBuffer.iHeight;
-      } else {
-        iWidth  = sDstBufInfo.UsrData.sVideoBuffer.iSurfaceWidth;
-        iHeight = sDstBufInfo.UsrData.sVideoBuffer.iSurfaceHeight;
-      }
+      iWidth  = sDstBufInfo.UsrData.sSystemBuffer.iWidth;
+      iHeight = sDstBufInfo.UsrData.sSystemBuffer.iHeight;
 
       if (pOptionFile != NULL) {
         if (iWidth != iLastWidth && iHeight != iLastHeight) {
@@ -268,13 +246,8 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
 
   if (sDstBufInfo.iBufferStatus == 1) {
     cOutputModule.Process ((void**)pDst, &sDstBufInfo, pYuvFile);
-    if (sDstBufInfo.eBufferProperty == BUFFER_HOST) {
-      iWidth  = sDstBufInfo.UsrData.sSystemBuffer.iWidth;
-      iHeight = sDstBufInfo.UsrData.sSystemBuffer.iHeight;
-    } else {
-      iWidth  = sDstBufInfo.UsrData.sVideoBuffer.iSurfaceWidth;
-      iHeight = sDstBufInfo.UsrData.sVideoBuffer.iSurfaceHeight;
-    }
+    iWidth  = sDstBufInfo.UsrData.sSystemBuffer.iWidth;
+    iHeight = sDstBufInfo.UsrData.sSystemBuffer.iHeight;
 
     if (pOptionFile != NULL) {
       /* Anyway, we need write in case of final frame decoding */

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -173,10 +173,6 @@ typedef struct TagWelsDecoderContext {
   // Configuration
   SDecodingParam*    	pParam;
   uint32_t			uiCpuFlag;			// CPU compatibility detected
-  int32_t 	   		iDecoderMode;		// indicate decoder running mode
-  int32_t				iSetMode;			// indicate decoder mode set from upper layer, this is read-only for decoder internal
-  int32_t 			iDecoderOutputProperty; // indicate the output buffer property
-  int32_t				iModeSwitchType;	// 1: optimal decision; 2: forced switch to the other mode; 0: no switch
 
   int32_t				iOutputColorFormat;		// color space format to be outputed
   VIDEO_BITSTREAM_TYPE eVideoType; //indicate the type of video to decide whether or not to do qp_delta error detection.

--- a/codec/decoder/core/inc/utils.h
+++ b/codec/decoder/core/inc/utils.h
@@ -64,8 +64,6 @@ extern void WelsLog (void* pPtr, int32_t iLevel, const char* kpFmt, ...) __attri
 extern void WelsLog (void* pPtr, int32_t iLevel, const char* kpFmt, ...);
 #endif
 
-#define DECODER_MODE_NAME(a) ((a == SW_MODE)?"SW_MODE":((a == GPU_MODE)?"GPU_MODE":((a == AUTO_MODE)?"AUTO_MODE":"SWITCH_MODE")))
-#define OUTPUT_PROPERTY_NAME(a) ((a == 0)?"system_memory":"video_memory")
 #define BUFFER_STATUS_NAME(a) ((a == 0)?"unvalid":"valid")
 
 

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -402,12 +402,6 @@ int32_t WelsInitDecoder (PWelsDecoderContext pCtx, void* pTraceHandle, PWelsLogC
   // open decoder
   WelsOpenDecoder (pCtx);
 
-  // decode mode setting
-  pCtx->iDecoderMode = SW_MODE;
-  pCtx->iSetMode = AUTO_MODE;
-  pCtx->iDecoderOutputProperty = BUFFER_HOST;
-  pCtx->iModeSwitchType = 0; // 0: do not do mode switch
-
 
   return ERR_NONE;
 }

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -76,9 +76,6 @@ static inline int32_t DecodeFrameConstruction (PWelsDecoderContext pCtx, uint8_t
              "DecodeFrameConstruction()::::output good I frame, %d x %d, crop_left:%d, crop_right:%d, crop_top:%d, crop_bottom:%d.\n",
              kiWidth, kiHeight, pCtx->sFrameCrop.iLeftOffset, pCtx->sFrameCrop.iRightOffset, pCtx->sFrameCrop.iTopOffset,
              pCtx->sFrameCrop.iBottomOffset);
-    WelsLog (pCtx, WELS_LOG_INFO, "After decoding, set_mode:[%s], eWorkMode:[%s], eBufferProperty:[%s]\n",
-             DECODER_MODE_NAME (pCtx->iSetMode), DECODER_MODE_NAME (pCtx->iDecoderMode),
-             OUTPUT_PROPERTY_NAME (pDstInfo->eBufferProperty));
   }
 
   //////output:::normal path
@@ -99,7 +96,6 @@ static inline int32_t DecodeFrameConstruction (PWelsDecoderContext pCtx, uint8_t
   ppDst[0] = ppDst[0] + pCtx->sFrameCrop.iTopOffset * 2 * pPic->iLinesize[0] + pCtx->sFrameCrop.iLeftOffset * 2;
   ppDst[1] = ppDst[1] + pCtx->sFrameCrop.iTopOffset  * pPic->iLinesize[1] + pCtx->sFrameCrop.iLeftOffset;
   ppDst[2] = ppDst[2] + pCtx->sFrameCrop.iTopOffset  * pPic->iLinesize[1] + pCtx->sFrameCrop.iLeftOffset;
-  pDstInfo->eBufferProperty = BUFFER_HOST;
   pDstInfo->iBufferStatus = 1;
 
   return 0;
@@ -935,7 +931,6 @@ int32_t InitialDqLayersContext (PWelsDecoderContext pCtx, const int32_t kiMaxWid
       return ERR_INFO_OUT_OF_MEMORY;
 
     memset (pDq, 0, sizeof (SDqLayer));
-    if (pCtx->iDecoderMode == SW_MODE) {
 
       do {
         const int32_t kiHshift	= iPlaneIdx ? 1 : 0;
@@ -1015,7 +1010,6 @@ int32_t InitialDqLayersContext (PWelsDecoderContext pCtx, const int32_t kiMaxWid
                               (NULL == pCtx->sMb.pInterPredictionDoneFlag[i])
                              )
                             )
-    } // end of if(pCtx->iDecoderMode == SW_MODE)
 
     pCtx->pDqLayersList[i] = pDq;
     ++ i;
@@ -1579,8 +1573,6 @@ int32_t ConstructAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBufferI
     }
   }
 
-
-  pDstInfo->eBufferProperty = (EBufferProperty)pCtx->iDecoderOutputProperty;
 
   iErr = DecodeCurrentAccessUnit (pCtx, ppDst, iStride, &iWidth, &iHeight, pDstInfo);
 

--- a/codec/decoder/core/src/pic_queue.cpp
+++ b/codec/decoder/core/src/pic_queue.cpp
@@ -81,7 +81,6 @@ PPicture AllocPicture (PWelsDecoderContext pCtx, const int32_t kiPicWidth, const
 
   iLumaSize	= iPicWidth * iPicHeight;
   iChromaSize	= iPicChromaWidth * iPicChromaHeight;
-  if (pCtx->iDecoderMode == SW_MODE) {
     pPic->pBuffer[0]	= static_cast<uint8_t*> (WelsMalloc (iLumaSize /* luma */
                         + (iChromaSize << 1) /* Cb,Cr */, "_pic->buffer[0]"));
 
@@ -93,7 +92,6 @@ PPicture AllocPicture (PWelsDecoderContext pCtx, const int32_t kiPicWidth, const
     pPic->pData[0]	= pPic->pBuffer[0] + (1 + pPic->iLinesize[0]) * PADDING_LENGTH;
     pPic->pData[1]	= pPic->pBuffer[1] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[1]) * PADDING_LENGTH) >> 1);
     pPic->pData[2]	= pPic->pBuffer[2] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[2]) * PADDING_LENGTH) >> 1);
-  }
 
 
 


### PR DESCRIPTION
There is no implementation available for actually doing decoding in HW.

Or are there plans to bring in support for HW decoding APIs on desktop platforms, to actually take these interfaces into use?
