### PR TITLE
fix bug of re-allocate memory for small-size SPS

### DIFF
--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -252,9 +252,6 @@ typedef struct TagWelsDecoderContext {
   int32_t				iCsStride[3];		// strides for Cs
   int32_t				iRsStride[3];		// strides for Rs
 
-  int32_t             iPicWidthReq;		// picture width have requested the memory
-  int32_t             iPicHeightReq;		// picture height have requested the memory
-
   uint8_t				uiTargetDqId;		// maximal DQ ID in current access unit, meaning target layer ID
   bool				bAvcBasedFlag;		// For decoding bitstream:
   bool				bEndOfStreamFlag;	// Flag on end of stream requested by external application layer

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -912,11 +912,6 @@ int32_t InitialDqLayersContext (PWelsDecoderContext pCtx, const int32_t kiMaxWid
   pCtx->sMb.iMbWidth		= (kiMaxWidth + 15) >> 4;
   pCtx->sMb.iMbHeight		= (kiMaxHeight + 15) >> 4;
 
-  if (pCtx->bInitialDqLayersMem && kiMaxWidth <= pCtx->iPicWidthReq
-      && kiMaxHeight <= pCtx->iPicHeightReq)	// have same dimension memory, skipped
-    return ERR_NONE;
-
-
   UninitialDqLayersContext (pCtx);
 
   do {
@@ -1014,8 +1009,6 @@ int32_t InitialDqLayersContext (PWelsDecoderContext pCtx, const int32_t kiMaxWid
 
 
   pCtx->bInitialDqLayersMem	= true;
-  pCtx->iPicWidthReq			= kiMaxWidth;
-  pCtx->iPicHeightReq			= kiMaxHeight;
 
   return ERR_NONE;
 }
@@ -1169,8 +1162,6 @@ void UninitialDqLayersContext (PWelsDecoderContext pCtx) {
     ++ i;
   } while (i < LAYER_NUM_EXCHANGEABLE);
 
-  pCtx->iPicWidthReq			= 0;
-  pCtx->iPicHeightReq			= 0;
   pCtx->bInitialDqLayersMem	= false;
 }
 


### PR DESCRIPTION
remove the error-remaining logic and variables to make sure active SPS is used.
It should fix the issue #373 
review request can be seen via:
https://rbcommons.com/s/OpenH264/r/153/
