### PR TITLE
remove unused codes in reference picture management

### DIFF
--- a/codec/decoder/core/inc/manage_dec_ref.h
+++ b/codec/decoder/core/inc/manage_dec_ref.h
@@ -47,16 +47,10 @@
 
 namespace WelsDec {
 
-typedef enum TagRemoveFlag {
-REMOVE_TARGET = 0,
-REMOVE_BASE = 1,
-REMOVE_BASE_FIRST = 2
-} ERemoveFlag;
-
 void  WelsResetRefPic (PWelsDecoderContext pCtx);
 int32_t WelsInitRefList (PWelsDecoderContext pCtx, int32_t iPoc);
 int32_t WelsReorderRefList (PWelsDecoderContext pCtx);
-int32_t WelsMarkAsRef (PWelsDecoderContext pCtx, const bool kbRefBaseMarkingFlag);
+int32_t WelsMarkAsRef (PWelsDecoderContext pCtx);
 
 } // namespace WelsDec
 

--- a/codec/decoder/core/inc/picture.h
+++ b/codec/decoder/core/inc/picture.h
@@ -67,7 +67,6 @@ bool		bAvailableFlag;	// indicate whether it is available in this picture memory
 uint8_t		uiTemporalId;
 uint8_t		uiSpatialId;
 uint8_t		uiQualityId;
-bool		bRefBaseFlag;
 
 int32_t		iFrameNum;		// frame number			//for ref pic management
 int32_t		iLongTermFrameIdx;					//id for long term ref pic


### PR DESCRIPTION
remove unused codes related to SVC syntax in internal decoder for reference picture management.
detailed review request can be seen via:
https://rbcommons.com/s/OpenH264/r/121/
