### PR TITLE
Check for the right function pointer

### DIFF
--- a/codec/encoder/core/src/svc_base_layer_md.cpp
+++ b/codec/encoder/core/src/svc_base_layer_md.cpp
@@ -473,7 +473,7 @@ int32_t WelsMdI4x4 (void* pEnc, void* pMd, SMB* pCurMb, SMbCache* pMbCache) {
     iBestCost = INT_MAX;
     iBestMode = kpAvailMode[0];
 
-    if (pFunc->sSampleDealingFuncs.pfIntra4x4Combined3Satd && (iAvailCount >= 6)) {
+    if (pFunc->sSampleDealingFuncs.pfIntra4x4Combined3 && (iAvailCount >= 6)) {
       pDst = &pMbCache->pMemPredBlk4[iBestPredBufferNum << 4];
 
       iBestCost = pFunc->sSampleDealingFuncs.pfIntra4x4Combined3 (pCurDec, kiLineSizeDec, pCurEnc, kiLineSizeEnc, pDst,


### PR DESCRIPTION
This code checked whether one function pointer was non-null,
but the went on to call a different function pointer. Check
for the one that actually was called.
