### PR TITLE
Avoid overflow when populating a struct timespec

### DIFF
--- a/codec/common/WelsThreadLib.cpp
+++ b/codec/common/WelsThreadLib.cpp
@@ -330,8 +330,9 @@ WELS_THREAD_ERROR_CODE    WelsEventWaitWithTimeOut (WELS_EVENT* event, uint32_t 
 
     gettimeofday (&tv, 0);
 
-    ts.tv_sec = tv.tv_sec + dwMilliseconds / 1000;
-    ts.tv_nsec = tv.tv_usec * 1000 + (dwMilliseconds % 1000) * 1000000;
+    ts.tv_nsec = tv.tv_usec * 1000 + dwMilliseconds * 1000000;
+    ts.tv_sec = tv.tv_sec + ts.tv_nsec / 1000000000;
+    ts.tv_nsec %= 1000000000;
 
     return sem_timedwait (event, &ts);
 #endif//__APPLE__


### PR DESCRIPTION
When adding the (dwMilliseconds % 1000) \* 1000000 part
to ts.tv_nsec, the ts.tv_nsec field can grow larger than one
whole second. Therefore first add all of dwMilliseconds to
the tv_nsec field and add all whole seconds to the tv_sec
field instead - this way we make sure that the tv_nsec field
actually is less than a second.
