### PR TITLE
Explicitly allow read-only relocations when building on OS X in 32 bit mode

### DIFF
--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -8,5 +8,6 @@ ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f macho64
 else
 ASMFLAGS += -f macho
+LDFLAGS += -read_only_relocs suppress
 endif
 


### PR DESCRIPTION
This fixes building libwels.dylib, since the assembly code
isn't position independent.
