### PR TITLE
use forward declaration to replace type cast

### DIFF
--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -52,6 +52,8 @@
 
 namespace WelsSVCEnc {
 
+typedef struct TagWelsEncCtx sWelsEncCtx;
+
 typedef  struct {
   SPicture*	pScaledInputPicture;
   int32_t		iScaledWidth[MAX_DEPENDENCY_LAYER];
@@ -85,11 +87,11 @@ typedef struct {
 
 class CWelsLib {
  public:
-  CWelsLib (void* pEncCtx);
+  CWelsLib (sWelsEncCtx* pEncCtx);
   virtual  ~CWelsLib();
 
-  int32_t CreateIface (void** pEncCtx);
-  int32_t DestroyIface (void* pEncCtx);
+  int32_t CreateIface (IWelsVP** ppInterfaceVp);
+  int32_t DestroyIface (IWelsVP* pInterfaceVp);
 
  protected:
   void* QueryFunction (const char* pName);
@@ -101,22 +103,22 @@ class CWelsLib {
 
 class CWelsPreProcess {
  public:
-  CWelsPreProcess (void* pEncCtx);
+  CWelsPreProcess (sWelsEncCtx* pEncCtx);
   virtual  ~CWelsPreProcess();
 
  public:
-  int32_t WelsPreprocessReset (void* pEncCtx);
-  int32_t WelsPreprocessStep1 (void* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiConfiguredLayerNum);
-  int32_t WelsPreprocessStep3 (void* pEncCtx, const int32_t kiDIdx);
+  int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx);
+  int32_t WelsPreprocessStep1 (sWelsEncCtx* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiConfiguredLayerNum);
+  int32_t WelsPreprocessStep3 (sWelsEncCtx* pEncCtx, const int32_t kiDIdx);
 
  private:
   int32_t WelsPreprocessCreate();
   int32_t WelsPreprocessDestroy();
-  int32_t InitLastSpatialPictures (void* pEncCtx);
+  int32_t InitLastSpatialPictures (sWelsEncCtx* pEncCtx);
 
  private:
-  int32_t SingleLayerPreprocess (void* pEncCtx, const SSourcePicture* kpSrc, Scaled_Picture* m_sScaledPicture);
-  int32_t MultiLayerPreprocess (void* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiSpatialNum);
+  int32_t SingleLayerPreprocess (sWelsEncCtx* pEncCtx, const SSourcePicture* kpSrc, Scaled_Picture* m_sScaledPicture);
+  int32_t MultiLayerPreprocess (sWelsEncCtx* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiSpatialNum);
 
   void	BilateralDenoising (SPicture* pSrc, const int32_t iWidth, const int32_t iHeight);
   bool  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture);
@@ -127,11 +129,11 @@ class CWelsPreProcess {
                           bool bCalculateVar, bool bCalculateBGD);
   void    BackgroundDetection (SVAAFrameInfo* pVaaInfo, SPicture* pCurPicture, SPicture* pRefPicture, bool bDetectFlag);
   void    AdaptiveQuantCalculation (SVAAFrameInfo* pVaaInfo, SPicture* pCurPicture, SPicture* pRefPicture);
-  void    AnalyzePictureComplexity (void* pCtx, SPicture* pCurPicture, SPicture* pRefPicture,
+  void    AnalyzePictureComplexity (sWelsEncCtx* pCtx, SPicture* pCurPicture, SPicture* pRefPicture,
                                     const int32_t kiDependencyId, const bool kbCalculateBGD);
   void    Padding (uint8_t* pSrcY, uint8_t* pSrcU, uint8_t* pSrcV, int32_t iStrideY, int32_t iStrideUV,
                    int32_t iActualWidth, int32_t iPaddingWidth, int32_t iActualHeight, int32_t iPaddingHeight);
-  void    SetRefMbType (void* pCtx, uint32_t** pRefMbTypeArray, int32_t iRefPicType);
+  void    SetRefMbType (sWelsEncCtx* pCtx, uint32_t** pRefMbTypeArray, int32_t iRefPicType);
 
   int32_t ColorspaceConvert (SWelsSvcCodingParam* pSvcParam, SPicture* pDstPic, const SSourcePicture* kpSrc,
                              const int32_t kiWidth, const int32_t kiHeight);
@@ -139,13 +141,13 @@ class CWelsPreProcess {
                               const int32_t kiWidth, const int32_t kiHeight);
 
  private:
-  Scaled_Picture  m_sScaledPicture;
-  SPicture*		m_pLastSpatialPicture[MAX_DEPENDENCY_LAYER][2];
+  Scaled_Picture   m_sScaledPicture;
+  SPicture*	   m_pLastSpatialPicture[MAX_DEPENDENCY_LAYER][2];
   IWelsVP*         m_pInterfaceVp;
   CWelsLib*        m_pEncLib;
-  void*            m_pEncCtx;
-  bool          m_bInitDone;
-  bool          m_bOfficialBranch;
+  sWelsEncCtx*     m_pEncCtx;
+  bool             m_bInitDone;
+  bool             m_bOfficialBranch;
 };
 
 }

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2123,7 +2123,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
 
   WelsRcInitModule (pCtx,  pCtx->pSvcParam->bEnableRc ? WELS_RC_GOM : WELS_RC_DISABLE);
 
-  pCtx->pVpp = new CWelsPreProcess ((void*)pCtx);
+  pCtx->pVpp = new CWelsPreProcess (pCtx);
   if (pCtx->pVpp == NULL) {
     WelsLog (pCtx, WELS_LOG_ERROR, "WelsInitEncoderExt(), pOut of memory in case new CWelsPreProcess().\n");
     FreeMemorySvc (&pCtx);

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -81,7 +81,7 @@ inline  void   WelsUpdateSpatialIdxMap (sWelsEncCtx* pEncCtx, int32_t iPos, SPic
 
 
 //***************************************************************************************************//
-CWelsLib::CWelsLib (void* pEncCtx) {
+CWelsLib::CWelsLib (sWelsEncCtx* pEncCtx) {
   m_pInterface[0] = m_pInterface[1] = NULL;
 
 #ifndef NO_DYNAMIC_VP
@@ -156,7 +156,8 @@ void* CWelsLib::QueryFunction (const char* pName) {
   return pFunc;
 }
 
-int32_t CWelsLib::CreateIface (void** ppEncCtx) {
+int32_t CWelsLib::CreateIface (IWelsVP** ppInterfaceVp) {
+  *ppInterfaceVp = NULL;
 #ifndef NO_DYNAMIC_VP
   if (m_pVpLib) {
 
@@ -177,20 +178,20 @@ int32_t CWelsLib::CreateIface (void** ppEncCtx) {
     m_pInterface[1] = (void*)pDestroyVpInterface;
 
     if (m_pInterface[0] && m_pInterface[1])
-      pCreateVpInterface (ppEncCtx, WELSVP_INTERFACE_VERION);
+      pCreateVpInterface ((void**)ppInterfaceVp, WELSVP_INTERFACE_VERION);
 #ifndef NO_DYNAMIC_VP
   } else {
   }
 #endif
 
-  return ppEncCtx ? 0 : 1;
+  return (*ppInterfaceVp) ? 0 : 1;
 }
 
-int32_t CWelsLib::DestroyIface (void* pEncCtx) {
-  if (pEncCtx) {
+int32_t CWelsLib::DestroyIface (IWelsVP* pInterfaceVp) {
+  if (pInterfaceVp) {
     pfnDestroyVpInterface pDestroyVpInterface = (pfnDestroyVpInterface) m_pInterface[1];
     if (pDestroyVpInterface) {
-      pDestroyVpInterface (pEncCtx, WELSVP_INTERFACE_VERION);
+      pDestroyVpInterface (pInterfaceVp, WELSVP_INTERFACE_VERION);
     } else {
     }
   }
@@ -204,7 +205,7 @@ int32_t CWelsLib::DestroyIface (void* pEncCtx) {
 *
 ***************************************************************************/
 
-CWelsPreProcess::CWelsPreProcess (void* pEncCtx) {
+CWelsPreProcess::CWelsPreProcess (sWelsEncCtx* pEncCtx) {
   m_pInterfaceVp = NULL;
   m_pEncLib = NULL;
   m_bInitDone = false;
@@ -214,7 +215,7 @@ CWelsPreProcess::CWelsPreProcess (void* pEncCtx) {
 }
 
 CWelsPreProcess::~CWelsPreProcess() {
-  FreeScaledPic (&m_sScaledPicture, static_cast<sWelsEncCtx*> (m_pEncCtx)->pMemAlign);
+  FreeScaledPic (&m_sScaledPicture,  m_pEncCtx->pMemAlign);
   WelsPreprocessDestroy();
 }
 
@@ -224,7 +225,7 @@ int32_t CWelsPreProcess::WelsPreprocessCreate() {
     if (!m_pEncLib)
       goto exit;
 
-    m_pEncLib->CreateIface ((void**)&m_pInterfaceVp);
+    m_pEncLib->CreateIface (&m_pInterfaceVp);
     if (!m_pInterfaceVp)
       goto exit;
   } else
@@ -239,7 +240,7 @@ exit:
 
 int32_t CWelsPreProcess::WelsPreprocessDestroy() {
   if (m_pEncLib) {
-    m_pEncLib->DestroyIface ((void*)m_pInterfaceVp);
+    m_pEncLib->DestroyIface (m_pInterfaceVp);
     m_pInterfaceVp = NULL;
     WelsSafeDelete (m_pEncLib);
   }
@@ -247,30 +248,28 @@ int32_t CWelsPreProcess::WelsPreprocessDestroy() {
   return 0;
 }
 
-int32_t CWelsPreProcess::WelsPreprocessReset (void* pCtx) {
-  sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
+int32_t CWelsPreProcess::WelsPreprocessReset (sWelsEncCtx* pCtx) {
   int32_t iRet = -1;
 
-  if (pEncCtx) {
-    FreeScaledPic (&m_sScaledPicture, pEncCtx->pMemAlign);
-    iRet = InitLastSpatialPictures (pEncCtx);
-    iRet = WelsInitScaledPic (pEncCtx->pSvcParam, &m_sScaledPicture, pEncCtx->pMemAlign);
+  if (pCtx) {
+    FreeScaledPic (&m_sScaledPicture, pCtx->pMemAlign);
+    iRet = InitLastSpatialPictures (pCtx);
+    iRet = WelsInitScaledPic (pCtx->pSvcParam, &m_sScaledPicture, pCtx->pMemAlign);
   }
 
   return iRet;
 }
 
-int32_t CWelsPreProcess::WelsPreprocessStep1 (void* pCtx, const SSourcePicture** kppSrcPicList,
+int32_t CWelsPreProcess::WelsPreprocessStep1 (sWelsEncCtx* pCtx, const SSourcePicture** kppSrcPicList,
     const int32_t kiConfiguredLayerNum) {
-  sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pSvcParam = pEncCtx->pSvcParam;
+  SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
   int32_t	iNumDependencyLayer = (int32_t)pSvcParam->iNumDependencyLayer;
   int32_t iSpatialNum = 0;
 
   if (!m_bInitDone) {
     if (WelsPreprocessCreate() != 0)
       return -1;
-    if (WelsPreprocessReset (pEncCtx) != 0)
+    if (WelsPreprocessReset (pCtx) != 0)
       return -1;
 
     m_bOfficialBranch  = (iNumDependencyLayer != kiConfiguredLayerNum);
@@ -295,57 +294,56 @@ int32_t CWelsPreProcess::WelsPreprocessStep1 (void* pCtx, const SSourcePicture**
   if (kiConfiguredLayerNum <= 0)
     return -1;
 
-  pEncCtx->pVaa->bSceneChangeFlag = pEncCtx->pVaa->bIdrPeriodFlag = false;
+  pCtx->pVaa->bSceneChangeFlag = pCtx->pVaa->bIdrPeriodFlag = false;
   if (pSvcParam->uiIntraPeriod)
-    pEncCtx->pVaa->bIdrPeriodFlag = (1 + pEncCtx->iFrameIndex >= (int32_t)pSvcParam->uiIntraPeriod) ? true : false;
+    pCtx->pVaa->bIdrPeriodFlag = (1 + pCtx->iFrameIndex >= (int32_t)pSvcParam->uiIntraPeriod) ? true : false;
 
   if (m_bOfficialBranch) {	// Perform Down Sampling potentially due to application
     assert (kiConfiguredLayerNum == 1);
-    iSpatialNum	= SingleLayerPreprocess (pEncCtx, kppSrcPicList[0], &m_sScaledPicture);
+    iSpatialNum	= SingleLayerPreprocess (pCtx, kppSrcPicList[0], &m_sScaledPicture);
   } else { // for console each spatial pictures are available there
     iSpatialNum	= kiConfiguredLayerNum;
-    MultiLayerPreprocess (pEncCtx, kppSrcPicList, iSpatialNum);
+    MultiLayerPreprocess (pCtx, kppSrcPicList, iSpatialNum);
   }
 
   return iSpatialNum;
 }
 
-int32_t CWelsPreProcess::WelsPreprocessStep3 (void* pCtx, const int32_t kiDidx) {
-  sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pSvcParam = pEncCtx->pSvcParam;
-  bool bNeededMbAq = (pSvcParam->bEnableAdaptiveQuant && (pEncCtx->eSliceType == P_SLICE));
-  bool bCalculateBGD = (pEncCtx->eSliceType == P_SLICE && pSvcParam->bEnableBackgroundDetection);
+int32_t CWelsPreProcess::WelsPreprocessStep3 (sWelsEncCtx* pCtx, const int32_t kiDidx) {
+  SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
+  bool bNeededMbAq = (pSvcParam->bEnableAdaptiveQuant && (pCtx->eSliceType == P_SLICE));
+  bool bCalculateBGD = (pCtx->eSliceType == P_SLICE && pSvcParam->bEnableBackgroundDetection);
 
-  int32_t iCurTemporalIdx  = pEncCtx->uiSpatialLayersInTemporal[kiDidx] - 1;
+  int32_t iCurTemporalIdx  = pCtx->uiSpatialLayersInTemporal[kiDidx] - 1;
 
-  int32_t iRefTemporalIdx = (int32_t)g_kuiRefTemporalIdx[pSvcParam->iDecompStages][pEncCtx->iCodingIndex &
+  int32_t iRefTemporalIdx = (int32_t)g_kuiRefTemporalIdx[pSvcParam->iDecompStages][pCtx->iCodingIndex &
                             (pSvcParam->uiGopSize - 1)];
-  if (pEncCtx->uiTemporalId == 0 && pEncCtx->pLtr[pEncCtx->uiDependencyId].bReceivedT0LostFlag)
-    iRefTemporalIdx = pEncCtx->uiSpatialLayersInTemporal[kiDidx] + pEncCtx->pVaa->uiValidLongTermPicIdx;
+  if (pCtx->uiTemporalId == 0 && pCtx->pLtr[pCtx->uiDependencyId].bReceivedT0LostFlag)
+    iRefTemporalIdx = pCtx->uiSpatialLayersInTemporal[kiDidx] + pCtx->pVaa->uiValidLongTermPicIdx;
 
-  SPicture* pCurPic = pEncCtx->pSpatialPic[kiDidx][iCurTemporalIdx];
-  SPicture* pRefPic = pEncCtx->pSpatialPic[kiDidx][iRefTemporalIdx];
+  SPicture* pCurPic = pCtx->pSpatialPic[kiDidx][iCurTemporalIdx];
+  SPicture* pRefPic = pCtx->pSpatialPic[kiDidx][iRefTemporalIdx];
   {
     SPicture* pLastPic = m_pLastSpatialPicture[kiDidx][0];
     bool bCalculateSQDiff = ((pLastPic->pData[0] == pRefPic->pData[0]) && bNeededMbAq);
-    bool bCalculateVar = (pSvcParam->iRCMode == RC_MODE1 && pEncCtx->eSliceType == I_SLICE);
+    bool bCalculateVar = (pSvcParam->iRCMode == RC_MODE1 && pCtx->eSliceType == I_SLICE);
 
-    VaaCalculation (pEncCtx->pVaa, pCurPic, pRefPic, bCalculateSQDiff, bCalculateVar, bCalculateBGD);
+    VaaCalculation (pCtx->pVaa, pCurPic, pRefPic, bCalculateSQDiff, bCalculateVar, bCalculateBGD);
   }
 
   if (pSvcParam->bEnableBackgroundDetection) {
-    BackgroundDetection (pEncCtx->pVaa, pCurPic, pRefPic, bCalculateBGD && pRefPic->iPictureType != I_SLICE);
+    BackgroundDetection (pCtx->pVaa, pCurPic, pRefPic, bCalculateBGD && pRefPic->iPictureType != I_SLICE);
   }
 
   if (bNeededMbAq) {
     SPicture* pCurPic = m_pLastSpatialPicture[kiDidx][1];
     SPicture* pRefPic = m_pLastSpatialPicture[kiDidx][0];
 
-    AdaptiveQuantCalculation (pEncCtx->pVaa, pCurPic, pRefPic);
+    AdaptiveQuantCalculation (pCtx->pVaa, pCurPic, pRefPic);
   }
 
   if (pSvcParam->bEnableRc) {
-    AnalyzePictureComplexity (pEncCtx, pCurPic, pRefPic, kiDidx, bCalculateBGD);
+    AnalyzePictureComplexity (pCtx, pCurPic, pRefPic, kiDidx, bCalculateBGD);
   }
 
   WelsExchangeSpatialPictures (&m_pLastSpatialPicture[kiDidx][1], &m_pLastSpatialPicture[kiDidx][0]);
@@ -358,12 +356,11 @@ int32_t CWelsPreProcess::WelsPreprocessStep3 (void* pCtx, const int32_t kiDidx) 
 *	SingleLayerPreprocess: down sampling if applicable
 *  @return:	exact number of spatial layers need to encoder indeed
 */
-int32_t CWelsPreProcess::SingleLayerPreprocess (void* pCtx, const SSourcePicture* kpSrc,
+int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSourcePicture* kpSrc,
     Scaled_Picture* pScaledPicture) {
-  sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pSvcParam    = pEncCtx->pSvcParam;
+  SWelsSvcCodingParam* pSvcParam    = pCtx->pSvcParam;
   int8_t	iDependencyId			= pSvcParam->iNumDependencyLayer - 1;
-  int32_t iPicturePos	                    = pEncCtx->uiSpatialLayersInTemporal[iDependencyId] - 1;
+  int32_t iPicturePos	                    = pCtx->uiSpatialLayersInTemporal[iDependencyId] - 1;
 
   SPicture* pSrcPic					= NULL;	// large
   SPicture* pDstPic					= NULL;	// small
@@ -379,12 +376,12 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (void* pCtx, const SSourcePicture
   pDlayerParam = &pSvcParam->sDependencyLayers[iDependencyId];
   iTargetWidth	  = pDlayerParam->iFrameWidth;
   iTargetHeight  = pDlayerParam->iFrameHeight;
-  iTemporalId    = pDlayerParam->uiCodingIdx2TemporalId[pEncCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)];
+  iTemporalId    = pDlayerParam->uiCodingIdx2TemporalId[pCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)];
   iSrcWidth   = pSvcParam->SUsedPicRect.iWidth;
   iSrcHeight  = pSvcParam->SUsedPicRect.iHeight;
 
   pSrcPic = pScaledPicture->pScaledInputPicture ? pScaledPicture->pScaledInputPicture :
-            pEncCtx->pSpatialPic[iDependencyId][iPicturePos];
+            pCtx->pSpatialPic[iDependencyId][iPicturePos];
 
   WelsMoveMemoryWrapper (pSvcParam, pSrcPic, kpSrc, iSrcWidth, iSrcHeight);
 
@@ -397,36 +394,36 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (void* pCtx, const SSourcePicture
   pDstPic = pSrcPic;
   if (pScaledPicture->pScaledInputPicture) {
     // for highest downsampling
-    pDstPic		= pEncCtx->pSpatialPic[iDependencyId][iPicturePos];
+    pDstPic		= pCtx->pSpatialPic[iDependencyId][iPicturePos];
     iShrinkWidth = pScaledPicture->iScaledWidth[iDependencyId];
     iShrinkHeight = pScaledPicture->iScaledHeight[iDependencyId];
   }
   DownsamplePadding (pSrcPic, pDstPic, iSrcWidth, iSrcHeight, iShrinkWidth, iShrinkHeight, iTargetWidth, iTargetHeight);
 
-  if (pSvcParam->bEnableSceneChangeDetect && !pEncCtx->pVaa->bIdrPeriodFlag
-      && !pEncCtx->bEncCurFrmAsIdrFlag
-      && ! (pEncCtx->iCodingIndex & (pSvcParam->uiGopSize - 1))) {
-    SPicture* pRefPic = pEncCtx->pLtr[iDependencyId].bReceivedT0LostFlag ?
-                        pEncCtx->pSpatialPic[iDependencyId][pEncCtx->uiSpatialLayersInTemporal[iDependencyId] +
-                            pEncCtx->pVaa->uiValidLongTermPicIdx] : m_pLastSpatialPicture[iDependencyId][0];
+  if (pSvcParam->bEnableSceneChangeDetect && !pCtx->pVaa->bIdrPeriodFlag
+      && !pCtx->bEncCurFrmAsIdrFlag
+      && ! (pCtx->iCodingIndex & (pSvcParam->uiGopSize - 1))) {
+    SPicture* pRefPic = pCtx->pLtr[iDependencyId].bReceivedT0LostFlag ?
+                        pCtx->pSpatialPic[iDependencyId][pCtx->uiSpatialLayersInTemporal[iDependencyId] +
+                            pCtx->pVaa->uiValidLongTermPicIdx] : m_pLastSpatialPicture[iDependencyId][0];
 
-    pEncCtx->pVaa->bSceneChangeFlag = DetectSceneChange (pDstPic, pRefPic);
+    pCtx->pVaa->bSceneChangeFlag = DetectSceneChange (pDstPic, pRefPic);
   }
 
   for (int32_t i = 0; i < pSvcParam->iNumDependencyLayer; i++) {
-    if (pSvcParam->sDependencyLayers[i].uiCodingIdx2TemporalId[pEncCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)]
+    if (pSvcParam->sDependencyLayers[i].uiCodingIdx2TemporalId[pCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)]
         != INVALID_TEMPORAL_ID) {
       ++ iActualSpatialLayerNum;
     }
   }
 
   if (iTemporalId != INVALID_TEMPORAL_ID) {
-    WelsUpdateSpatialIdxMap (pEncCtx, iActualSpatialLayerNum - 1, pDstPic, iDependencyId);
+    WelsUpdateSpatialIdxMap (pCtx, iActualSpatialLayerNum - 1, pDstPic, iDependencyId);
     ++ iSpatialNum;
     -- iActualSpatialLayerNum;
   }
 
-  m_pLastSpatialPicture[iDependencyId][1]	= pEncCtx->pSpatialPic[iDependencyId][iPicturePos];
+  m_pLastSpatialPicture[iDependencyId][1]	= pCtx->pSpatialPic[iDependencyId][iPicturePos];
   -- iDependencyId;
 
   // generate other spacial layer
@@ -438,25 +435,25 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (void* pCtx, const SSourcePicture
       pDlayerParam			= &pSvcParam->sDependencyLayers[iDependencyId];
       iTargetWidth	= pDlayerParam->iFrameWidth;
       iTargetHeight	= pDlayerParam->iFrameHeight;
-      iTemporalId = pDlayerParam->uiCodingIdx2TemporalId[pEncCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)];
-      iPicturePos		= pEncCtx->uiSpatialLayersInTemporal[iDependencyId] - 1;
+      iTemporalId = pDlayerParam->uiCodingIdx2TemporalId[pCtx->iCodingIndex & (pSvcParam->uiGopSize - 1)];
+      iPicturePos		= pCtx->uiSpatialLayersInTemporal[iDependencyId] - 1;
 
       // NOT work for CGS, FIXME
       // spatial layer is able to encode indeed
       if ((iTemporalId != INVALID_TEMPORAL_ID)) {
         // down sampling performed
 
-        pDstPic	= pEncCtx->pSpatialPic[iDependencyId][iPicturePos];	// small
+        pDstPic	= pCtx->pSpatialPic[iDependencyId][iPicturePos];	// small
         iShrinkWidth = pScaledPicture->iScaledWidth[iDependencyId];
         iShrinkHeight = pScaledPicture->iScaledHeight[iDependencyId];
         DownsamplePadding (pSrcPic, pDstPic, iSrcWidth, iSrcHeight, iShrinkWidth, iShrinkHeight, iTargetWidth, iTargetHeight);
 
-        WelsUpdateSpatialIdxMap (pEncCtx, iActualSpatialLayerNum - 1, pDstPic, iDependencyId);
+        WelsUpdateSpatialIdxMap (pCtx, iActualSpatialLayerNum - 1, pDstPic, iDependencyId);
 
         -- iActualSpatialLayerNum;
         ++ iSpatialNum;
 
-        m_pLastSpatialPicture[iDependencyId][1]	= pEncCtx->pSpatialPic[iDependencyId][iPicturePos];
+        m_pLastSpatialPicture[iDependencyId][1]	= pCtx->pSpatialPic[iDependencyId][iPicturePos];
       }
       -- iDependencyId;
     }
@@ -465,10 +462,9 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (void* pCtx, const SSourcePicture
   return iSpatialNum;
 }
 
-int32_t CWelsPreProcess::MultiLayerPreprocess (void* pCtx, const SSourcePicture** kppSrcPicList,
+int32_t CWelsPreProcess::MultiLayerPreprocess (sWelsEncCtx* pCtx, const SSourcePicture** kppSrcPicList,
     const int32_t kiSpatialNum) {
-  sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pSvcParam	= pEncCtx->pSvcParam;
+  SWelsSvcCodingParam* pSvcParam	= pCtx->pSvcParam;
   const SSourcePicture* pSrc			= NULL;
   SPicture* pDstPic						= NULL;
   const int32_t iSpatialLayersCfgCount =
@@ -489,9 +485,9 @@ int32_t CWelsPreProcess::MultiLayerPreprocess (void* pCtx, const SSourcePicture*
     } while (j < iSpatialLayersCfgCount);
 
     assert (j < iSpatialLayersCfgCount);
-    pDstPic = pEncCtx->pSpatialPic[j][pEncCtx->uiSpatialLayersInTemporal[j] - 1];
+    pDstPic = pCtx->pSpatialPic[j][pCtx->uiSpatialLayersInTemporal[j] - 1];
 
-    WelsUpdateSpatialIdxMap (pEncCtx, i, pDstPic, j);
+    WelsUpdateSpatialIdxMap (pCtx, i, pDstPic, j);
 
     WelsMoveMemoryWrapper (pSvcParam, pDstPic, pSrc, pSrc->iPicWidth, pSrc->iPicHeight);
 
@@ -503,12 +499,12 @@ int32_t CWelsPreProcess::MultiLayerPreprocess (void* pCtx, const SSourcePicture*
   } while (i < kiSpatialNum);
 
   if (pSvcParam->bEnableSceneChangeDetect && (kiSpatialNum == pSvcParam->iNumDependencyLayer)
-      && !pEncCtx->pVaa->bIdrPeriodFlag && !pEncCtx->bEncCurFrmAsIdrFlag) {
-    SPicture* pRef = pEncCtx->pLtr[0].bReceivedT0LostFlag ?
-                     pEncCtx->pSpatialPic[0][pEncCtx->uiSpatialLayersInTemporal[0] + pEncCtx->pVaa->uiValidLongTermPicIdx] :
+      && !pCtx->pVaa->bIdrPeriodFlag && !pCtx->bEncCurFrmAsIdrFlag) {
+    SPicture* pRef = pCtx->pLtr[0].bReceivedT0LostFlag ?
+                     pCtx->pSpatialPic[0][pCtx->uiSpatialLayersInTemporal[0] + pCtx->pVaa->uiValidLongTermPicIdx] :
                      m_pLastSpatialPicture[0][0];
 
-    pEncCtx->pVaa->bSceneChangeFlag = DetectSceneChange (pDstPic, pRef);
+    pCtx->pVaa->bSceneChangeFlag = DetectSceneChange (pDstPic, pRef);
   }
 
   return 0;
@@ -568,15 +564,14 @@ void  FreeScaledPic (Scaled_Picture*  pScaledPicture, CMemoryAlign* pMemoryAlign
   }
 }
 
-int32_t CWelsPreProcess::InitLastSpatialPictures (void* pCtx) {
-  sWelsEncCtx* pEncCtx         = (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pParam	= pEncCtx->pSvcParam;
+int32_t CWelsPreProcess::InitLastSpatialPictures (sWelsEncCtx* pCtx) {
+  SWelsSvcCodingParam* pParam	= pCtx->pSvcParam;
   const int32_t kiDlayerCount			= pParam->iNumDependencyLayer;
   int32_t iDlayerIndex					= 0;
 
   for (; iDlayerIndex < kiDlayerCount; iDlayerIndex++) {
-    const int32_t kiLayerInTemporal = pEncCtx->uiSpatialLayersInTemporal[iDlayerIndex];
-    m_pLastSpatialPicture[iDlayerIndex][0]	= pEncCtx->pSpatialPic[iDlayerIndex][kiLayerInTemporal - 2];
+    const int32_t kiLayerInTemporal = pCtx->uiSpatialLayersInTemporal[iDlayerIndex];
+    m_pLastSpatialPicture[iDlayerIndex][0]	= pCtx->pSpatialPic[iDlayerIndex][kiLayerInTemporal - 2];
     m_pLastSpatialPicture[iDlayerIndex][1]	= NULL;
   }
   for (; iDlayerIndex < MAX_DEPENDENCY_LAYER; iDlayerIndex++) {
@@ -805,15 +800,14 @@ void CWelsPreProcess::AdaptiveQuantCalculation (SVAAFrameInfo* pVaaInfo, SPictur
   }
 }
 
-void CWelsPreProcess::SetRefMbType (void* pCtx, uint32_t** pRefMbTypeArray, int32_t iRefPicType) {
-  sWelsEncCtx* pEncCtx	    = (sWelsEncCtx*)pCtx;
-  const uint8_t uiTid		    = pEncCtx->uiTemporalId;
-  const uint8_t uiDid          = pEncCtx->uiDependencyId;
-  SRefList* pRefPicLlist				= pEncCtx->ppRefPicListExt[uiDid];
-  SLTRState* pLtr				= &pEncCtx->pLtr[uiDid];
+void CWelsPreProcess::SetRefMbType (sWelsEncCtx* pCtx, uint32_t** pRefMbTypeArray, int32_t iRefPicType) {
+  const uint8_t uiTid	    = pCtx->uiTemporalId;
+  const uint8_t uiDid       = pCtx->uiDependencyId;
+  SRefList* pRefPicLlist    = pCtx->ppRefPicListExt[uiDid];
+  SLTRState* pLtr	    = &pCtx->pLtr[uiDid];
   uint8_t i							= 0;
 
-  if (pEncCtx->pSvcParam->bEnableLongTermReference && pLtr->bReceivedT0LostFlag && uiTid == 0) {
+  if (pCtx->pSvcParam->bEnableLongTermReference && pLtr->bReceivedT0LostFlag && uiTid == 0) {
     for (i = 0; i < pRefPicLlist->uiLongRefCount; i++) {
       SPicture* pRef = pRefPicLlist->pLongRefList[i];
       if (pRef != NULL && pRef->uiRecieveConfirmed == 1/*RECIEVE_SUCCESS*/) {
@@ -833,21 +827,20 @@ void CWelsPreProcess::SetRefMbType (void* pCtx, uint32_t** pRefMbTypeArray, int3
 }
 
 
-void CWelsPreProcess::AnalyzePictureComplexity (void* pCtx, SPicture* pCurPicture, SPicture* pRefPicture,
+void CWelsPreProcess::AnalyzePictureComplexity (sWelsEncCtx* pCtx, SPicture* pCurPicture, SPicture* pRefPicture,
     const int32_t kiDependencyId, const bool bCalculateBGD) {
-  sWelsEncCtx* pEncCtx	= (sWelsEncCtx*)pCtx;
-  SWelsSvcCodingParam* pSvcParam = pEncCtx->pSvcParam;
-  SVAAFrameInfo* pVaaInfo			= pEncCtx->pVaa;
+  SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
+  SVAAFrameInfo* pVaaInfo	 = pCtx->pVaa;
 
   SComplexityAnalysisParam* sComplexityAnalysisParam = & (pVaaInfo->sComplexityAnalysisParam);
-  SWelsSvcRc* SWelsSvcRc = &pEncCtx->pWelsSvcRc[kiDependencyId];
+  SWelsSvcRc* SWelsSvcRc = &pCtx->pWelsSvcRc[kiDependencyId];
   int32_t iComplexityAnalysisMode = 0;
 
-  if (pSvcParam->iRCMode == RC_MODE0 && pEncCtx->eSliceType == P_SLICE) {
+  if (pSvcParam->iRCMode == RC_MODE0 && pCtx->eSliceType == P_SLICE) {
     iComplexityAnalysisMode = FRAME_SAD;
-  } else if (pSvcParam->iRCMode == RC_MODE1 && pEncCtx->eSliceType == P_SLICE) {
+  } else if (pSvcParam->iRCMode == RC_MODE1 && pCtx->eSliceType == P_SLICE) {
     iComplexityAnalysisMode = GOM_SAD;
-  } else if (pSvcParam->iRCMode == RC_MODE1 && pEncCtx->eSliceType == I_SLICE) {
+  } else if (pSvcParam->iRCMode == RC_MODE1 && pCtx->eSliceType == I_SLICE) {
     iComplexityAnalysisMode = GOM_VAR;
   } else {
     return;
@@ -856,7 +849,7 @@ void CWelsPreProcess::AnalyzePictureComplexity (void* pCtx, SPicture* pCurPictur
   sComplexityAnalysisParam->iComplexityAnalysisMode = iComplexityAnalysisMode;
   sComplexityAnalysisParam->pCalcResult = & (pVaaInfo->sVaaCalcInfo);
   sComplexityAnalysisParam->pBackgroundMbFlag = pVaaInfo->pVaaBackgroundMbFlag;
-  SetRefMbType (pEncCtx, & (sComplexityAnalysisParam->uiRefMbType), pRefPicture->iPictureType);
+  SetRefMbType (pCtx, & (sComplexityAnalysisParam->uiRefMbType), pRefPicture->iPictureType);
   sComplexityAnalysisParam->iCalcBgd = bCalculateBGD;
   sComplexityAnalysisParam->iFrameComplexity = 0;
 


### PR DESCRIPTION
Change: 
1.  use forward declaration to replace type casting,  clean related code. 
2.  Potential issue fix:  in function CWelsLib::CreateIface,  it does not make sense to check ppEncCtx when decide to return 0 or 1.  

Review: 
https://rbcommons.com/s/OpenH264/r/81/
