### PR TITLE
Actually use the parameters set in SEncParamBase/SEncParamExt

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -409,7 +409,7 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
             pCodingParam.sSpatialLayers[iIdxSpatial].sSliceCfg.sSliceArgument.uiSliceMbNum,	// confirmed_safe_unsafe_usage
             kiLesserSliceNum * sizeof (uint32_t)) ;
 
-    pDlp->iDLayerQp = SVC_QUALITY_BASE_QP;
+    pDlp->iDLayerQp = pCodingParam.sSpatialLayers[iIdxSpatial].iDLayerQp;
 
     uiProfileIdc	= PRO_SCALABLE_BASELINE;
     ++ pDlp;


### PR DESCRIPTION
Some of the parameters were not copied to all target fields in ParamBaseTranscode, and some parameters were completely ignored in ParamTranscode.
