### PR TITLE
fix double free crash in encoder

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -105,7 +105,7 @@ static void    SigIntHandler (int a) {
 }
 static int     g_LevelSetting = 0;
 
-int ParseLayerConfig( CReadConfig cRdLayerCfg, const int iLayer, SEncParamExt& pSvcParam )
+int ParseLayerConfig( CReadConfig & cRdLayerCfg, const int iLayer, SEncParamExt& pSvcParam )
 {
   if (!cRdLayerCfg.ExistFile()) {
     fprintf (stderr, "Unabled to open layer #%d configuration file: %s.\n", iLayer, cRdLayerCfg.GetFileName().c_str());


### PR DESCRIPTION
fix another issue it will cause encode crash(Issue #477)

int ParseLayerConfig( CReadConfig cRdLayerCfg, const int iLayer, SEncParamExt& pSvcParam )

the cRdLayerCfg is passed by copy construct to a new object, but it do not handle the resource well, so it will cause double free and crash.    replace the object pass by reference, so it can work well on Linux.  

Thanks licaiguo here.  
