### PR TITLE
init the spatial last spatial picture if excption

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -405,6 +405,7 @@ int32_t CWelsPreProcess::UpdateSpatialPictures(sWelsEncCtx* pCtx, SWelsSvcCoding
     const int8_t iCurTid, const int32_t d_idx) {
   if (iCurTid < m_uiSpatialLayersInTemporal[d_idx] - 1 || pParam->iDecompStages == 0){
     if ((iCurTid >= MAX_TEMPORAL_LEVEL) || (m_uiSpatialLayersInTemporal[d_idx] - 1 > MAX_TEMPORAL_LEVEL)) {
+      InitLastSpatialPictures(pCtx);
       return 1;
     }
     if (pParam->bEnableLongTermReference && pCtx->bLongTermRefFlag[d_idx][iCurTid]) {


### PR DESCRIPTION
this patch is try to fix the incorrect exception handle logic which is discussed before in preprocess module. 
the origin code: 
if the iCurTid or m_uiSpatialLayersInTemporal is invalid,  it will return false and need to force IDR frame.  But it is lack of re-order the spatial picture list,  then it cause the memory conflict when exchange the last spatial pictures(encoding next frame).  

The modification here means to init the last spatial pictures in the exception handle,  it is assume that the spatial picture list is in initialize status(so need not to reorder it).  Its OK because next frame should be IDR.  

Review:
https://rbcommons.com/s/OpenH264/r/99/
