### PR TITLE
remain size to prevent MB residual reading overflow

### DIFF
--- a/codec/decoder/core/inc/wels_const.h
+++ b/codec/decoder/core/inc/wels_const.h
@@ -93,6 +93,7 @@
 
 #define MAX_NAL_UNIT_NUM_IN_AU	32	// predefined maximal number of NAL Units in an access unit
 #define MAX_ACCESS_UNIT_CAPACITY	1048576	// Maximal AU capacity in bytes: (1<<20) = 1024 KB predefined
+#define MAX_MACROBLOCK_CAPACITY 5000 //Maximal legal MB capacity, 15000 bits is enough
 
 enum {
   BASE_MB = 0,

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -361,7 +361,7 @@ DECODING_STATE CWelsDecoder::DecodeFrame2 (const unsigned char* kpSrc,
     const int kiSrcLen,
     void** ppDst,
     SBufferInfo* pDstInfo) {
-  if (kiSrcLen > MAX_ACCESS_UNIT_CAPACITY) {
+  if (kiSrcLen > MAX_ACCESS_UNIT_CAPACITY - MAX_MACROBLOCK_CAPACITY) {//prevent from residual reading overflow
     m_pDecContext->iErrorCode |= dsOutOfMemory;
     IWelsTrace::WelsVTrace (m_pTrace, IWelsTrace::WELS_LOG_INFO,
       "max AU size exceeded. Allowed size = %d, current size = %d",


### PR DESCRIPTION
It is for MB level residual bit reading check, via pre-allocating enough memory to prevent overflow.
Detailed review request can be seen via:
https://rbcommons.com/s/OpenH264/r/92/
