### PR TITLE
Simplify encoder interface--remove EncoderFrame2 function 

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -64,9 +64,7 @@ class ISVCEncoder {
   /*
    * return: EVideoFrameType [IDR: videoFrameTypeIDR; P: videoFrameTypeP; ERROR: videoFrameTypeInvalid]
    */
-  virtual int EXTAPI EncodeFrame (const unsigned char* kpSrc, SFrameBSInfo* pBsInfo) = 0;
-  virtual int EXTAPI EncodeFrame2 (const SSourcePicture**   kppSrcPicList, int nSrcPicNum, SFrameBSInfo* pBsInfo) = 0;
-
+  virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) = 0;
   /*
    * return: 0 - success; otherwise - failed;
    */
@@ -75,7 +73,7 @@ class ISVCEncoder {
   /*
    * return: 0 - success; otherwise - failed;
    */
-  virtual int EXTAPI PauseFrame (const unsigned char* kpSrc, SFrameBSInfo* pBsInfo) = 0;
+  virtual int EXTAPI PauseFrame (const SSourcePicture* kpSrcPic,SFrameBSInfo* pBsInfo) = 0;
 
   /*
    * return: 0 - success; otherwise - failed;
@@ -146,12 +144,10 @@ struct ISVCEncoderVtbl {
 
   int (*Uninitialize) (ISVCEncoder*);
 
-  int (*EncodeFrame) (ISVCEncoder*, const unsigned char* kpSrc, SFrameBSInfo* pBsInfo);
-  int (*EncodeFrame2) (ISVCEncoder*, const SSourcePicture**   kppSrcPicList, int nSrcPicNum, SFrameBSInfo* pBsInfo);
-
+  int (*EncodeFrame) (ISVCEncoder*, const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
   int (*EncodeParameterSets) (ISVCEncoder*, SFrameBSInfo* pBsInfo);
 
-  int (*PauseFrame) (ISVCEncoder*, const unsigned char* kpSrc, SFrameBSInfo* pBsInfo);
+  int (*PauseFrame) (ISVCEncoder*, const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
 
   int (*ForceIntraFrame) (ISVCEncoder*, bool bIDR);
 

--- a/codec/console/enc/inc/read_config.h
+++ b/codec/console/enc/inc/read_config.h
@@ -50,7 +50,6 @@ typedef struct tagFilesSet {
   string strSeqFile;	// for cmd lines
   struct {
     string strLayerCfgFile;
-    string strSeqFile;
   } sSpatialLayers[MAX_DEPENDENCY_LAYER];
 } SFilesSet;
 

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -120,7 +120,14 @@ int ParseConfig (CReadConfig& cRdCfg, SEncParamExt& pSvcParam, SFilesSet& sFileS
     if (iRd > 0) {
       if (strTag[0].empty())
         continue;
-      if (strTag[0].compare ("OutputFile") == 0) {
+	  if (strTag[0].compare ("SourceWidth") == 0) {
+		pSvcParam.iPicWidth	= atoi (strTag[1].c_str());
+      } else if (strTag[0].compare ("SourceHeight") == 0) {
+		  pSvcParam.iPicHeight = atoi (strTag[1].c_str());
+      } else if (strTag[0].compare ("InputFile") == 0) {
+		   if (strTag[1].length() > 0)
+            sFileSet.strSeqFile	= strTag[1];
+      } else if (strTag[0].compare ("OutputFile") == 0) {
         sFileSet.strBsFile	= strTag[1];
       } else if (strTag[0].compare ("MaxFrameRate") == 0) {
         pSvcParam.fMaxFrameRate	= (float)atof (strTag[1].c_str());
@@ -260,16 +267,13 @@ int ParseConfig (CReadConfig& cRdCfg, SEncParamExt& pSvcParam, SFilesSet& sFileS
       if (iLayerRd > 0) {
         if (strTag[0].empty())
           continue;
-        if (strTag[0].compare ("SourceWidth") == 0) {
+        if (strTag[0].compare ("FrameWidth") == 0) {
 			pDLayer->iVideoWidth	= atoi (strTag[1].c_str());
-        } else if (strTag[0].compare ("SourceHeight") == 0) {
+        } else if (strTag[0].compare ("FrameHeight") == 0) {
           pDLayer->iVideoHeight	= atoi (strTag[1].c_str());
         } else if (strTag[0].compare ("FrameRateOut") == 0) {
           pDLayer->fFrameRate = (float)atof (strTag[1].c_str());
-        } else if (strTag[0].compare ("InputFile") == 0) {
-          if (strTag[1].length() > 0)
-            sFileSet.sSpatialLayers[iLayer].strSeqFile	= strTag[1];
-        } else if (strTag[0].compare ("ReconFile") == 0) {
+        }else if (strTag[0].compare ("ReconFile") == 0) {
           const int kiLen = strTag[1].length();
           if (kiLen >= MAX_FNAME_LEN)
             return 1;
@@ -427,7 +431,8 @@ int ParseCommandLine (int argc, char** argv, SEncParamExt& pSvcParam, SFilesSet&
 
     if (!strcmp (pCommand, "-bf") && (n < argc))
       sFileSet.strBsFile.assign (argv[n++]);
-
+	else if (!strcmp (pCommand, "-org") && (n < argc))
+       sFileSet.strSeqFile.assign (argv[n++]);
     else if (!strcmp (pCommand, "-frms") && (n < argc))
       pSvcParam.uiFrameToBeCoded = atoi (argv[n++]);
 
@@ -500,9 +505,6 @@ int ParseCommandLine (int argc, char** argv, SEncParamExt& pSvcParam, SFilesSet&
 				pDLayer->iVideoHeight	= atoi (strTag[1].c_str());
             } else if (strTag[0].compare ("FrameRateOut") == 0) {
 				pDLayer->fFrameRate = (float)atof (strTag[1].c_str());
-            } else if (strTag[0].compare ("InputFile") == 0) {
-              if (strTag[1].length() > 0)
-                sFileSet.sSpatialLayers[iLayer].strSeqFile = strTag[1];
             } else if (strTag[0].compare ("ReconFile") == 0) {
 #ifdef ENABLE_FRAME_DUMP
               const int kiLen = strTag[1].length();
@@ -541,12 +543,6 @@ int ParseCommandLine (int argc, char** argv, SEncParamExt& pSvcParam, SFilesSet&
 
       }
     }
-
-    else if (!strcmp (pCommand, "-org") && (n + 1 < argc)) {
-      unsigned int	iLayer = atoi (argv[n++]);
-      sFileSet.sSpatialLayers[iLayer].strSeqFile.assign (argv[n++]);
-    }
-
     else if (!strcmp (pCommand, "-drec") && (n + 1 < argc)) {
 #ifdef ENABLE_FRAME_DUMP
       unsigned int	iLayer = atoi (argv[n++]);
@@ -745,7 +741,7 @@ int ProcessEncodingSvcWithParam (ISVCEncoder* pPtrEnc, int argc, char** argv) {
   int32_t iFrameSize = 0;
   uint8_t* pPlanes[3] = { 0 };
   int32_t iFrame = 0;
-
+  SSourcePicture* pSrcPic = NULL;
 #if defined ( STICK_STREAM_SIZE )
   FILE* fTrackStream = fopen ("coding_size.stream", "wb");;
 #endif
@@ -814,6 +810,22 @@ int ProcessEncodingSvcWithParam (ISVCEncoder* pPtrEnc, int argc, char** argv) {
     goto ERROR_RET;
   }
 
+  pSrcPic = new SSourcePicture;
+  if (pSrcPic == NULL) {
+     ret = 1;
+     goto ERROR_RET;
+   }
+
+  pSrcPic->iColorFormat = sSvcParam.iInputCsp;
+  pSrcPic->iPicHeight = sSvcParam.iPicHeight;
+  pSrcPic->iPicWidth = sSvcParam.iPicWidth;
+  pSrcPic->iStride[0] = sSvcParam.iPicWidth;
+  pSrcPic->iStride[1] = pSrcPic->iStride[2] = sSvcParam.iPicWidth>>1;
+
+  pSrcPic->pData[0] = pPlanes[0];
+  pSrcPic->pData[1] = pSrcPic->pData[0] + (sSvcParam.iPicWidth*sSvcParam.iPicHeight);
+  pSrcPic->pData[2] = pSrcPic->pData[1] + (sSvcParam.iPicWidth*sSvcParam.iPicHeight>>2);
+
   while (true) {
     if (feof (pFpSrc))
       break;
@@ -825,7 +837,7 @@ int ProcessEncodingSvcWithParam (ISVCEncoder* pPtrEnc, int argc, char** argv) {
       break;
 
     iStart	= WelsTime();
-    long iEncode = pPtrEnc->EncodeFrame (pPlanes[0], &sFbi);
+    long iEncode = pPtrEnc->EncodeFrame (pSrcPic, &sFbi);
     iTotal += WelsTime() - iStart;
     if (videoFrameTypeInvalid == iEncode) {
       fprintf (stderr, "EncodeFrame() failed: %ld.\n", iEncode);
@@ -870,7 +882,10 @@ ERROR_RET:
     fclose (pFpSrc);
     pFpSrc = NULL;
   }
-
+  if(pSrcPic){
+   delete pSrcPic;
+   pSrcPic = NULL;
+  }
   return ret;
 }
 
@@ -886,15 +901,16 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
   int64_t iStart = 0, iTotal = 0;
 
   // Preparing encoding process
-  FILE* pFileYUV[MAX_DEPENDENCY_LAYER] = {0};
+  FILE* pFileYUV = NULL;
   int32_t iActualFrameEncodedCount = 0;
   int32_t iFrameIdx = 0;
   int32_t	iTotalFrameMax = -1;
   int8_t  iDlayerIdx = 0;
-  uint8_t* pYUV[MAX_DEPENDENCY_LAYER] = { 0 };
-  SSourcePicture**    pSrcPicList = NULL;
+  uint8_t* pYUV= NULL;
+  SSourcePicture* pSrcPic = NULL;
   // Inactive with sink with output file handler
   FILE* pFpBs = NULL;
+  int kiPicResSize = 0;
 #if defined(COMPARE_DATA)
   //For getting the golden file handle
   FILE* fpGolden = NULL;
@@ -937,9 +953,6 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
   }
 
   iTotalFrameMax = (int32_t)sSvcParam.uiFrameToBeCoded;
-  sSvcParam.iPicWidth = sSvcParam.sSpatialLayers[sSvcParam.iSpatialLayerNum - 1].iVideoWidth;
-  sSvcParam.iPicHeight = sSvcParam.sSpatialLayers[sSvcParam.iSpatialLayerNum - 1].iVideoHeight;
-
 
   if (cmResultSuccess != pPtrEnc->InitializeExt (&sSvcParam)) {	// SVC encoder initialization
     fprintf (stderr, "SVC encoder Initialize failed\n");
@@ -965,47 +978,40 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
   }
 #endif
 
-  pSrcPicList = new SSourcePicture * [sSvcParam.iSpatialLayerNum];
-  while (iDlayerIdx < sSvcParam.iSpatialLayerNum) {
-    SSpatialLayerConfig* pDLayer = &sSvcParam.sSpatialLayers[iDlayerIdx];
-	const int kiPicResSize = pDLayer->iVideoWidth * pDLayer->iVideoHeight;
-    SSourcePicture* pSrcPic = new SSourcePicture;
-    if (pSrcPic == NULL) {
-      iRet = 1;
-      goto INSIDE_MEM_FREE;
-    }
-    memset (pSrcPic, 0, sizeof (SSourcePicture));
+  kiPicResSize = sSvcParam.iPicWidth * sSvcParam.iPicHeight*3>>1;
 
-    pYUV[iDlayerIdx] = new uint8_t [ (3 * kiPicResSize) >> 1];
-    if (pYUV[iDlayerIdx] == NULL) {
-      iRet = 1;
-      goto INSIDE_MEM_FREE;
-    }
+  pSrcPic = new SSourcePicture;
+  if (pSrcPic == NULL) {
+     iRet = 1;
+     goto INSIDE_MEM_FREE;
+   }
+  pYUV = new uint8_t [kiPicResSize];
+  if (pYUV == NULL) {
+     iRet = 1;
+     goto INSIDE_MEM_FREE;
+   }
+  pSrcPic->iColorFormat = sSvcParam.iInputCsp;
+  pSrcPic->iPicHeight = sSvcParam.iPicHeight;
+  pSrcPic->iPicWidth = sSvcParam.iPicWidth;
+  pSrcPic->iStride[0] = sSvcParam.iPicWidth;
+  pSrcPic->iStride[1] = pSrcPic->iStride[2] = sSvcParam.iPicWidth>>1;
 
-    pSrcPic->iColorFormat = videoFormatI420;
-    pSrcPic->iPicWidth = pDLayer->iVideoWidth;
-    pSrcPic->iPicHeight = pDLayer->iVideoHeight;
-    pSrcPic->iStride[0] = pDLayer->iVideoWidth;
-    pSrcPic->iStride[1] = pSrcPic->iStride[2] = pDLayer->iVideoWidth >> 1;
-
-    pSrcPicList[iDlayerIdx] = pSrcPic;
-
-    pFileYUV[iDlayerIdx]	= fopen (fs.sSpatialLayers[iDlayerIdx].strSeqFile.c_str(), "rb");
-    if (pFileYUV[iDlayerIdx] != NULL) {
-      if (!fseek (pFileYUV[iDlayerIdx], 0, SEEK_END)) {
-        int64_t i_size = ftell (pFileYUV[iDlayerIdx]);
-        fseek (pFileYUV[iDlayerIdx], 0, SEEK_SET);
-        iTotalFrameMax = WELS_MAX ((int32_t) (i_size / ((3 * kiPicResSize) >> 1)), iTotalFrameMax);
+  pSrcPic->pData[0] = pYUV;
+  pSrcPic->pData[1] = pSrcPic->pData[0] + (sSvcParam.iPicWidth*sSvcParam.iPicHeight);
+  pSrcPic->pData[2] = pSrcPic->pData[1] + (sSvcParam.iPicWidth*sSvcParam.iPicHeight>>2);
+   pFileYUV = fopen (fs.strSeqFile.c_str(), "rb");
+    if (pFileYUV != NULL) {
+      if (!fseek (pFileYUV, 0, SEEK_END)) {
+        int64_t i_size = ftell (pFileYUV);
+        fseek (pFileYUV, 0, SEEK_SET);
+        iTotalFrameMax = WELS_MAX ((int32_t) (i_size / kiPicResSize), iTotalFrameMax);
       }
     } else {
       fprintf (stderr, "Unable to open source sequence file (%s), check corresponding path!\n",
-               fs.sSpatialLayers[iDlayerIdx].strSeqFile.c_str());
+               fs.strSeqFile.c_str());
       iRet = 1;
       goto INSIDE_MEM_FREE;
     }
-
-    ++ iDlayerIdx;
-  }
 
   iFrameIdx = 0;
   while (iFrameIdx < iTotalFrameMax && (((int32_t)sSvcParam.uiFrameToBeCoded <= 0)
@@ -1019,57 +1025,14 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
       break;
     }
 #endif//ONLY_ENC_FRAMES_NUM
-
-    iDlayerIdx = 0;
-    int  nSpatialLayerNum = 0;
-    while (iDlayerIdx < sSvcParam.iSpatialLayerNum) {
-      SSpatialLayerConfig* pDLayer = &sSvcParam.sSpatialLayers[iDlayerIdx];
-	  const int kiPicResSize = ((pDLayer->iVideoWidth * pDLayer->iVideoHeight) * 3) >> 1;
-      uint32_t uiSkipIdx = 1;//(1 << pDLayer->iTemporalResolution);
-
       bool bCanBeRead = false;
+      bCanBeRead = (fread (pYUV, 1, kiPicResSize, pFileYUV) == kiPicResSize);
 
-      if (iFrameIdx % uiSkipIdx == 0) {	// such layer is enabled to encode indeed
-        bCanBeRead = (fread (pYUV[iDlayerIdx], 1, kiPicResSize, pFileYUV[iDlayerIdx]) == kiPicResSize);
-
-        if (bCanBeRead) {
-          bOnePicAvailableAtLeast	= true;
-
-          pSrcPicList[nSpatialLayerNum]->pData[0] = pYUV[iDlayerIdx];
-          pSrcPicList[nSpatialLayerNum]->pData[1] = pSrcPicList[nSpatialLayerNum]->pData[0] +
-              (pDLayer->iVideoWidth * pDLayer->iVideoHeight);
-          pSrcPicList[nSpatialLayerNum]->pData[2] = pSrcPicList[nSpatialLayerNum]->pData[1] +
-              ((pDLayer->iVideoWidth * pDLayer->iVideoHeight) >> 2);
-
-          pSrcPicList[nSpatialLayerNum]->iPicWidth = pDLayer->iVideoWidth;
-          pSrcPicList[nSpatialLayerNum]->iPicHeight = pDLayer->iVideoHeight;
-          pSrcPicList[nSpatialLayerNum]->iStride[0] = pDLayer->iVideoWidth;
-          pSrcPicList[nSpatialLayerNum]->iStride[1] = pSrcPicList[nSpatialLayerNum]->iStride[2]
-              = pDLayer->iVideoWidth >> 1;
-
-          ++ nSpatialLayerNum;
-        } else {	// file end while reading
-          bSomeSpatialUnavailable = true;
-          break;
-        }
-      } else {
-
-      }
-
-      ++ iDlayerIdx;
-    }
-
-    if (bSomeSpatialUnavailable)
-      break;
-
-    if (!bOnePicAvailableAtLeast) {
-      ++ iFrameIdx;
-      continue;
-    }
-
-    // To encoder this frame
+      if (!bCanBeRead)
+		  break;
+      // To encoder this frame
     iStart	= WelsTime();
-    int iEncFrames = pPtrEnc->EncodeFrame2 (const_cast<const SSourcePicture**> (pSrcPicList), nSpatialLayerNum, &sFbi);
+    int iEncFrames = pPtrEnc->EncodeFrame (pSrcPic, &sFbi);
     iTotal += WelsTime() - iStart;
 
     // fixed issue in case dismatch source picture introduced by frame skipped, 1/12/2010
@@ -1132,8 +1095,7 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
 		sSvcParam.iPicWidth, sSvcParam.iPicHeight,
             iActualFrameEncodedCount, dElapsed, (iActualFrameEncodedCount * 1.0) / dElapsed);
   }
-
-INSIDE_MEM_FREE: {
+INSIDE_MEM_FREE:
     if (pFpBs) {
       fclose (pFpBs);
       pFpBs = NULL;
@@ -1151,34 +1113,18 @@ INSIDE_MEM_FREE: {
     }
 #endif
     // Destruction memory introduced in this routine
-    iDlayerIdx = 0;
-    while (iDlayerIdx < sSvcParam.iSpatialLayerNum) {
-      if (pFileYUV[iDlayerIdx] != NULL) {
-        fclose (pFileYUV[iDlayerIdx]);
-        pFileYUV[iDlayerIdx] = NULL;
+      if (pFileYUV!= NULL) {
+        fclose (pFileYUV);
+        pFileYUV = NULL;
       }
-      ++ iDlayerIdx;
-    }
-
-    if (pSrcPicList) {
-      for (int32_t i = 0; i < sSvcParam.iSpatialLayerNum; i++) {
-        if (pSrcPicList[i]) {
-          delete pSrcPicList[i];
-          pSrcPicList[i] = NULL;
-        }
+      if (pYUV) {
+        delete pYUV;
+        pYUV = NULL;
       }
-      delete []pSrcPicList;
-      pSrcPicList = NULL;
-    }
-
-    for (int32_t i = 0; i < MAX_DEPENDENCY_LAYER; i++) {
-      if (pYUV[i]) {
-        delete [] pYUV[i];
-        pYUV[i] = NULL;
-      }
-    }
-  }
-
+	  if(pSrcPic){
+		  delete pSrcPic;
+		  pSrcPic = NULL;
+	  }
   return iRet;
 }
 

--- a/codec/encoder/plus/inc/welsEncoderExt.h
+++ b/codec/encoder/plus/inc/welsEncoderExt.h
@@ -74,7 +74,7 @@ class CWelsH264SVCEncoder : public ISVCEncoder {
   /*
    * return: EVideoFrameType [IDR: videoFrameTypeIDR; P: videoFrameTypeP; ERROR: videoFrameTypeInvalid]
    */
-  virtual int EXTAPI EncodeFrame (const unsigned char* kpSrc, SFrameBSInfo* pBsInfo);
+  virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
   virtual int EXTAPI EncodeFrame2 (const SSourcePicture** kppSrcPicList, int nSrcPicNum, SFrameBSInfo* pBsInfo);
 
   /*
@@ -85,7 +85,7 @@ class CWelsH264SVCEncoder : public ISVCEncoder {
   /*
    * return: 0 - success; otherwise - failed;
    */
-  virtual int EXTAPI PauseFrame (const unsigned char* pSrc, SFrameBSInfo* pBsInfo);
+  virtual int EXTAPI PauseFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
 
   /*
    * return: 0 - success; otherwise - failed;

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -498,16 +498,13 @@ int32_t CWelsH264SVCEncoder::RawData2SrcPic (const uint8_t* pSrc) {
 /*
  *	SVC core encoding
  */
-int CWelsH264SVCEncoder::EncodeFrame (const unsigned char* pSrc, SFrameBSInfo* pBsInfo) {
-  if (! (pSrc && m_pEncContext && m_bInitialFlag)) {
+int CWelsH264SVCEncoder::EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) {
+  if (! (kpSrcPic && m_pEncContext && m_bInitialFlag)) {
     return videoFrameTypeInvalid;
   }
 
   int32_t uiFrameType = videoFrameTypeInvalid;
-
-  if (RawData2SrcPic ((uint8_t*)pSrc) == 0) {
-    uiFrameType = EncodeFrame2 (const_cast<const SSourcePicture**> (m_pSrcPicList), 1, pBsInfo);
-  }
+  uiFrameType = EncodeFrame2 (&kpSrcPic, 1, pBsInfo);
 
 #ifdef REC_FRAME_COUNT
   ++ m_uiCountFrameNum;
@@ -621,14 +618,15 @@ int CWelsH264SVCEncoder::EncodeParameterSets (SFrameBSInfo* pBsInfo) {
 /*
  * return: 0 - success; otherwise - failed;
  */
-int CWelsH264SVCEncoder::PauseFrame (const unsigned char* kpSrc, SFrameBSInfo* pBsInfo) {
+int CWelsH264SVCEncoder::PauseFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) {
   int32_t  iReturn = 1;
 
   ForceIntraFrame (true);
 
-  if (EncodeFrame (kpSrc, pBsInfo) != videoFrameTypeInvalid) {
-    iReturn = 0;
+  if (EncodeFrame2 (&kpSrcPic, 1,pBsInfo) != videoFrameTypeInvalid) {
+	iReturn = 0;
   }
+ 
 
   // to avoid pause frame bitstream and
   // normal bitstream use different video channel.

--- a/test/BaseEncoderTest.cpp
+++ b/test/BaseEncoderTest.cpp
@@ -48,8 +48,18 @@ void BaseEncoderTest::EncodeStream(InputStream* in, int width, int height,
   SFrameBSInfo info;
   memset(&info, 0, sizeof(SFrameBSInfo));
 
+  SSourcePicture pic;
+  memset(&pic,0,sizeof(SSourcePicture));
+  pic.iPicWidth = width;
+  pic.iPicHeight = height;
+  pic.iColorFormat = videoFormatI420;
+  pic.iStride[0] = pic.iPicWidth;
+  pic.iStride[1] = pic.iStride[2] = pic.iPicWidth>>1;
+  pic.pData[0] = buf.data();
+  pic.pData[1] = pic.pData[0] + width *height;
+  pic.pData[2] = pic.pData[1] + (width*height>>2);
   while (in->read(buf.data(), frameSize) == frameSize) {
-    rv = encoder_->EncodeFrame(buf.data(), &info);
+    rv = encoder_->EncodeFrame(&pic, &info);
     ASSERT_TRUE(rv != videoFrameTypeInvalid);
     if (rv != videoFrameTypeSkip && cbk != NULL) {
       cbk->onEncodeFrame(info);

--- a/test/c_interface_test.c
+++ b/test/c_interface_test.c
@@ -14,12 +14,11 @@ void CheckEncoderInterface(ISVCEncoder* p, CheckFunc check) {
   CHECK(2, p, InitializeExt);
   CHECK(3, p, Uninitialize);
   CHECK(4, p, EncodeFrame);
-  CHECK(5, p, EncodeFrame2);
-  CHECK(6, p, EncodeParameterSets);
-  CHECK(7, p, PauseFrame);
-  CHECK(8, p, ForceIntraFrame);
-  CHECK(9, p, SetOption);
-  CHECK(10, p, GetOption);
+  CHECK(5, p, EncodeParameterSets);
+  CHECK(6, p, PauseFrame);
+  CHECK(7, p, ForceIntraFrame);
+  CHECK(8, p, SetOption);
+  CHECK(9, p, GetOption);
 }
 
 void CheckDecoderInterface(ISVCDecoder* p, CheckFunc check) {

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -34,36 +34,31 @@ struct SVCEncoderImpl : public ISVCEncoder {
     EXPECT_TRUE(gThis == this);
     return 3;
   }
-  virtual int EXTAPI EncodeFrame(const unsigned char* kpSrc,
+  virtual int EXTAPI EncodeFrame(const SSourcePicture* kpSrcPic,
       SFrameBSInfo* pBsInfo) {
     EXPECT_TRUE(gThis == this);
     return 4;
   }
-  virtual int EXTAPI EncodeFrame2(const SSourcePicture** kppSrcPicList,
-      int nSrcPicNum, SFrameBSInfo* pBsInfo) {
+  virtual int EXTAPI EncodeParameterSets(SFrameBSInfo* pBsInfo) {
     EXPECT_TRUE(gThis == this);
     return 5;
   }
-  virtual int EXTAPI EncodeParameterSets(SFrameBSInfo* pBsInfo) {
+  virtual int EXTAPI PauseFrame(const SSourcePicture* kpSrcPic,
+      SFrameBSInfo* pBsInfo) {
     EXPECT_TRUE(gThis == this);
     return 6;
   }
-  virtual int EXTAPI PauseFrame(const unsigned char* kpSrc,
-      SFrameBSInfo* pBsInfo) {
+  virtual int EXTAPI ForceIntraFrame(bool bIDR) {
     EXPECT_TRUE(gThis == this);
     return 7;
   }
-  virtual int EXTAPI ForceIntraFrame(bool bIDR) {
+  virtual int EXTAPI SetOption(ENCODER_OPTION eOptionId, void* pOption) {
     EXPECT_TRUE(gThis == this);
     return 8;
   }
-  virtual int EXTAPI SetOption(ENCODER_OPTION eOptionId, void* pOption) {
-    EXPECT_TRUE(gThis == this);
-    return 9;
-  }
   virtual int EXTAPI GetOption(ENCODER_OPTION eOptionId, void* pOption) {
     EXPECT_TRUE(gThis == this);
-    return 10;
+    return 9;
   }
 };
 

--- a/testbin/layer2.cfg
+++ b/testbin/layer2.cfg
@@ -2,11 +2,10 @@
 
 
 #============================== INPUT / OUTPUT ==============================
-SourceWidth     320                     # Input  frame width
-SourceHeight    192                    # Input  frame height
+FrameWidth     320                     # Input  frame width
+FrameHeight    192                    # Input  frame height
 FrameRateIn     12                      # Input  frame rate [Hz]
 FrameRateOut    12                     # Output frame rate [Hz]
-InputFile       ../res/CiscoVT2people_320x192_12fps.yuv # Input  file
 ReconFile       rec_layer2.yuv          # Reconstructed file
 
 #============================== CODING ==============================

--- a/testbin/welsenc.cfg
+++ b/testbin/welsenc.cfg
@@ -1,6 +1,9 @@
 # Cisco Scalable H.264/AVC Extension Encoder Configuration File
 
 #============================== GENERAL ==============================
+SourceWidth      320          #input video width
+SourceHeight     192          #input video height
+InputFile       ../res/CiscoVT2people_320x192_12fps.yuv # Input  file
 OutputFile              test.264               # Bitstream file
 MaxFrameRate            30                     # Maximum frame rate [Hz]
 FramesToBeEncoded       -1                    # Number of frames (at input frame rate)


### PR DESCRIPTION
simplify encoder interface configure
1. remove EncoderFrame2 from interface function.
2. take a SSourcePicture instead of an unsigned char\* in EncodeFrame and PauseFrame function 
3. only one source data as input.if the user sets multiple spacial layers, VP will do down-sampling
