### PR TITLE
get cpu cores for android

### DIFF
--- a/codec/common/cpu.cpp
+++ b/codec/common/cpu.cpp
@@ -216,7 +216,7 @@ void WelsXmmRegEmptyOp(void * pSrc) {
 
 #if defined(HAVE_NEON)//For supporting both android platform and iOS platform
 #if defined(ANDROID_NDK)
-uint32_t WelsCPUFeatureDetectAndroid()
+uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors)
 {
   uint32_t         uiCPU = 0;
   AndroidCpuFamily cpuFamily = ANDROID_CPU_FAMILY_UNKNOWN;
@@ -234,6 +234,11 @@ uint32_t WelsCPUFeatureDetectAndroid()
       uiCPU |= WELS_CPU_NEON;
     }
   }
+
+  if( pNumberOfLogicProcessors != NULL ){
+    *pNumberOfLogicProcessors = android_getCpuCount();
+  }
+
   return uiCPU;
 }
 

--- a/codec/common/cpu.h
+++ b/codec/common/cpu.h
@@ -82,7 +82,9 @@ void     WelsXmmRegEmptyOp(void * pSrc);
 
 #if defined(HAVE_NEON)
 #if defined(ANDROID_NDK)
-	uint32_t WelsCPUFeatureDetectAndroid();
+
+uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors);
+
 #endif
 
 #if defined(APPLE_IOS)

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -148,7 +148,7 @@ void WelsDecoderDefaults (PWelsDecoderContext pCtx) {
   pCtx->uiCpuFlag = WelsCPUFeatureDetect (&iCpuCores);
 #elif defined(HAVE_NEON)
 #if defined(ANDROID_NDK)
-  pCtx->uiCpuFlag	= WelsCPUFeatureDetectAndroid();
+  pCtx->uiCpuFlag	= WelsCPUFeatureDetect(&iCpuCores);
 #endif
 #if defined(APPLE_IOS)
   pCtx->uiCpuFlag	= WelsCPUFeatureDetectIOS();


### PR DESCRIPTION
let cpu feature detect function be same with X86 and can get cpu cores. 
  if cpu feature functio in iOS can be  same with the X86 and android, it can bring simplification when calling  

Review: 
https://rbcommons.com/s/OpenH264/r/143/
