### PR TITLE
Mark the stack as non-executable in the arm assembly

### DIFF
--- a/codec/common/arm_arch_common_macro.S
+++ b/codec/common/arm_arch_common_macro.S
@@ -45,6 +45,8 @@ mov pc, lr
 #else
 
 .syntax unified
+.section .note.GNU-stack,"",%progbits // Mark stack as non-executable
+.text
 
 .macro WELS_ASM_FUNC_BEGIN funcName
 .align 2


### PR DESCRIPTION
Otherwise the linker is forced to enable an executable stack for
executables that the code is linked into.
