### PR TITLE
Include time.h in the MemoryAlloc test

### DIFF
--- a/test/EncUT_MemoryAlloc.cpp
+++ b/test/EncUT_MemoryAlloc.cpp
@@ -1,5 +1,6 @@
 #include "../gtest/include/gtest/gtest.h"
 #include <string.h>		// use memset/memcmp
+#include <time.h>
 #include "../codec/encoder/core/inc/memory_align.h"
 
 using namespace WelsSVCEnc;


### PR DESCRIPTION
This is required to get the time() function. This fixes building
on older MSVC versions.
