### PR TITLE
Use SliceModeEnum as data type for the slice mode fields

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -163,7 +163,7 @@ typedef enum {
 } SliceModeEnum;
 
 typedef struct {
-  unsigned int uiSliceMode; //by default, uiSliceMode will be 0
+  SliceModeEnum uiSliceMode; //by default, uiSliceMode will be SM_SINGLE_SLICE
   SSliceArgument sSliceArgument;
 } SSliceConfig;
 

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -164,7 +164,7 @@ int ParseLayerConfig( CReadConfig cRdLayerCfg, const int iLayer, SEncParamExt& p
       } else if (strTag[0].compare ("InitialQP") == 0) {
         sLayerCtx.iDLayerQp	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("SliceMode") == 0) {
-        sLayerCtx.sSliceCfg.uiSliceMode	= (SliceMode)atoi (strTag[1].c_str());
+        sLayerCtx.sSliceCfg.uiSliceMode	= (SliceModeEnum)atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("SliceSize") == 0) { //SM_DYN_SLICE
         sLayerCtx.sSliceCfg.sSliceArgument.uiSliceSizeConstraint	= atoi (strTag[1].c_str());
         continue;
@@ -601,7 +601,7 @@ int FillSpecificParameters (SEncParamExt& sParam) {
   sParam.sSpatialLayers[iIndexLayer].fFrameRate	= 7.5f;
   sParam.sSpatialLayers[iIndexLayer].iSpatialBitrate		= 64000;
 #ifdef MT_ENABLED
-  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = 0;
+  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
 #endif
 
   ++ iIndexLayer;
@@ -610,7 +610,7 @@ int FillSpecificParameters (SEncParamExt& sParam) {
   sParam.sSpatialLayers[iIndexLayer].fFrameRate	= 15.0f;
   sParam.sSpatialLayers[iIndexLayer].iSpatialBitrate		= 160000;
 #ifdef MT_ENABLED
-  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = 0;
+  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
 #endif
 
   ++ iIndexLayer;
@@ -619,7 +619,7 @@ int FillSpecificParameters (SEncParamExt& sParam) {
   sParam.sSpatialLayers[iIndexLayer].fFrameRate	= 30.0f;
   sParam.sSpatialLayers[iIndexLayer].iSpatialBitrate		= 512000;
 #ifdef MT_ENABLED
-  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = 0;
+  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
   sParam.sSpatialLayers[iIndexLayer].sSliceCfg.sSliceArgument.uiSliceNum = 1;
 #endif
 
@@ -629,7 +629,7 @@ int FillSpecificParameters (SEncParamExt& sParam) {
   sParam.sSpatialLayers[iIndexLayer].fFrameRate	= 30.0f;
   sParam.sSpatialLayers[iIndexLayer].iSpatialBitrate		= 1500000;
 #ifdef MT_ENABLED
-  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = 0;
+  sParam.sSpatialLayers[iIndexLayer].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
   sParam.sSpatialLayers[iIndexLayer].sSliceCfg.sSliceArgument.uiSliceNum = 1;
 #endif
 

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -190,7 +190,7 @@ static void FillDefault (SEncParamExt& param, const bool kbEnableRc) {
 
   param.sSpatialLayers[0].iDLayerQp = SVC_QUALITY_BASE_QP;
   param.sSpatialLayers[0].fFrameRate = param.fMaxFrameRate;
-  param.sSpatialLayers[0].sSliceCfg.uiSliceMode = 0;
+  param.sSpatialLayers[0].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
   param.sSpatialLayers[0].sSliceCfg.sSliceArgument.uiSliceSizeConstraint = 1500;
   param.sSpatialLayers[0].sSliceCfg.sSliceArgument.uiSliceNum = 1;
 
@@ -221,7 +221,7 @@ void FillDefault (const bool kbEnableRc) {
 
 
   //init multi-slice
-   sDependencyLayers[0].sSliceCfg.uiSliceMode = 0;
+   sDependencyLayers[0].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
    sDependencyLayers[0].sSliceCfg.sSliceArgument.uiSliceSizeConstraint    = 1500;
    sDependencyLayers[0].sSliceCfg.sSliceArgument.uiSliceNum      = 1;
 
@@ -406,7 +406,7 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
 
 
     //multi slice
-    pDlp->sSliceCfg.uiSliceMode = (SliceMode)pCodingParam.sSpatialLayers[iIdxSpatial].sSliceCfg.uiSliceMode;
+    pDlp->sSliceCfg.uiSliceMode = pCodingParam.sSpatialLayers[iIdxSpatial].sSliceCfg.uiSliceMode;
     pDlp->sSliceCfg.sSliceArgument.uiSliceSizeConstraint
       = (uint32_t) (pCodingParam.sSpatialLayers[iIdxSpatial].sSliceCfg.sSliceArgument.uiSliceSizeConstraint);
     pDlp->sSliceCfg.sSliceArgument.uiSliceNum

--- a/codec/encoder/core/inc/svc_enc_slice_segment.h
+++ b/codec/encoder/core/inc/svc_enc_slice_segment.h
@@ -47,10 +47,6 @@
 
 #include "codec_app_def.h"
 namespace WelsSVCEnc {
-/*!
- * \brief	SSlice mode
- */
-typedef uint16_t SliceMode;
 
 
 // NOTE:
@@ -77,7 +73,7 @@ typedef uint16_t SliceMode;
  */
 /* Single/multiple slices */
 typedef struct SlicepEncCtx_s {
-SliceMode		uiSliceMode;			/* 0: single slice in frame; 1: multiple slices in frame; */
+SliceModeEnum		uiSliceMode;			/* 0: single slice in frame; 1: multiple slices in frame; */
 int16_t			iMbWidth;			/* width of picture size in mb */
 int16_t			iMbHeight;			/* height of picture size in mb */
 int16_t			iSliceNumInFrame;	/* count number of slices in frame; */

--- a/codec/encoder/core/src/svc_enc_slice_segment.cpp
+++ b/codec/encoder/core/src/svc_enc_slice_segment.cpp
@@ -340,7 +340,7 @@ int32_t InitSliceSegment (SSliceCtx* pSliceSeg,
                           const int32_t kiMbWidth,
                           const int32_t kiMbHeight) {
   const int32_t kiCountMbNum = kiMbWidth * kiMbHeight;
-  SliceMode uiSliceMode = SM_SINGLE_SLICE;
+  SliceModeEnum uiSliceMode = SM_SINGLE_SLICE;
 
   if (NULL == pSliceSeg || NULL == pMso || kiMbWidth == 0 || kiMbHeight == 0)
     return 1;


### PR DESCRIPTION
This makes the use of the field clearer and safer by allowing
the compiler check that users actually assign proper enum
values.
