### PR TITLE
cast to uint32_t in GET_WORD to prevent possible left shift error.

### DIFF
--- a/codec/decoder/core/inc/dec_golomb.h
+++ b/codec/decoder/core/inc/dec_golomb.h
@@ -57,7 +57,7 @@ namespace WelsDec {
   if (iReadBytes > iAllowedBytes+1) { \
     return ERR_INFO_READ_OVERFLOW; \
   } \
-	iCurBits |= ((pBufPtr[0] << 8) | pBufPtr[1]) << (iLeftBits); \
+	iCurBits |= ((uint32_t)((pBufPtr[0] << 8) | pBufPtr[1])) << (iLeftBits); \
 	iLeftBits -= 16; \
 	pBufPtr +=2; \
 }


### PR DESCRIPTION
add cast to uint32_t to left shift.
detailed review request could be seen via:
https://rbcommons.com/s/OpenH264/r/109/
