### PR TITLE
Add missing defines when building the encoder for iOS using the xcode project files

### DIFF
--- a/codec/build/iOS/common/common.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/common/common.xcodeproj/project.pbxproj
@@ -385,8 +385,12 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = (
 					APPLE_IOS,
 					HAVE_NEON,
+					MT_ENABLED,
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = APPLE_IOS;
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
+					APPLE_IOS,
+					MT_ENABLED,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
@@ -407,8 +411,12 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = (
 					APPLE_IOS,
 					HAVE_NEON,
+					MT_ENABLED,
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = APPLE_IOS;
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
+					APPLE_IOS,
+					MT_ENABLED,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/codec/build/iOS/enc/welsenc/welsenc.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/enc/welsenc/welsenc.xcodeproj/project.pbxproj
@@ -636,10 +636,12 @@
 					APPLE_IOS,
 					NO_DYNAMIC_VP,
 					HAVE_NEON,
+					MT_ENABLED,
 				);
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
 					APPLE_IOS,
 					NO_DYNAMIC_VP,
+					MT_ENABLED,
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../../common",
@@ -669,10 +671,12 @@
 					APPLE_IOS,
 					NO_DYNAMIC_VP,
 					HAVE_NEON,
+					MT_ENABLED,
 				);
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
 					APPLE_IOS,
 					NO_DYNAMIC_VP,
+					MT_ENABLED,
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../../common",


### PR DESCRIPTION
Add missing NO_DYNAMIC_VP when building for the simulator, enable multithreading.
