### PR TITLE
give right name to pre-process step1 and step3

### DIFF
--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -108,8 +108,8 @@ class CWelsPreProcess {
 
  public:
   int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx);
-  int32_t WelsPreprocessStep1 (sWelsEncCtx* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiConfiguredLayerNum);
-  int32_t WelsPreprocessStep3 (sWelsEncCtx* pEncCtx, const int32_t kiDIdx);
+  int32_t BuildSpatialPicList (sWelsEncCtx* pEncCtx, const SSourcePicture** kppSrcPicList, const int32_t kiConfiguredLayerNum);
+  int32_t AnalyzeSpatialPic (sWelsEncCtx* pEncCtx, const int32_t kiDIdx);
 
  private:
   int32_t WelsPreprocessCreate();

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3136,7 +3136,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, void* pDst, const SSourcePictur
   pFbi->iLayerNum	= 0;	// for initialization
 
   // perform csc/denoise/downsample/padding, generate spatial layers
-  iSpatialNum = pCtx->pVpp->WelsPreprocessStep1 (pCtx, ppSrcList, iConfiguredLayerNum);
+  iSpatialNum = pCtx->pVpp->BuildSpatialPicList (pCtx, ppSrcList, iConfiguredLayerNum);
   if (iSpatialNum < 1) {	// skip due to temporal layer settings (different frame rate)
     ++ pCtx->iCodingIndex;
     return WELS_FRAME_TYPE_SKIP;
@@ -3184,7 +3184,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, void* pDst, const SSourcePictur
     SDLayerParam* param_d		= &pSvcParam->sDependencyLayers[d_idx];
 
     pCtx->uiDependencyId	= iCurDid = (int8_t)d_idx;
-    pCtx->pVpp->WelsPreprocessStep3 (pCtx, d_idx);
+    pCtx->pVpp->AnalyzeSpatialPic (pCtx, d_idx);
 
     pCtx->pEncPic	 = pEncPic = (pSpatialIndexMap + iSpatialIdx)->pSrc;
     pCtx->pEncPic->iPictureType	= pCtx->eSliceType;

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -260,7 +260,7 @@ int32_t CWelsPreProcess::WelsPreprocessReset (sWelsEncCtx* pCtx) {
   return iRet;
 }
 
-int32_t CWelsPreProcess::WelsPreprocessStep1 (sWelsEncCtx* pCtx, const SSourcePicture** kppSrcPicList,
+int32_t CWelsPreProcess::BuildSpatialPicList (sWelsEncCtx* pCtx, const SSourcePicture** kppSrcPicList,
     const int32_t kiConfiguredLayerNum) {
   SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
   int32_t	iNumDependencyLayer = (int32_t)pSvcParam->iNumDependencyLayer;
@@ -309,7 +309,7 @@ int32_t CWelsPreProcess::WelsPreprocessStep1 (sWelsEncCtx* pCtx, const SSourcePi
   return iSpatialNum;
 }
 
-int32_t CWelsPreProcess::WelsPreprocessStep3 (sWelsEncCtx* pCtx, const int32_t kiDidx) {
+int32_t CWelsPreProcess::AnalyzeSpatialPic (sWelsEncCtx* pCtx, const int32_t kiDidx) {
   SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
   bool bNeededMbAq = (pSvcParam->bEnableAdaptiveQuant && (pCtx->eSliceType == P_SLICE));
   bool bCalculateBGD = (pCtx->eSliceType == P_SLICE && pSvcParam->bEnableBackgroundDetection);


### PR DESCRIPTION
give right name to pre-process step1 and step3.  
   The step1 will do down-sample/padding(if need),  denoise(if on), scene change detect(if on), and it will produce the spatial picture list for encode.  
   The step3 will do VAA calculation,  background detection(if on), adaptive quant calculation(if on), picture complexity analyze(if rc on).   It is helper for the encoder mode decision algorithm.   So rename the step1 and step3 to BuildSpatialPicList and AnalyzeSpatialPic

Review:
https://rbcommons.com/s/OpenH264/r/86/
