### PR TITLE
Use the cpu-features NDK library for detecting the number of cores in WelsThreadLib

### DIFF
--- a/codec/common/WelsThreadLib.cpp
+++ b/codec/common/WelsThreadLib.cpp
@@ -55,6 +55,9 @@
 #define HW_NCPU_NAME "hw.ncpu"
 #endif
 #endif
+#ifdef ANDROID_NDK
+#include <cpu-features.h>
+#endif
 
 #include "WelsThreadLib.h"
 #include <stdio.h>
@@ -414,7 +417,10 @@ WELS_THREAD_ERROR_CODE    WelsMultipleEventsWaitAllBlocking (uint32_t nCount, WE
 }
 
 WELS_THREAD_ERROR_CODE    WelsQueryLogicalProcessInfo (WelsLogicalProcessInfo* pInfo) {
-#ifdef LINUX
+#ifdef ANDROID_NDK
+  pInfo->ProcessorCount = android_getCpuCount();
+  return WELS_THREAD_ERROR_OK;
+#elif defined(LINUX)
 
   cpu_set_t cpuset;
 


### PR DESCRIPTION
On arm, the exact same detection is done in WelsCPUFeatureDetect,
but in the x86 version of that function we use x86 cpuid for getting
the core count, and this is not available on all processors. For the
case when cpuid can't tell the core count, use the NDK function as
higher level API.

The thread lib itself doesn't build properly on android yet, but will
do so soon.
