### PR TITLE
remove unused temporal ID info in decoder API

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -111,14 +111,6 @@ typedef enum { //feedback that whether or not have VCL NAL in current AU
   FEEDBACK_VCL_NAL,
   FEEDBACK_UNKNOWN_NAL
 } FEEDBACK_VCL_NAL_IN_AU;
-typedef enum { //feedback the iTemporalId in current AU if have VCL NAL
-  FEEDBACK_TEMPORAL_ID_0 = 0,
-  FEEDBACK_TEMPORAL_ID_1,
-  FEEDBACK_TEMPORAL_ID_2,
-  FEEDBACK_TEMPORAL_ID_3,
-  FEEDBACK_TEMPORAL_ID_4,
-  FEEDBACK_UNKNOWN_TEMPORAL_ID
-} FEEDBACK_TEMPORAL_ID;
 
 /* Type of layer being encoded */
 typedef enum {


### PR DESCRIPTION
remove them as they are not used in decoder.
review quest can be seen via:
https://rbcommons.com/s/OpenH264/r/90/
