### PR TITLE
Use -dynamiclib instead of -shared for building shared libraries on OS X

### DIFF
--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -1,6 +1,7 @@
 include build/platform-x86-common.mk
 ASM = nasm
 SHAREDLIBSUFFIX = dylib
+SHARED = -dynamiclib
 CFLAGS += -Wno-deprecated-declarations -Werror -fPIC -DMACOS -DMT_ENABLED -MMD -MP
 LDFLAGS += -lpthread
 ASMFLAGS += --prefix _ -DNOPREFIX


### PR DESCRIPTION
Older toolchains don't recognize the -shared parameter.
