### PR TITLE
Exclude the arm assembly header as well

### DIFF
--- a/build/mktargets.sh
+++ b/build/mktargets.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 python build/mktargets.py --directory codec/decoder --library decoder
 python build/mktargets.py --directory codec/encoder --library encoder --exclude DllEntry.cpp
-python build/mktargets.py --directory codec/common --library common --exclude asm_inc.asm
+python build/mktargets.py --directory codec/common --library common --exclude asm_inc.asm --exclude arm_arch_common_macro.S
 python build/mktargets.py --directory codec/processing --library processing
 
 python build/mktargets.py --directory codec/console/dec --binary h264dec

--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -24,7 +24,6 @@ endif
 
 ifeq ($(ASM_ARCH), arm)
 COMMON_ASM_S_SRCS=\
-	$(COMMON_SRCDIR)/arm_arch_common_macro.S\
 	$(COMMON_SRCDIR)/deblocking_neon.S\
 
 COMMON_OBJS += $(COMMON_ASM_S_SRCS:.S=.o)


### PR DESCRIPTION
This avoids warnings about object files not containing any symbols.
