### PR TITLE
Mark the arm asm labels as functions

### DIFF
--- a/codec/common/arm_arch_common_macro.S
+++ b/codec/common/arm_arch_common_macro.S
@@ -45,6 +45,7 @@ _$0:
 .align 2
 .arm
 .global \funcName
+.type \funcName, %function
 \funcName:
 .endm
 


### PR DESCRIPTION
This fixes calling them from thumb code, on linux.
