### PR TITLE
Exclude assembly files that are used as headers

### DIFF
--- a/build/mktargets.sh
+++ b/build/mktargets.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 python build/mktargets.py --directory codec/decoder --library decoder
 python build/mktargets.py --directory codec/encoder --library encoder --exclude DllEntry.cpp
-python build/mktargets.py --directory codec/common --library common
+python build/mktargets.py --directory codec/common --library common --exclude asm_inc.asm
 python build/mktargets.py --directory codec/processing --library processing
 
 python build/mktargets.py --directory codec/console/dec --binary h264dec

--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -10,7 +10,6 @@ COMMON_OBJS += $(COMMON_CPP_SRCS:.cpp=.o)
 
 ifeq ($(ASM_ARCH), x86)
 COMMON_ASM_SRCS=\
-	$(COMMON_SRCDIR)/asm_inc.asm\
 	$(COMMON_SRCDIR)/cpuid.asm\
 	$(COMMON_SRCDIR)/deblock.asm\
 	$(COMMON_SRCDIR)/expand_picture.asm\


### PR DESCRIPTION
This avoids some warnings about object files not containing any
symbols.
