### PR TITLE
Do a blocking wait with WelsMultipleEventsWaitSingleBlocking

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3280,7 +3280,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
 
             lwait = WelsMultipleEventsWaitSingleBlocking (iNumThreadsScheduled,
                     &pCtx->pSliceThreading->pSliceCodedEvent[0],
-                    2);	// 2 ms for one tick
+                    (uint32_t) -1);
             iEventId = (int32_t) (lwait - WELS_THREAD_ERROR_WAIT_OBJECT_0);
             if (iEventId >= 0 && iEventId < iNumThreadsScheduled) {
               if (iIndexOfSliceToBeCoded < iSliceCount) {
@@ -3293,8 +3293,6 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
               } else {	// no other slices left for coding
                 -- iNumThreadsRunning;
               }
-            } else {
-              WelsSleep (1);
             }
 #else
             // TODO for pthread platforms


### PR DESCRIPTION
There is no point in doing a timed wait here - there's no work
that we can do if the wait timed out, and sleeping for 1 ms
inbetween doesn't help, it only adds potential extra latency
to reacting to threads that need more work to do.

This uses (uint32_t)-1 instead of INFINITE because it's in common code (not in the threadlib code itslef) and will be shared with the unix codepath later.
