### PR TITLE
Mark source parameters to MC functions as const

### DIFF
--- a/codec/common/mc_chroma.asm
+++ b/codec/common/mc_chroma.asm
@@ -67,11 +67,11 @@ SECTION .text
 
 ALIGN 16
 ;*******************************************************************************
-; void McChromaWidthEq4_mmx( uint8_t *src,
+; void McChromaWidthEq4_mmx( const uint8_t *src,
 ;							int32_t iSrcStride,
 ;							uint8_t *pDst,
 ;							int32_t iDstStride,
-;							uint8_t *pABCD,
+;							const uint8_t *pABCD,
 ;							int32_t iHeigh );
 ;*******************************************************************************
 WELS_EXTERN McChromaWidthEq4_mmx
@@ -159,11 +159,11 @@ McChromaWidthEq4_mmx:
 
 ALIGN 16
 ;*******************************************************************************
-; void McChromaWidthEq8_sse2( uint8_t *pSrc,
+; void McChromaWidthEq8_sse2( const uint8_t *pSrc,
 ;						int32_t iSrcStride,
 ;						uint8_t *pDst,
 ;						int32_t iDstStride,
-;						uint8_t *pABCD,
+;						const uint8_t *pABCD,
 ;						int32_t iheigh );
 ;*******************************************************************************
 WELS_EXTERN McChromaWidthEq8_sse2
@@ -254,11 +254,11 @@ McChromaWidthEq8_sse2:
 
 ALIGN 16
 ;***********************************************************************
-; void McChromaWidthEq8_ssse3( uint8_t *pSrc,
+; void McChromaWidthEq8_ssse3( const uint8_t *pSrc,
 ;						 int32_t iSrcStride,
 ;                        uint8_t *pDst,
 ;                        int32_t iDstStride,
-;                        uint8_t *pABCD,
+;                        const uint8_t *pABCD,
 ;					     int32_t iHeigh);
 ;***********************************************************************
 WELS_EXTERN McChromaWidthEq8_ssse3

--- a/codec/common/mc_common.h
+++ b/codec/common/mc_common.h
@@ -43,56 +43,56 @@ extern "C" {
 //***************************************************************************//
 //                       MMXEXT definition                                   //
 //***************************************************************************//
-void McHorVer20WidthEq4_mmx (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer20WidthEq4_mmx (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                              int32_t iHeight);
-void McChromaWidthEq4_mmx (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChromaWidthEq4_mmx (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                            const uint8_t* kpABCD, int32_t iHeight);
-void McCopyWidthEq4_mmx (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McCopyWidthEq4_mmx (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                          int32_t iHeight);
-void McCopyWidthEq8_mmx (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McCopyWidthEq8_mmx (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                          int32_t iHeight);
-void PixelAvgWidthEq4_mmx (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                           uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
-void PixelAvgWidthEq8_mmx (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                           uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
+void PixelAvgWidthEq4_mmx (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                           const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
+void PixelAvgWidthEq8_mmx (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                           const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
 
 //***************************************************************************//
 //                       SSE2 definition                                     //
 //***************************************************************************//
-void McChromaWidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChromaWidthEq8_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                             const uint8_t* kpABCD, int32_t iHeight);
-void McCopyWidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McCopyWidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                            int32_t iHeight);
-void McHorVer20WidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer20WidthEq8_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                               int32_t iHeight);
-void McHorVer20WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer20WidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                int32_t iHeight);
-void McHorVer02WidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer02WidthEq8_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                               int32_t iHeight);
-void McHorVer22Width8HorFirst_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer22Width8HorFirst_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                     int32_t iHeight);
-void McHorVer22Width8VerLastAlign_sse2 (uint8_t* pTap, int32_t iTapStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer22Width8VerLastAlign_sse2 (const uint8_t* pTap, int32_t iTapStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iWidth, int32_t iHeight);
-void McHorVer22Width8VerLastUnAlign_sse2 (uint8_t* pTap, int32_t iTapStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer22Width8VerLastUnAlign_sse2 (const uint8_t* pTap, int32_t iTapStride, uint8_t* pDst, int32_t iDstStride,
                                          int32_t iWidth, int32_t iHeight);
 
-void PixelAvgWidthEq16_sse2 (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                             uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
+void PixelAvgWidthEq16_sse2 (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                             const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight);
 
-void McHorVer20Width9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+void McHorVer20Width9Or17_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                 int32_t iHeight);
 
-void McHorVer02Height9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+void McHorVer02Height9Or17_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                  int32_t iHeight);
 
-void McHorVer22HorFirst_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pTap, int32_t iTapStride, int32_t iWidth,
+void McHorVer22HorFirst_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pTap, int32_t iTapStride, int32_t iWidth,
                               int32_t iHeight);
 
 //***************************************************************************//
 //                       SSSE3 definition                                    //
 //***************************************************************************//
 
-void McChromaWidthEq8_ssse3 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChromaWidthEq8_ssse3 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                              const uint8_t* kpABCD, int32_t iHeight);
 
 #endif //X86_ASM

--- a/codec/common/mc_luma.asm
+++ b/codec/common/mc_luma.asm
@@ -76,7 +76,7 @@ WELS_EXTERN McHorVer20WidthEq4_mmx
 
 ALIGN 16
 ;*******************************************************************************
-; void McHorVer20WidthEq4_mmx( uint8_t *pSrc,
+; void McHorVer20WidthEq4_mmx( const uint8_t *pSrc,
 ;                       int iSrcStride,
 ;						uint8_t *pDst,
 ;						int iDstStride,
@@ -179,7 +179,7 @@ WELS_EXTERN McHorVer20WidthEq16_sse2
 
 ALIGN 16
 ;***********************************************************************
-; void McHorVer22Width8HorFirst_sse2(int16_t *pSrc,
+; void McHorVer22Width8HorFirst_sse2(const int16_t *pSrc,
 ;                       int16_t iSrcStride,
 ;						uint8_t *pDst,
 ;						int32_t iDstStride
@@ -241,7 +241,7 @@ McHorVer22Width8HorFirst_sse2:
 
 ALIGN 16
 ;*******************************************************************************
-; void McHorVer20WidthEq8_sse2(  uint8_t *pSrc,
+; void McHorVer20WidthEq8_sse2(  const uint8_t *pSrc,
 ;                       int iSrcStride,
 ;												uint8_t *pDst,
 ;												int iDstStride,
@@ -307,7 +307,7 @@ McHorVer20WidthEq8_sse2:
 
 ALIGN 16
 ;*******************************************************************************
-; void McHorVer20WidthEq16_sse2(  uint8_t *pSrc,
+; void McHorVer20WidthEq16_sse2(  const uint8_t *pSrc,
 ;                       int iSrcStride,
 ;												uint8_t *pDst,
 ;												int iDstStride,
@@ -398,7 +398,7 @@ McHorVer20WidthEq16_sse2:
 
 
 ;*******************************************************************************
-; void McHorVer02WidthEq8_sse2( uint8_t *pSrc,
+; void McHorVer02WidthEq8_sse2( const uint8_t *pSrc,
 ;                       int iSrcStride,
 ;                       uint8_t *pDst,
 ;                       int iDstStride,
@@ -504,7 +504,7 @@ WELS_EXTERN McHorVer22HorFirst_sse2
 
 
 ;***********************************************************************
-; void McHorVer02Height9Or17_sse2(	uint8_t *pSrc,
+; void McHorVer02Height9Or17_sse2(	const uint8_t *pSrc,
 ;                       int32_t iSrcStride,
 ;                       uint8_t *pDst,
 ;                       int32_t iDstStride,
@@ -654,7 +654,7 @@ McHorVer02Height9Or17_sse2:
 
 ALIGN 16
 ;***********************************************************************
-; void McHorVer20Width9Or17_sse2(		uint8_t *pSrc,
+; void McHorVer20Width9Or17_sse2(		const uint8_t *pSrc,
 ;                       int32_t iSrcStride,
 ;						uint8_t *pDst,
 ;						int32_t iDstStride,
@@ -826,7 +826,7 @@ McHorVer20Width9Or17_sse2:
 ALIGN 16
 ;***********************************************************************
 ;void McHorVer22HorFirst_sse2
-;							(uint8_t *pSrc,
+;							(const uint8_t *pSrc,
 ;							int32_t iSrcStride,
 ;							uint8_t * pTap,
 ;							int32_t iTapStride,
@@ -1003,7 +1003,7 @@ McHorVer22HorFirst_sse2:
 %endmacro
 ;***********************************************************************
 ;void McHorVer22Width8VerLastAlign_sse2(
-;											uint8_t *pTap,
+;											const uint8_t *pTap,
 ;											int32_t iTapStride,
 ;											uint8_t * pDst,
 ;											int32_t iDstStride,
@@ -1149,7 +1149,7 @@ McHorVer22HorFirst_sse2:
 
 ;***********************************************************************
 ;void McHorVer22Width8VerLastUnAlign_sse2(
-;											uint8_t *pTap,
+;											const uint8_t *pTap,
 ;											int32_t iTapStride,
 ;											uint8_t * pDst,
 ;											int32_t iDstStride,

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -95,7 +95,7 @@ typedef struct TagRefPic {
   int32_t				iMaxLongTermFrameIdx;
 } SRefPic, *PRefPic;
 
-typedef void (*PWelsMcFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PWelsMcFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight);
 typedef struct TagMcFunc {
   PWelsMcFunc pMcLumaFunc;

--- a/codec/decoder/core/inc/mc.h
+++ b/codec/decoder/core/inc/mc.h
@@ -40,7 +40,7 @@
 
 namespace WelsDec {
 
-typedef void (*PMcChromaWidthExtFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PMcChromaWidthExtFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     const uint8_t* kpABCD, int32_t iHeight);
 
 void InitMcFunc (SMcFunc* pMcFunc, int32_t iCpu);

--- a/codec/decoder/core/src/mc.cpp
+++ b/codec/decoder/core/src/mc.cpp
@@ -84,13 +84,13 @@ static const uint8_t g_kuiABCD[8][8][4] = {	//g_kA[dy][dx], g_kB[dy][dx], g_kC[d
   }
 };
 
-typedef void (*PWelsMcWidthHeightFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PWelsMcWidthHeightFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iWidth, int32_t iHeight);
 
 //***************************************************************************//
 //                          C code implementation                            //
 //***************************************************************************//
-static inline void McCopyWidthEq2_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq2_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                        int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) { // iWidth == 2 only for chroma
@@ -100,7 +100,7 @@ static inline void McCopyWidthEq2_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t*
   }
 }
 
-static inline void McCopyWidthEq4_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq4_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                        int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) {
@@ -110,7 +110,7 @@ static inline void McCopyWidthEq4_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t*
   }
 }
 
-static inline void McCopyWidthEq8_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq8_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                        int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) {
@@ -120,7 +120,7 @@ static inline void McCopyWidthEq8_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t*
   }
 }
 
-static inline void McCopyWidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq16_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) {
@@ -141,7 +141,7 @@ static inline int32_t HorFilterInput16bit_c (int16_t* pSrc) {
   return (iPix05 - (iPix14 * 5)+ (iPix23 * 20)); 
 }
 // h: iOffset=1 / v: iOffset=iSrcStride
-static inline int32_t FilterInput8bitWithStride_c (uint8_t* pSrc, const int32_t kiOffset) {
+static inline int32_t FilterInput8bitWithStride_c (const uint8_t* pSrc, const int32_t kiOffset) {
   const int32_t kiOffset1 = kiOffset;
   const int32_t kiOffset2 = (kiOffset << 1);
   const int32_t kiOffset3 = kiOffset + kiOffset2;
@@ -152,8 +152,8 @@ static inline int32_t FilterInput8bitWithStride_c (uint8_t* pSrc, const int32_t 
   return (kuiPix05 - ((kuiPix14 << 2) + kuiPix14) + (kuiPix23 << 4) + (kuiPix23 << 2));
 }
 
-static inline void PixelAvg_c (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                                 uint8_t* pSrcB, int32_t iSrcBStride, int32_t iWidth, int32_t iHeight) {
+static inline void PixelAvg_c (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                                 const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iWidth, int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
     for (j = 0; j < iWidth; j++) {
@@ -164,7 +164,7 @@ static inline void PixelAvg_c (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA
     pSrcB += iSrcBStride;
   }
 }
-static inline void McCopy_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McCopy_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                int32_t iHeight) {
   if (iWidth == 16)
     McCopyWidthEq16_c (pSrc, iSrcStride, pDst, iDstStride, iHeight);
@@ -176,7 +176,7 @@ static inline void McCopy_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, i
     McCopyWidthEq2_c (pSrc, iSrcStride, pDst, iDstStride, iHeight);
 }
 
-static inline void McHorVer20_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer20_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -188,7 +188,7 @@ static inline void McHorVer20_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   }
 }
 
-static inline void McHorVer02_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer02_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -200,7 +200,7 @@ static inline void McHorVer02_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   }
 }
 
-static inline void McHorVer22_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer22_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   int16_t iTmp[16 + 5] = {0}; //16
   int32_t i, j, k;
@@ -218,25 +218,25 @@ static inline void McHorVer22_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
 }
 
 /////////////////////luma MC//////////////////////////
-static inline void McHorVer01_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer01_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiTmp[256];
   McHorVer02_c (pSrc, iSrcStride, uiTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, pSrc, iSrcStride, uiTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer03_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer03_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiTmp[256];
   McHorVer02_c (pSrc, iSrcStride, uiTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, pSrc + iSrcStride, iSrcStride, uiTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer10_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer10_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiTmp[256];
   McHorVer20_c (pSrc, iSrcStride, uiTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, pSrc, iSrcStride, uiTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer11_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer11_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiVerTmp[256];
@@ -244,7 +244,7 @@ static inline void McHorVer11_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer02_c (pSrc, iSrcStride, uiVerTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiVerTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer12_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer12_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiVerTmp[256];
   uint8_t uiCtrTmp[256];
@@ -252,7 +252,7 @@ static inline void McHorVer12_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer22_c (pSrc, iSrcStride, uiCtrTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiVerTmp, 16, uiCtrTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer13_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer13_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiVerTmp[256];
@@ -260,7 +260,7 @@ static inline void McHorVer13_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer02_c (pSrc, iSrcStride, uiVerTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiVerTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer21_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer21_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiCtrTmp[256];
@@ -268,7 +268,7 @@ static inline void McHorVer21_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer22_c (pSrc, iSrcStride, uiCtrTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiCtrTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer23_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer23_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiCtrTmp[256];
@@ -276,13 +276,13 @@ static inline void McHorVer23_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer22_c (pSrc, iSrcStride, uiCtrTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiCtrTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer30_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer30_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   McHorVer20_c (pSrc, iSrcStride, uiHorTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, pSrc + 1, iSrcStride, uiHorTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer31_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer31_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiVerTmp[256];
@@ -290,7 +290,7 @@ static inline void McHorVer31_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer02_c (pSrc + 1, iSrcStride, uiVerTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiVerTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer32_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer32_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiVerTmp[256];
   uint8_t uiCtrTmp[256];
@@ -298,7 +298,7 @@ static inline void McHorVer32_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   McHorVer22_c (pSrc, iSrcStride, uiCtrTmp, 16, iWidth, iHeight);
   PixelAvg_c (pDst, iDstStride, uiVerTmp, 16, uiCtrTmp, 16, iWidth, iHeight);
 }
-static inline void McHorVer33_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer33_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                    int32_t iHeight) {
   uint8_t uiHorTmp[256];
   uint8_t uiVerTmp[256];
@@ -307,7 +307,7 @@ static inline void McHorVer33_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   PixelAvg_c (pDst, iDstStride, uiHorTmp, 16, uiVerTmp, 16, iWidth, iHeight);
 }
 
-void McLuma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McLuma_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                  int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight)
 //pSrc has been added the offset of mv
 {
@@ -321,11 +321,11 @@ void McLuma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStr
   pWelsMcFunc[iMvX & 0x03][iMvY & 0x03] (pSrc, iSrcStride, pDst, iDstStride, iWidth, iHeight);
 }
 
-static inline void McChromaWithFragMv_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McChromaWithFragMv_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight) {
   int32_t i, j;
   int32_t iA, iB, iC, iD;
-  uint8_t* pSrcNext = pSrc + iSrcStride;
+  const uint8_t* pSrcNext = pSrc + iSrcStride;
   const uint8_t *pABCD = g_kuiABCD[iMvY & 0x07][iMvX & 0x07];
   iA = pABCD[0];
   iB = pABCD[1];
@@ -341,7 +341,7 @@ static inline void McChromaWithFragMv_c (uint8_t* pSrc, int32_t iSrcStride, uint
   }
 }
 
-void McChroma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChroma_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                    int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight)
 //pSrc has been added the offset of mv
 {
@@ -357,26 +357,26 @@ void McChroma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstS
 //***************************************************************************//
 //                       SSE2 implement                          //
 //***************************************************************************//
-static inline void McHorVer22WidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22WidthEq8_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   ENFORCE_STACK_ALIGN_2D (int16_t, iTap, 21, 8, 16)
   McHorVer22Width8HorFirst_sse2 (pSrc - 2, iSrcStride, (uint8_t*)iTap, 16, iHeight + 5);
   McHorVer22Width8VerLastAlign_sse2 ((uint8_t*)iTap, 16, pDst, iDstStride, 8, iHeight);
 }
 
-static inline void McHorVer02WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer02WidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   McHorVer02WidthEq8_sse2 (pSrc,     iSrcStride, pDst,     iDstStride, iHeight);
   McHorVer02WidthEq8_sse2 (&pSrc[8], iSrcStride, &pDst[8], iDstStride, iHeight);
 }
 
-static inline void McHorVer22WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22WidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   McHorVer22WidthEq8_sse2 (pSrc,     iSrcStride, pDst,     iDstStride, iHeight);
   McHorVer22WidthEq8_sse2 (&pSrc[8], iSrcStride, &pDst[8], iDstStride, iHeight);
 }
 
-static inline void McCopy_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McCopy_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                   int32_t iHeight) {
   if (iWidth == 16)
     McCopyWidthEq16_sse2 (pSrc, iSrcStride, pDst, iDstStride, iHeight);
@@ -388,7 +388,7 @@ static inline void McCopy_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst
     McCopyWidthEq2_c (pSrc, iSrcStride, pDst, iDstStride, iHeight);
 }
 
-static inline void McHorVer20_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer20_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   if (iWidth == 16)
     McHorVer20WidthEq16_sse2 (pSrc, iSrcStride, pDst, iDstStride, iHeight);
@@ -398,7 +398,7 @@ static inline void McHorVer20_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     McHorVer20WidthEq4_mmx (pSrc, iSrcStride, pDst, iDstStride, iHeight);
 }
 
-static inline void McHorVer02_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer02_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   if (iWidth == 16)
     McHorVer02WidthEq16_sse2 (pSrc, iSrcStride, pDst, iDstStride, iHeight);
@@ -408,7 +408,7 @@ static inline void McHorVer02_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     McHorVer02_c (pSrc, iSrcStride, pDst, iDstStride, 4, iHeight);
 }
 
-static inline void McHorVer22_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   if (iWidth == 16)
     McHorVer22WidthEq16_sse2 (pSrc, iSrcStride, pDst, iDstStride, iHeight);
@@ -418,7 +418,7 @@ static inline void McHorVer22_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     McHorVer22_c (pSrc, iSrcStride, pDst, iDstStride, 4, iHeight);
 }
 
-static inline void McHorVer01_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer01_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16);
   if (iWidth == 16) {
@@ -432,7 +432,7 @@ static inline void McHorVer01_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pSrc, iSrcStride, pTmp, 16, iHeight);
   }
 }
-static inline void McHorVer03_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer03_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16);
   if (iWidth == 16) {
@@ -446,7 +446,7 @@ static inline void McHorVer03_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pSrc + iSrcStride, iSrcStride, pTmp, 16, iHeight);
   }
 }
-static inline void McHorVer10_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer10_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16);
   if (iWidth == 16) {
@@ -460,7 +460,7 @@ static inline void McHorVer10_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pSrc, iSrcStride, pTmp, 16, iHeight);
   }
 }
-static inline void McHorVer11_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer11_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
@@ -478,7 +478,7 @@ static inline void McHorVer11_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pHorTmp, 16, pVerTmp, 16, iHeight);
   }
 }
-static inline void McHorVer12_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer12_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pCtrTmp, 256, 16);
@@ -496,7 +496,7 @@ static inline void McHorVer12_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pVerTmp, 16, pCtrTmp, 16, iHeight);
   }
 }
-static inline void McHorVer13_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer13_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
@@ -514,7 +514,7 @@ static inline void McHorVer13_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pHorTmp, 16, pVerTmp, 16, iHeight);
   }
 }
-static inline void McHorVer21_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer21_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pCtrTmp, 256, 16);
@@ -532,7 +532,7 @@ static inline void McHorVer21_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pHorTmp, 16, pCtrTmp, 16, iHeight);
   }
 }
-static inline void McHorVer23_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer23_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pCtrTmp, 256, 16);
@@ -550,7 +550,7 @@ static inline void McHorVer23_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pHorTmp, 16, pCtrTmp, 16, iHeight);
   }
 }
-static inline void McHorVer30_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer30_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   if (iWidth == 16) {
@@ -564,7 +564,7 @@ static inline void McHorVer30_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pSrc + 1, iSrcStride, pHorTmp, 16, iHeight);
   }
 }
-static inline void McHorVer31_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer31_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
@@ -582,7 +582,7 @@ static inline void McHorVer31_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pHorTmp, 16, pVerTmp, 16, iHeight);
   }
 }
-static inline void McHorVer32_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer32_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pCtrTmp, 256, 16);
@@ -600,7 +600,7 @@ static inline void McHorVer32_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
     PixelAvgWidthEq4_mmx (pDst, iDstStride, pVerTmp, 16, pCtrTmp, 16, iHeight);
   }
 }
-static inline void McHorVer33_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer33_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iWidth, int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pHorTmp, 256, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, pVerTmp, 256, 16);
@@ -619,7 +619,7 @@ static inline void McHorVer33_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* 
   }
 }
 
-void McLuma_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McLuma_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                     int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight)
 //pSrc has been added the offset of mv
 {
@@ -633,7 +633,7 @@ void McLuma_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDst
   pWelsMcFunc[iMvX & 0x03][iMvY & 0x03] (pSrc, iSrcStride, pDst, iDstStride, iWidth, iHeight);
 }
 
-void McChroma_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChroma_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                       int16_t iMvX, int16_t iMvY, int32_t iWidth, int32_t iHeight) {
   static const PMcChromaWidthExtFunc kpMcChromaWidthFuncs[2] = {
     McChromaWidthEq4_mmx,

--- a/codec/encoder/core/inc/wels_func_ptr_def.h
+++ b/codec/encoder/core/inc/wels_func_ptr_def.h
@@ -68,14 +68,14 @@ typedef int32_t (*PQuantizationSkipFunc) (int16_t* pDct, int16_t iFF,  int16_t i
 typedef int32_t (*PQuantizationHadamardFunc) (int16_t* pRes, const int16_t kiFF, int16_t iMF, int16_t* pDct,
     int16_t* pBlock);
 
-typedef void (*PWelsMcFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PWelsMcFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                              SMVUnitXY mv, int32_t iWidth, int32_t iHeight);
 
-typedef void (*PWelsLumaHalfpelMcFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PWelsLumaHalfpelMcFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iWidth, int32_t iHeight);
-typedef void (*PWelsLumaQuarpelMcFunc) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*PWelsLumaQuarpelMcFunc) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight);
-typedef void (*PWelsSampleAveragingFunc) (uint8_t*, int32_t, uint8_t*, int32_t, uint8_t*, int32_t, int32_t);
+typedef void (*PWelsSampleAveragingFunc) (uint8_t*, int32_t, const uint8_t*, int32_t, const uint8_t*, int32_t, int32_t);
 
 typedef struct TagMcFunc {
   PWelsLumaHalfpelMcFunc      pfLumaHalfpelHor;

--- a/codec/encoder/core/src/mc.cpp
+++ b/codec/encoder/core/src/mc.cpp
@@ -81,16 +81,16 @@ static const uint8_t g_kuiABCD[8][8][4] = { ////g_kuiA[dy][dx], g_kuiB[dy][dx], 
     {4, 4, 28, 28}, {3, 5, 21, 35}, {2, 6, 14, 42}, {1, 7, 7, 49}
   }
 };
-typedef int32_t (*VerFilterFunc) (uint8_t* pSrc, const int32_t kiSrcStride);
-typedef int32_t (*HorFilterFunc) (uint8_t* pSrc);
+typedef int32_t (*VerFilterFunc) (const uint8_t* pSrc, const int32_t kiSrcStride);
+typedef int32_t (*HorFilterFunc) (const uint8_t* pSrc);
 typedef int32_t (*HorFilterFuncInput16Bits) (int16_t* pSrc);
 
 VerFilterFunc fpVerFilter			= NULL;
 HorFilterFunc fpHorFilter			= NULL;
 HorFilterFuncInput16Bits fpHorFilterInput16Bits = NULL;
 
-typedef void (*WelsMcFunc0) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iHeight);
-typedef void (*WelsMcFunc1) (uint8_t* pDst, int32_t iDstStride, uint8_t* psrcA, int32_t iSrcAStride,  uint8_t* pSrcB,
+typedef void (*WelsMcFunc0) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iHeight);
+typedef void (*WelsMcFunc1) (uint8_t* pDst, int32_t iDstStride, const uint8_t* psrcA, int32_t iSrcAStride,  const uint8_t* pSrcB,
                              int32_t iSrcBStride, int32_t iHeight);
 WelsMcFunc0 McCopyWidthEq16 = NULL;
 WelsMcFunc0 McCopyWidthEq8 = NULL;
@@ -103,7 +103,7 @@ WelsMcFunc0 pfMcHorVer22WidthEq16 = NULL;
 //***************************************************************************//
 //                          C code implementation                            //
 //***************************************************************************//
-static inline void McCopyWidthEq4_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq4_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                      int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) {
@@ -113,7 +113,7 @@ static inline void McCopyWidthEq4_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t*
   }
 }
 
-static inline void McCopyWidthEq8_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq8_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                      int32_t iHeight)
 
 {
@@ -124,7 +124,7 @@ static inline void McCopyWidthEq8_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t*
     pSrc += iSrcStride;
   }
 }
-static inline void McCopyWidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McCopyWidthEq16_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                       int32_t iHeight) {
   int32_t i;
   for (i = 0; i < iHeight; i++) {
@@ -135,7 +135,7 @@ static inline void McCopyWidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t
 }
 
 //--------------------Luma sample MC------------------//
-static inline int32_t HorFilter_c (uint8_t* pSrc) {
+static inline int32_t HorFilter_c (const uint8_t* pSrc) {
   int32_t iPix05 = pSrc[-2] + pSrc[3];
   int32_t iPix14 = pSrc[-1] + pSrc[2];
   int32_t iPix23 = pSrc[ 0] + pSrc[1];
@@ -150,7 +150,7 @@ static inline int32_t HorFilterInput16bit1_c (int16_t* pSrc) {
 
   return (iPix05 - ((iPix14 << 2) + iPix14) + (iPix23 << 4) + (iPix23 << 2));
 }
-static inline int32_t VerFilter_c (uint8_t* pSrc, const int32_t kiSrcStride) {
+static inline int32_t VerFilter_c (const uint8_t* pSrc, const int32_t kiSrcStride) {
   const int32_t kiLine1	= kiSrcStride;
   const int32_t kiLine2	= (kiSrcStride << 1);
   const int32_t kiLine3 = kiLine1 + kiLine2;
@@ -161,8 +161,8 @@ static inline int32_t VerFilter_c (uint8_t* pSrc, const int32_t kiSrcStride) {
   return (kuiPix05 - ((kuiPix14 << 2) + kuiPix14) + (kuiPix23 << 4) + (kuiPix23 << 2));
 }
 
-static inline void PixelAvgWidthEq8_c (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                                       uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight) {
+static inline void PixelAvgWidthEq8_c (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                                       const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
     for (j = 0; j < 8; j++) {
@@ -173,8 +173,8 @@ static inline void PixelAvgWidthEq8_c (uint8_t* pDst, int32_t iDstStride, uint8_
     pSrcB += iSrcBStride;
   }
 }
-static inline void PixelAvgWidthEq16_c (uint8_t* pDst, int32_t iDstStride, uint8_t* pSrcA, int32_t iSrcAStride,
-                                        uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight) {
+static inline void PixelAvgWidthEq16_c (uint8_t* pDst, int32_t iDstStride, const uint8_t* pSrcA, int32_t iSrcAStride,
+                                        const uint8_t* pSrcB, int32_t iSrcBStride, int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
     for (j = 0; j < 16; j++) {
@@ -187,7 +187,7 @@ static inline void PixelAvgWidthEq16_c (uint8_t* pDst, int32_t iDstStride, uint8
 }
 
 //horizontal filter to gain half sample, that is (2, 0) location in quarter sample
-static inline void McHorVer20WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer20WidthEq16_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -199,7 +199,7 @@ static inline void McHorVer20WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uin
   }
 }
 //vertical filter to gain half sample, that is (0, 2) location in quarter sample
-static inline void McHorVer02WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer02WidthEq16_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -211,7 +211,7 @@ static inline void McHorVer02WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uin
   }
 }
 //horizontal and vertical filter to gain half sample, that is (2, 2) location in quarter sample
-static inline void McHorVer22WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22WidthEq16_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   int16_t pTmp[16 + 5] = {0}; //16
   int32_t i, j, k;
@@ -230,28 +230,28 @@ static inline void McHorVer22WidthEq16_c (uint8_t* pSrc, int32_t iSrcStride, uin
 
 /////////////////////luma MC//////////////////////////
 
-static inline void McHorVer01WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer01WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16)
 
   pfMcHorVer02WidthEq16 (pSrc, iSrcStride, pTmp, 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pSrc, iSrcStride, pTmp, 16, iHeight);
 }
-static inline void McHorVer03WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer03WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16)
 
   pfMcHorVer02WidthEq16 (pSrc, iSrcStride, pTmp, 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pSrc + iSrcStride, iSrcStride, pTmp, 16, iHeight);
 }
-static inline void McHorVer10WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer10WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16)
 
   pfMcHorVer20WidthEq16 (pSrc, iSrcStride, pTmp, 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pSrc, iSrcStride, pTmp, 16, iHeight);
 }
-static inline void McHorVer11WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer11WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -259,7 +259,7 @@ static inline void McHorVer11WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer02WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer12WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer12WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -267,7 +267,7 @@ static inline void McHorVer12WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer22WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer13WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer13WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -275,7 +275,7 @@ static inline void McHorVer13WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer02WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer21WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer21WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -283,7 +283,7 @@ static inline void McHorVer21WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer22WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer23WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer23WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -291,14 +291,14 @@ static inline void McHorVer23WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer22WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer30WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer30WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 256, 16)
 
   pfMcHorVer20WidthEq16 (pSrc, iSrcStride, pTmp, 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pSrc + 1, iSrcStride, pTmp, 16, iHeight);
 }
-static inline void McHorVer31WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer31WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -306,7 +306,7 @@ static inline void McHorVer31WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer02WidthEq16 (pSrc + 1, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer32WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer32WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -314,7 +314,7 @@ static inline void McHorVer32WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfMcHorVer22WidthEq16 (pSrc, iSrcStride, &pTmp[256], 16, iHeight);
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
-static inline void McHorVer33WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer33WidthEq16 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                         int32_t iHeight) {
   ENFORCE_STACK_ALIGN_1D (uint8_t, pTmp, 512, 16)
 
@@ -323,7 +323,7 @@ static inline void McHorVer33WidthEq16 (uint8_t* pSrc, int32_t iSrcStride, uint8
   pfPixelAvgWidthEq16 (pDst, iDstStride, pTmp, 16, &pTmp[256], 16, iHeight);
 }
 
-static inline void McHorVer20_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer20_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                  int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -335,7 +335,7 @@ static inline void McHorVer20_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   }
 }
 //vertical filter to gain half sample, that is (0, 2) location in quarter sample
-static inline void McHorVer02_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer02_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                  int32_t iHeight) {
   int32_t i, j;
   for (i = 0; i < iHeight; i++) {
@@ -347,7 +347,7 @@ static inline void McHorVer02_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
   }
 }
 //horizontal and vertical filter to gain half sample, that is (2, 2) location in quarter sample
-static inline void McHorVer22_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McHorVer22_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                                  int32_t iHeight) {
   int16_t pTmp[17 + 5] = {0}; //w+1
   int32_t i, j, k;
@@ -363,7 +363,7 @@ static inline void McHorVer22_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDs
     pDst += iDstStride;
   }
 }
-static inline void McCopy (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
+static inline void McCopy (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride, int32_t iWidth,
                            int32_t iHeight) {
   int32_t i;
   if (iWidth == 16 && McCopyWidthEq16 != NULL)
@@ -381,7 +381,7 @@ static inline void McCopy (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int
   }
 }
 
-void McChroma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChroma_c (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                  SMVUnitXY mv, int32_t iWidth, int32_t iHeight)
 //pSrc has been added the offset of mv
 {
@@ -398,7 +398,7 @@ void McChroma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstS
 
     int32_t i, j;
 
-    uint8_t* pSrcNext = pSrc + iSrcStride;
+    const uint8_t* pSrcNext = pSrc + iSrcStride;
 
     for (i = 0; i < iHeight; i++) {
       for (j = 0; j < iWidth; j++) {
@@ -415,7 +415,7 @@ void McChroma_c (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstS
 //***************************************************************************//
 #if defined(X86_ASM)
 
-static inline void McHorVer22WidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22WidthEq8_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   ENFORCE_STACK_ALIGN_2D (int16_t, pTap, 21, 8, 16)
   McHorVer22Width8HorFirst_sse2 (pSrc - 2, iSrcStride, (uint8_t*)pTap, 16, iHeight + 5);
@@ -424,17 +424,17 @@ static inline void McHorVer22WidthEq8_sse2 (uint8_t* pSrc, int32_t iSrcStride, u
 
 //2010.2.5
 
-static inline void McHorVer02WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* PDst, int32_t iDstStride,
+static inline void McHorVer02WidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* PDst, int32_t iDstStride,
     int32_t iHeight) {
   McHorVer02WidthEq8_sse2 (pSrc,     iSrcStride, PDst,     iDstStride, iHeight);
   McHorVer02WidthEq8_sse2 (&pSrc[8], iSrcStride, &PDst[8], iDstStride, iHeight);
 }
-static inline void McHorVer22WidthEq16_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+static inline void McHorVer22WidthEq16_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iHeight) {
   McHorVer22WidthEq8_sse2 (pSrc,     iSrcStride, pDst,     iDstStride, iHeight);
   McHorVer22WidthEq8_sse2 (&pSrc[8], iSrcStride, &pDst[8], iDstStride, iHeight);
 }
-void McHorVer22Width9Or17Height9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McHorVer22Width9Or17Height9Or17_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
     int32_t iWidth,
     int32_t iHeight) {
   ENFORCE_STACK_ALIGN_2D (int16_t, pTap, 22, 24, 16)
@@ -444,9 +444,9 @@ void McHorVer22Width9Or17Height9Or17_sse2 (uint8_t* pSrc, int32_t iSrcStride, ui
   McHorVer22Width8VerLastUnAlign_sse2 ((uint8_t*)pTap + tmp1,  48, pDst + iWidth - 8, iDstStride, 8, iHeight);
 }
 
-typedef void (*McChromaWidthEqx) (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+typedef void (*McChromaWidthEqx) (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                                   const uint8_t* pABCD, int32_t iHeigh);
-void McChroma_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChroma_sse2 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                     SMVUnitXY sMv, int32_t iWidth, int32_t iHeight) {
   const int32_t kiD8x = sMv.iMvX & 0x07;
   const int32_t kiD8y = sMv.iMvY & 0x07;
@@ -462,7 +462,7 @@ void McChroma_sse2 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iD
   }
 }
 
-void McChroma_ssse3 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
+void McChroma_ssse3 (const uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t iDstStride,
                      SMVUnitXY sMv, int32_t iWidth, int32_t iHeight) {
   const int32_t kiD8x = sMv.iMvX & 0x07;
   const int32_t kiD8y = sMv.iMvY & 0x07;
@@ -480,7 +480,7 @@ void McChroma_ssse3 (uint8_t* pSrc, int32_t iSrcStride, uint8_t* pDst, int32_t i
 }
 
 #endif //X86_ASM
-typedef void (*PixelAvgFunc) (uint8_t*, int32_t, uint8_t*, int32_t, uint8_t*, int32_t, int32_t);
+typedef void (*PixelAvgFunc) (uint8_t*, int32_t, const uint8_t*, int32_t, const uint8_t*, int32_t, int32_t);
 void WelsInitMcFuncs (SWelsFuncPtrList* pFuncList, uint32_t uiCpuFlag) {
   static PixelAvgFunc pfPixAvgFunc[2] = {PixelAvgWidthEq8_c, PixelAvgWidthEq16_c};
 


### PR DESCRIPTION
This makes the usage of the functions clearer to the caller, clearly indicating which parameters will be changed by the functions. This can also possibly help the compiler optimize code around calls to such functions, knowing that these arrays are unchanged after the function call.
