### PR TITLE
Fix building with MT_DEBUG enabled after the encoder interface update

### DIFF
--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -1459,7 +1459,7 @@ void TrackSliceConsumeTime (sWelsEncCtx* pCtx, int32_t* pDidList, const int32_t 
   while (iSpatialIdx < iSpatialNum) {
     const int32_t kiDid		= pDidList[iSpatialIdx];
     SDLayerParam* pDlp		= &pPara->sDependencyLayers[kiDid];
-    SMulSliceOption* pMso	= &pDlp->sSliceCfg;
+    SSliceConfig* pMso		= &pDlp->sSliceCfg;
     SDqLayer* pCurDq		= pCtx->ppDqLayerList[kiDid];
     SSliceCtx* pSliceCtx = pCurDq->pSliceEncCtx;
     const uint32_t kuiCountSliceNum = pSliceCtx->iSliceNumInFrame;


### PR DESCRIPTION
There is no struct named SMulSliceOption any longer.
