### PR TITLE
Remove the iUsageType field from encoder parameter structs

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -177,7 +177,6 @@ typedef struct {
 /* SVC Encoding Parameters */
 typedef struct TagEncParamBase{
 
-  int       iUsageType;	//enable_screen_content_signal;// 0: //camera video signal; 1: screen content signal;
   int		iInputCsp;	// color space of input sequence
 
   int		iPicWidth;			// width of picture in samples
@@ -191,7 +190,6 @@ typedef struct TagEncParamBase{
 
 typedef struct TagEncParamExt
 {
-  int       iUsageType;	//application type;// 0: //camera video signal; 1: screen content signal;
   int		iInputCsp;	// color space of input sequence
 
   int		iPicWidth;			// width of picture in samples

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -201,7 +201,6 @@ void FillDefault (const bool kbEnableRc) {
 
   iMaxQp = 51;
   iMinQp = 0;
-  iUsageType = 0;
   memset(sDependencyLayers,0,sizeof(SDLayerParam)*MAX_DEPENDENCY_LAYER);
 
 
@@ -277,7 +276,6 @@ int32_t ParamBaseTranscode (const SEncParamBase& pCodingParam, const bool kbEnab
    return 0;
 }
 void GetBaseParams (SEncParamBase* pCodingParam) {
-  pCodingParam->iUsageType     = iUsageType;
   pCodingParam->iInputCsp      = iInputCsp;
   pCodingParam->iPicWidth      = iPicWidth;
   pCodingParam->iPicHeight     = iPicHeight;


### PR DESCRIPTION
The field is never actually used for anything.
