### PR TITLE
Unify ifdef conditions related to threading code

### DIFF
--- a/codec/common/WelsThreadLib.cpp
+++ b/codec/common/WelsThreadLib.cpp
@@ -184,7 +184,7 @@ WELS_THREAD_ERROR_CODE    WelsQueryLogicalProcessInfo (WelsLogicalProcessInfo* p
   return WELS_THREAD_ERROR_OK;
 }
 
-#elif   defined(__GNUC__)
+#else
 
 void WelsSleep (uint32_t dwMilliseconds) {
   usleep (dwMilliseconds * 1000);	// microseconds

--- a/codec/common/WelsThreadLib.h
+++ b/codec/common/WelsThreadLib.h
@@ -62,8 +62,6 @@ typedef    HANDLE                    WELS_EVENT;
 
 #else	// NON-WINDOWS
 
-#if defined(__GNUC__) // LINUX, MACOS etc
-
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
@@ -86,8 +84,6 @@ typedef   sem_t                     WELS_EVENT;
 #define   WELS_THREAD_ROUTINE_TYPE         void *
 #define   WELS_THREAD_ROUTINE_RETURN(rc)   return (void*)(intptr_t)rc;
 
-#endif//__GNUC__
-
 #endif//_WIN32
 
 typedef    int32_t        WELS_THREAD_ERROR_CODE;
@@ -109,10 +105,10 @@ WELS_THREAD_ERROR_CODE    WelsMutexLock (WELS_MUTEX*    mutex);
 WELS_THREAD_ERROR_CODE    WelsMutexUnlock (WELS_MUTEX* mutex);
 WELS_THREAD_ERROR_CODE    WelsMutexDestroy (WELS_MUTEX* mutex);
 
-#ifdef __GNUC__
+#ifndef _WIN32
 WELS_THREAD_ERROR_CODE    WelsEventOpen (WELS_EVENT** p_event, const char* event_name);
 WELS_THREAD_ERROR_CODE    WelsEventClose (WELS_EVENT* event, const char* event_name);
-#endif//__GNUC__
+#endif//!_WIN32
 WELS_THREAD_ERROR_CODE    WelsEventInit (WELS_EVENT* event);
 WELS_THREAD_ERROR_CODE    WelsEventDestroy (WELS_EVENT* event);
 WELS_THREAD_ERROR_CODE    WelsEventSignal (WELS_EVENT* event);

--- a/codec/encoder/core/inc/mt_defs.h
+++ b/codec/encoder/core/inc/mt_defs.h
@@ -102,9 +102,9 @@ WELS_EVENT*					pSliceCodedEvent[MAX_THREADS_NUM];// events for slice coded stat
 WELS_EVENT*					pReadySliceCodingEvent[MAX_THREADS_NUM];	// events for slice coding ready, [iThreadIdx]
 #endif//_WIN32
 
-#if defined(__GNUC__)
+#if !defined(_WIN32)
 WELS_THREAD_HANDLE*			pUpdateMbListThrdHandles;	// thread handles for update mb list thread, [iThreadIdx]
-#endif//__GNUC__
+#endif//!_WIN32
 #ifdef _WIN32
 WELS_EVENT*					pUpdateMbListEvent;		// signal to update mb list neighbor for various slices
 WELS_EVENT*					pFinUpdateMbListEvent;	// signal to indicate finish updating mb list

--- a/codec/encoder/core/inc/slice_multi_threading.h
+++ b/codec/encoder/core/inc/slice_multi_threading.h
@@ -75,9 +75,9 @@ void ReleaseMtResource (sWelsEncCtx** ppCtx);
 int32_t AppendSliceToFrameBs (sWelsEncCtx* pCtx, SLayerBSInfo* pLbi, const int32_t kiSliceCount);
 int32_t WriteSliceToFrameBs (sWelsEncCtx* pCtx, SLayerBSInfo* pLbi, uint8_t* pFrameBsBuffer, const int32_t iSliceIdx, int32_t& iSliceSize);
 
-#if defined(__GNUC__)
+#if !defined(_WIN32)
 WELS_THREAD_ROUTINE_TYPE UpdateMbListThreadProc (void* arg);
-#endif//__GNUC__
+#endif//!_WIN32
 
 WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg);
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2171,7 +2171,7 @@ void WelsUninitEncoderExt (sWelsEncCtx** ppCtx) {
       WelsMultipleEventsWaitAllBlocking (iThreadCount, & (*ppCtx)->pSliceThreading->pFinSliceCodingEvent[0]);
 
     }
-#elif defined(__GNUC__)
+#else
     while (iThreadIdx < iThreadCount) {
       int res = 0;
       if ((*ppCtx)->pSliceThreading->pThreadHandles[iThreadIdx]) {
@@ -3300,7 +3300,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
             } else {
               WelsSleep (1);
             }
-#else//__GNUC__
+#else
             // TODO for pthread platforms
             // alternate implementation using blocking due non-blocking with timeout mode not support at wels thread lib, tune back if available
             WelsMultipleEventsWaitAllBlocking (iNumThreadsRunning, &pCtx->pSliceThreading->pSliceCodedEvent[0]);


### PR DESCRIPTION
The two different variants of the threadlib basically are
win32 and unix - use _WIN32 to check for this consistently,
instead of occasionally using __GNUC__ to enable the unix
codepath. (**GNUC** is also defined on mingw, which still is
a windows platform and should use the _WIN32 code.)
