### PR TITLE
Enable x86 assembly by default if building for x86 android

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -18,6 +18,7 @@ else
     GCCPATHPREFIX = x86
     GCCPREFIX = i686-linux-android
     APP_ABI = x86
+    USE_ASM = Yes
 ifeq (Yes, $(USE_ASM))
     ASM = nasm
     CFLAGS += -DX86_ASM


### PR DESCRIPTION
Most users would probably miss enabling it otherwise.

It can still be disabled manually by passing USE_ASM=No on the
make command line.
