### PR TITLE
Ignore project.properties

### DIFF
--- a/codec/build/android/.gitignore
+++ b/codec/build/android/.gitignore
@@ -3,3 +3,4 @@ local.properties
 proguard-project.txt
 gen
 bin
+project.properties


### PR DESCRIPTION
This file is autogenerated when building nowadays.
