### PR TITLE
fix encode crash

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -849,7 +849,7 @@ int ProcessEncodingSvcWithConfig (ISVCEncoder* pPtrEnc, int argc, char** argv) {
 
   memset (&sFbi, 0, sizeof (SFrameBSInfo));
   memset (&sSvcParam, 0, sizeof (SEncParamExt));
-  memset (&fs,0,sizeof(SFilesSet));
+  memset (&fs.sRecFileName[0][0],0,sizeof(fs.sRecFileName));
   sSvcParam.iInputCsp	= videoFormatI420;	// I420 in default
   sSvcParam.sSpatialLayers[0].uiProfileIdc	= PRO_BASELINE;
 //	svc_cfg->sDependencyLayers[0].frext_mode	= 0;


### PR DESCRIPTION
just want to fix one issue it will cause encode crash (issue#477)
after fix it,  h264enc welscfg can work well on MAC, but still crash on linux.  

the SFileSet is structure but it contain C++ STL string objects.  the string can initialize it self, it need not to be memset.  and it is danger to memset on objects.  
