### PR TITLE
Provide a no-op WelsEmms macro if X86_ASM is disabled

### DIFF
--- a/codec/common/cpu.h
+++ b/codec/common/cpu.h
@@ -74,6 +74,8 @@ void     WelsXmmRegStore(void * src);
 void     WelsXmmRegLoad(void * src);
 #endif
 
+#else
+#define WelsEmms()
 #endif
 
 void     WelsXmmRegEmptyOp(void * pSrc);

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2948,9 +2948,7 @@ int32_t WelsEncoderEncodeParameterSets (sWelsEncCtx* pCtx, void* pDst) {
   pCtx->eLastNalPriority      = NRI_PRI_HIGHEST;
   pFbi->iLayerNum             = 1;
 
-#if defined(X86_ASM)
   WelsEmms();
-#endif //X86_ASM
 
   return ENC_RETURN_SUCCESS;
 }
@@ -3609,9 +3607,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
   pCtx->eLastNalPriority	= eNalRefIdc;
   pFbi->iLayerNum			= iLayerNum;
 
-#if defined(X86_ASM)
   WelsEmms();
-#endif //X86_ASM
 
   pFbi->eOutputFrameType = eFrameType;
   return ENC_RETURN_SUCCESS;

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -59,9 +59,7 @@
 #include "crt_util_safe_x.h"	// for safe crt like calls
 #include "rc.h"
 
-#if defined(X86_ASM)
 #include "cpu.h"
-#endif//X86_ASM
 
 #include "measure_time.h"
 namespace WelsSVCEnc {
@@ -123,9 +121,7 @@ void CalcSliceComplexRatio (void* pRatio, SSliceCtx* pSliceCtx, uint32_t* pSlice
   const int32_t kiSliceCount	= pSliceCtx->iSliceNumInFrame;
   int32_t iSliceIdx			= 0;
 
-#if defined(X86_ASM)
   WelsEmms();
-#endif //X86_ASM
 
   while (iSliceIdx < kiSliceCount) {
     fAvI[iSliceIdx]	= 1.0f * pCountMbInSlice[iSliceIdx] / pSliceTime[iSliceIdx];
@@ -149,9 +145,7 @@ int32_t NeedDynamicAdjust (void* pConsumeTime, const int32_t iSliceNum) {
   int32_t iSliceIdx		= 0;
   int32_t iNeedAdj		= false;
 
-#if defined(X86_ASM)
   WelsEmms();
-#endif //X86_ASM
 
   while (iSliceIdx < iSliceNum) {
     uiTotalConsume += pSliceConsume[iSliceIdx] + pSliceConsume[1 + iSliceIdx];
@@ -235,9 +229,7 @@ void DynamicAdjustSlicing (sWelsEncCtx* pCtx,
 
   iMaximalMbNum	= kiCountNumMb - (kiCountSliceNum - 1) * iMinimalMbNum;
 
-#if defined(X86_ASM)
   WelsEmms();
-#endif //X86_ASM
 
 #if defined(ENABLE_TRACE_MT)
   WelsLog (pCtx, WELS_LOG_DEBUG, "[MT] DynamicAdjustSlicing(), iDid= %d, iCountNumMb= %d\n", iCurDid, kiCountNumMb);


### PR DESCRIPTION
This allows always calling this function, reducing the number
of ifdefs in the calling code.
