### PR TITLE
Don't install 32 bit zlib in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ compiler:
   - clang
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq nasm g++-4.6-multilib gcc-multilib libc6-dev-i386 lib32z1-dev
+  - sudo apt-get install -qq nasm g++-4.6-multilib gcc-multilib libc6-dev-i386
 install: make gtest-bootstrap
 script: make -B ENABLE64BIT=Yes && make test && make -B ENABLE64BIT=Yes BUILDTYPE=Debug && make test && make -B ENABLE64BIT=No && make test && make -B ENABLE64BIT=No BUILDTYPE=Debug && make test


### PR DESCRIPTION
It shouldn't be necessary for anything in the build.
