### PR TITLE
Fix building android on x86

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -1,4 +1,5 @@
 ARCH = arm
+include build/platform-arch.mk
 SHAREDLIBSUFFIX = so
 GCCVERSION = 4.8
 NDKLEVEL = 12
@@ -12,8 +13,6 @@ ifeq ($(ARCH), arm)
     LDFLAGS += -march=armv7-a -Wl,--fix-cortex-a8
     APP_ABI = armeabi-v7a
   ifeq (Yes, $(USE_ASM))
-    ASM_ARCH = arm
-    CFLAGS += -DHAVE_NEON
     ASMFLAGS += -march=armv7-a -mfpu=neon
   endif
 else
@@ -21,9 +20,7 @@ else
     GCCPREFIX = i686-linux-android
     APP_ABI = x86
   ifeq (Yes, $(USE_ASM))
-    ASM_ARCH = x86
-    CFLAGS += -DX86_ASM
-    ASMFLAGS += -DNOPREFIX -f elf32 -DX86_32
+    ASMFLAGS += -DNOPREFIX -f elf32
   endif
 endif
 


### PR DESCRIPTION
In 70360cb11, the ASM variable was moved to the x86-common file
even though the android build file didn't include neither
platform-arch.mk nor platform-x86-common.mk.

Instead of explicitly declaring ASM here, include platform-arch.mk
and remove setting of the flags that platform-arch.mk sets.

This is inspired by and based on a patch by Licai Guo.
