### PR TITLE
Set the arch to armv7 by default when building for iOS

### DIFF
--- a/build/platform-ios.mk
+++ b/build/platform-ios.mk
@@ -1,3 +1,4 @@
+ARCH = armv7
 include build/platform-darwin.mk
 CXX = clang++
 CC = clang


### PR DESCRIPTION
Otherwise it would build for the simulator by default, which
in most cases probably isn't what was intended.
