### PR TITLE
Remove a dubious/unnecessary workaround for an issue in a nonstandard toolchain

### DIFF
--- a/codec/build/android/dec/jni/Android.mk
+++ b/codec/build/android/dec/jni/Android.mk
@@ -1,9 +1,5 @@
 ## yongzxu: refine mk files for android platform
 
-#To fix the bug that Intel NDK can't creat directory
-$(shell mkdir -p $(TARGET_OBJS)/cpufeatures)
-$(shell mkdir -p $(TARGET_OBJS)/welsdecdemo)
-
 LOCAL_PATH := $(call my-dir)
 MY_LOCAL_PATH := $(LOCAL_PATH)
 

--- a/codec/build/android/enc/jni/Android.mk
+++ b/codec/build/android/enc/jni/Android.mk
@@ -1,9 +1,5 @@
 ## yongzxu: refine mk files for android platform
 
-#To fix the bug that Intel NDK can't creat directory
-$(shell mkdir -p $(TARGET_OBJS)/cpufeatures)
-$(shell mkdir -p $(TARGET_OBJS)/welsdecdemo)
-
 LOCAL_PATH := $(call my-dir)
 MY_LOCAL_PATH := $(LOCAL_PATH)
 


### PR DESCRIPTION
There's no requirement to work with the Intel NDK. The NDK build
files don't even need to create any cpufeatures subdirectory since
all of the cpufeatures library is handled within the normal build
system. Finally, the encoder makefile tried to create a directory
for "welsdecdemo", not anything for "welsencdemo".

Thus, if this really was necessary, it would already have been noticed
that it missed an entry for "welsencdemo". Therefore, remove this
hack/workaround.
