### PR TITLE
Use a standard macro for 64 bit printf conversion specifiers

### DIFF
--- a/codec/common/typedefs.h
+++ b/codec/common/typedefs.h
@@ -44,7 +44,9 @@
 
 #ifndef  _MSC_VER
 
+#define __STDC_FORMAT_MACROS
 #include <stdint.h>
+#include <inttypes.h>
 
 #else
 
@@ -57,6 +59,7 @@ typedef int              int32_t ;
 typedef unsigned int     uint32_t;
 typedef __int64          int64_t ;
 typedef unsigned __int64 uint64_t;
+#define PRId64 "I64d"
 
 #endif // _MSC_VER defined
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3248,11 +3248,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
           t_bs_append = WelsTime() - t_bs_append;
           if (pCtx->pSliceThreading->pFSliceDiff) {
             fprintf (pCtx->pSliceThreading->pFSliceDiff,
-#if defined(_WIN32)
-                     "%6I64d us consumed at AppendSliceToFrameBs() for coding_idx: %d iDid: %d qid: %d\n",
-#else
-                     "%6lld us consumed at AppendSliceToFrameBs() for coding_idx: %d iDid: %d qid: %d\n",
-#endif//WIN32
+                     "%6"PRId64" us consumed at AppendSliceToFrameBs() for coding_idx: %d iDid: %d qid: %d\n",
                      t_bs_append, pCtx->iCodingIndex, iCurDid, 0);
           }
 #endif//MT_DEBUG

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -1234,11 +1234,7 @@ int32_t AdjustBaseLayer (sWelsEncCtx* pCtx) {
   iT0 = WelsTime() - iT0;
   if (pCtx->pSliceThreading->pFSliceDiff) {
     fprintf (pCtx->pSliceThreading->pFSliceDiff,
-#ifdef _WIN32
-             "%6I64d us adjust time at base spatial layer, iNeedAdj %d, DynamicAdjustSlicing()\n",
-#else
-             "%6lld us adjust time at base spatial layer, iNeedAdj %d, DynamicAdjustSlicing()\n",
-#endif//WIN32
+             "%6"PRId64" us adjust time at base spatial layer, iNeedAdj %d, DynamicAdjustSlicing()\n",
              iT0, iNeedAdj);
   }
 #endif//MT_DEBUG
@@ -1285,11 +1281,7 @@ int32_t AdjustEnhanceLayer (sWelsEncCtx* pCtx, int32_t iCurDid) {
   iT1 = WelsTime() - iT1;
   if (pCtx->pSliceThreading->pFSliceDiff) {
     fprintf (pCtx->pSliceThreading->pFSliceDiff,
-#ifdef _WIN32
-             "%6I64d us adjust time at spatial layer %d, iNeedAdj %d, DynamicAdjustSlicing()\n",
-#else
-             "%6lld us adjust time at spatial layer %d, iNeedAdj %d, DynamicAdjustSlicing()\n",
-#endif//WIN32
+             "%6"PRId64" us adjust time at spatial layer %d, iNeedAdj %d, DynamicAdjustSlicing()\n",
              iT1, iCurDid, iNeedAdj);
   }
 #endif//MT_DEBUG


### PR DESCRIPTION
This avoids duplicating the printf line with an ifdef every
time a 64 bit number needs to be printed.
