### PR TITLE
Use gtest functions for comparing hash strings

### DIFF
--- a/test/decode_encode_test.cpp
+++ b/test/decode_encode_test.cpp
@@ -99,7 +99,7 @@ TEST_P(DecodeEncodeTest, CompareOutput) {
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
   if (!HasFatalFailure()) {
-    ASSERT_TRUE(CompareHash(digest, p.hashStr));
+    CompareHash(digest, p.hashStr);
   }
 }
 

--- a/test/decoder_test.cpp
+++ b/test/decoder_test.cpp
@@ -57,7 +57,7 @@ TEST_P(DecoderOutputTest, CompareOutput) {
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
   if (!HasFatalFailure()) {
-    ASSERT_TRUE(CompareHash(digest, p.hashStr));
+    CompareHash(digest, p.hashStr);
   }
 }
 

--- a/test/encoder_test.cpp
+++ b/test/encoder_test.cpp
@@ -58,7 +58,7 @@ TEST_P(EncoderOutputTest, CompareOutput) {
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
   if (!HasFatalFailure()) {
-    ASSERT_TRUE(CompareHash(digest, p.hashStr));
+    CompareHash(digest, p.hashStr);
   }
 }
 

--- a/test/utils/HashFunctions.h
+++ b/test/utils/HashFunctions.h
@@ -3,15 +3,16 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <gtest/gtest.h>
 #include "../sha1.h"
 
-static bool CompareHash(const unsigned char* digest, const char* hashStr) {
+static void CompareHash(const unsigned char* digest, const char* hashStr) {
   char hashStrCmp[SHA_DIGEST_LENGTH * 2 + 1];
   for (int i = 0; i < SHA_DIGEST_LENGTH; ++i) {
     sprintf(&hashStrCmp[i*2], "%.2x", digest[i]);
   }
   hashStrCmp[SHA_DIGEST_LENGTH * 2] = '\0';
-  return strncmp(hashStr, hashStrCmp, SHA_DIGEST_LENGTH * 2) == 0;
+  EXPECT_STREQ(hashStr, hashStrCmp);
 }
 
 #endif //__HASHFUNCTIONS_H__


### PR DESCRIPTION
This prints the mismatched strings if the test failed,
simplifying managing and updating the test suite.
