### PR TITLE
Fix cropping when using SEncParamBase

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -266,10 +266,10 @@ int32_t ParamBaseTranscode (const SEncParamBase& pCodingParam, const bool kbEnab
     pDlp->sRecFileName[0]	= '\0';	// file to be constructed
 #endif//ENABLE_FRAME_DUMP
    pDlp->iActualWidth = sSpatialLayers[iIdxSpatial].iVideoWidth = iPicWidth;
-   pDlp->iFrameWidth =  WELS_ALIGN(pDlp->iActualWidth, MB_WIDTH_LUMA);
+   pDlp->iFrameWidth = pDlp->iActualWidth;
 
   pDlp->iActualHeight = sSpatialLayers[iIdxSpatial].iVideoHeight = iPicHeight;
-  pDlp->iFrameHeight =  WELS_ALIGN(pDlp->iActualHeight, MB_HEIGHT_LUMA);
+  pDlp->iFrameHeight = pDlp->iActualHeight;
 
     pDlp->iSpatialBitrate	=
 		sSpatialLayers[iIdxSpatial].iSpatialBitrate = pCodingParam.iTargetBitrate;	// target bitrate for current spatial layer

--- a/test/encoder_test.cpp
+++ b/test/encoder_test.cpp
@@ -73,7 +73,7 @@ static const EncodeFileParam kFileParamArray[] = {
   },
   {
       "res/Static_152_100.yuv",
-      "a004c7410a78bfe00af65ae7071ce1c485cf036e", 152, 100, 6.0f
+      "af5c6a41b567ce1b2cb6fd427f4379473d3b829f", 152, 100, 6.0f
   },
 };
 


### PR DESCRIPTION
The iFrameWidth/iFrameHeight fields are already aligned by the
SetActualPicResolution() function. Previously when iFrameWidth was
aligned directly in ParamBaseTranscode, this aligned value was used
to set iActualWidth/iActualHeight - losing the original, cropped
size.

This makes sure the output bitstream from the test of encoding
res/Static_152_100.yuv actually is cropped as it should.
