### PR TITLE
Explicitly sort the files in mktargets.py

### DIFF
--- a/build/mktargets.py
+++ b/build/mktargets.py
@@ -104,6 +104,11 @@ except:
 
 (cpp, asm, cfiles, sfiles) = find_sources()
 
+cpp = sorted(cpp, key=lambda s: s.lower())
+asm = sorted(asm, key=lambda s: s.lower())
+cfiles = sorted(cfiles, key=lambda s: s.lower())
+sfiles = sorted(sfiles, key=lambda s: s.lower())
+
 
 
 f = open(OUTFILE, "w")


### PR DESCRIPTION
This avoids spurious changes to the targets.mk files when mktargets
is rerun on different platforms and different file systems.

In particular, OS X seems to mostly return files sorted
alphabetically, case insensitively, while they are returned in
a file system specific order on linux.
