### PR TITLE
refine frame_idx maitain in encoding

### DIFF
--- a/codec/encoder/core/inc/encoder_context.h
+++ b/codec/encoder/core/inc/encoder_context.h
@@ -151,7 +151,6 @@ typedef struct TagWelsEncCtx {
   // Derived
   int32_t						iCodingIndex;
   int32_t						iFrameIndex;			// count how many frames elapsed during coding context currently
-  uint32_t					uiFrameIdxRc;           //only for RC
   int32_t						iFrameNum;				// current frame number coding
   int32_t						iPOC;					// frame iPOC
   EWelsSliceType				eSliceType;			// currently coding slice type

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -213,11 +213,7 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
   InitBits (&pEncCtx->pOut->sBsWrite, pEncCtx->pOut->pBsBuffer, pEncCtx->pOut->uiSize);
 
   if (keFrameType == WELS_FRAME_TYPE_P) {
-    if (pEncCtx->pSvcParam->uiIntraPeriod) {
-      ++pEncCtx->iFrameIndex;
-    }
-
-    ++pEncCtx->uiFrameIdxRc;
+    ++pEncCtx->iFrameIndex;
 
     if (pEncCtx->iPOC < (1 << pEncCtx->pSps->iLog2MaxPocLsb) - 2)     // if iPOC type is no 0, this need be modification
       pEncCtx->iPOC			+= 2;	// for POC type 0
@@ -237,16 +233,11 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
     pEncCtx->iFrameNum		= 0;
     pEncCtx->iPOC			= 0;
     pEncCtx->bEncCurFrmAsIdrFlag = false;
-    if (pEncCtx->pSvcParam->uiIntraPeriod) {
-      pEncCtx->iFrameIndex = 0;
-    }
-    pEncCtx->uiFrameIdxRc = 0;
+    pEncCtx->iFrameIndex = 0;
 
     pEncCtx->eNalType		= NAL_UNIT_CODED_SLICE_IDR;
     pEncCtx->eSliceType	= I_SLICE;
     pEncCtx->eNalPriority	= NRI_PRI_HIGHEST;
-
-    pEncCtx->iCodingIndex	= 0;
 
     // reset_ref_list
 
@@ -286,7 +277,7 @@ EFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum) {
   // perform scene change detection
   if ((!pSvcParam->bEnableSceneChangeDetect) || pEncCtx->pVaa->bIdrPeriodFlag ||
       (kiSpatialNum < pSvcParam->iSpatialLayerNum)
-      || (pEncCtx->uiFrameIdxRc < (VGOP_SIZE << 1))) { // avoid too frequent I frame coding, rc control
+      || (pEncCtx->iFrameIndex < (VGOP_SIZE << 1))) { // avoid too frequent I frame coding, rc control
     bSceneChangeFlag = false;
   } else {
     bSceneChangeFlag = pEncCtx->pVaa->bSceneChangeFlag;

--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -678,7 +678,7 @@ void RcTraceFrameBits (sWelsEncCtx* pEncCtx) {
 
   WelsLog (pEncCtx, WELS_LOG_INFO,
            "[Rc] encoding_qp%d, qp = %3d, index = %8d, iTid = %1d, used = %8d, target = %8d, remaingbits = %8d\n",
-           pEncCtx->uiDependencyId, pWelsSvcRc->iAverageFrameQp, pEncCtx->uiFrameIdxRc, pEncCtx->uiTemporalId,
+           pEncCtx->uiDependencyId, pWelsSvcRc->iAverageFrameQp, pEncCtx->iFrameIndex, pEncCtx->uiTemporalId,
            pWelsSvcRc->iFrameDqBits,
            pWelsSvcRc->iTargetBits, pWelsSvcRc->iRemainingBits);
 }


### PR DESCRIPTION
it does not make sense to maintain iFrameIdx and uiFrameIdxRc both.   only one is enough.  

Review: 
https://rbcommons.com/s/OpenH264/r/137
