### PR TITLE
use temporal layer num and remove gop size in external configure-- review request #94

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -224,7 +224,6 @@ typedef struct TagEncParamExt:SEncParamBase
   SSpatialLayerConfig sSpatialLayers[MAX_SPATIAL_LAYER_NUM];
   int		    iNumRefFrame;		// number of reference frame used
   unsigned int	uiFrameToBeCoded;	// frame to be encoded (at input frame rate)
-  unsigned int  uiGopSize;
   bool   bEnableRc;
   short		iMultipleThreadIdc;		// 1	# 0: auto(dynamic imp. internal encoder); 1: multiple threads imp. disabled; > 1: count number of threads;
   short		iCountThreadsNum;			//		# derived from disable_multiple_slice_idc (=0 or >1) means;

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -122,8 +122,8 @@ int ParseConfig (CReadConfig& cRdCfg, SEncParamExt& pSvcParam, SFilesSet& sFileS
         pSvcParam.uiFrameToBeCoded	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("SourceSequenceInRGB24") == 0) {
         pSvcParam.iInputCsp	= atoi (strTag[1].c_str()) == 0 ? videoFormatI420 : videoFormatRGB;
-      } else if (strTag[0].compare ("GOPSize") == 0) {
-        pSvcParam.uiGopSize	= atoi (strTag[1].c_str());
+      } else if (strTag[0].compare ("TemporalLayerNum") == 0) {
+        pSvcParam.iTemporalLayerNum	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("IntraPeriod") == 0) {
         pSvcParam.uiIntraPeriod	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("EnableSpsPpsIDAddition") == 0) {
@@ -428,8 +428,8 @@ int ParseCommandLine (int argc, char** argv, SEncParamExt& pSvcParam, SFilesSet&
     else if (!strcmp (pCommand, "-frms") && (n < argc))
       pSvcParam.uiFrameToBeCoded = atoi (argv[n++]);
 
-    else if (!strcmp (pCommand, "-gop") && (n < argc))
-      pSvcParam.uiGopSize = atoi (argv[n++]);
+    else if (!strcmp (pCommand, "-numtl") && (n < argc))
+      pSvcParam.iTemporalLayerNum = atoi (argv[n++]);
 
     else if (!strcmp (pCommand, "-iper") && (n < argc))
       pSvcParam.uiIntraPeriod = atoi (argv[n++]);

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -1838,7 +1838,7 @@ int32_t InitSliceSettings (SWelsSvcCodingParam* pCodingParam, const int32_t kiCp
                               pSlcArg->uiSliceNum; // uiSliceNum per input has been validated at ParamValidationExt()
 #endif//DYNAMIC_SLICE_ASSIGN
 #else//!MT_ENABLED
-    int16_t iSliceNum				= pSlcArg->iSliceNum; // uiSliceNum per input has been validated at ParamValidationExt()
+    int16_t iSliceNum				= pSlcArg->uiSliceNum; // uiSliceNum per input has been validated at ParamValidationExt()
 #endif//MT_ENABLED
 
     // NOTE: Per design, in case MT/DYNAMIC_SLICE_ASSIGN enabled, for SM_FIXEDSLCNUM_SLICE mode,

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -1459,7 +1459,7 @@ void TrackSliceConsumeTime (sWelsEncCtx* pCtx, int32_t* pDidList, const int32_t 
   while (iSpatialIdx < iSpatialNum) {
     const int32_t kiDid		= pDidList[iSpatialIdx];
     SDLayerParam* pDlp		= &pPara->sDependencyLayers[kiDid];
-    SMulSliceOption* pMso	= &pDlp->sSliceCfg;
+    SSliceConfig* pMso		= &pDlp->sSliceCfg;
     SDqLayer* pCurDq		= pCtx->ppDqLayerList[kiDid];
     SSliceCtx* pSliceCtx = pCurDq->pSliceEncCtx;
     const uint32_t kuiCountSliceNum = pSliceCtx->iSliceNumInFrame;

--- a/testbin/welsenc.cfg
+++ b/testbin/welsenc.cfg
@@ -5,7 +5,7 @@ OutputFile              test.264               # Bitstream file
 MaxFrameRate            30                     # Maximum frame rate [Hz]
 FramesToBeEncoded       -1                    # Number of frames (at input frame rate)
 
-GOPSize                 4                     # GOP Size (at maximum frame rate), 16
+TemporalLayerNum       3                     # temporal layer number(1--4)
 IntraPeriod            0                    # Intra Period ( multipler of GoP size or -1)
 EnableSpsPpsIDAddition  1
 


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/94/

same meanings for "temporal layer num" and "GOP size"
1. use temporal layer num and remove GOP size in external configure.
2. modify one typo 
3. welsenc.cfg also is updated
