### PR TITLE
add timestamp in encoder interface --- review request#138 

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -287,6 +287,7 @@ typedef struct {
   SLayerBSInfo	sLayerInfo[MAX_LAYER_NUM_OF_FRAME];
 
   int eOutputFrameType;
+  long long uiTimeStamp;
 } SFrameBSInfo, *PFrameBSInfo;
 
 typedef struct Source_Picture_s {
@@ -295,6 +296,7 @@ typedef struct Source_Picture_s {
   unsigned char*  pData[4];		// plane pData
   int  		iPicWidth;				// luma picture width in x coordinate
   int 		iPicHeight;				// luma picture height in y coordinate
+  long long uiTimeStamp;
 } SSourcePicture;
 
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2998,7 +2998,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
 
   pCtx->iEncoderError						= ENC_RETURN_SUCCESS;
   pFbi->iLayerNum	= 0;	// for initialization
-
+  pFbi->uiTimeStamp = pSrcPic->uiTimeStamp;
   // perform csc/denoise/downsample/padding, generate spatial layers
   iSpatialNum = pCtx->pVpp->BuildSpatialPicList (pCtx, &pSrcPic, 1);
   if (iSpatialNum < 1) {	// skip due to temporal layer settings (different frame rate)


### PR DESCRIPTION
add timestamp parameter in encoder interface, which will be used in delay output case. the application doesn't need to keep each frame timestamp.
