### PR TITLE
Add encoder tests with deblocking and/or denoising

### DIFF
--- a/test/BaseEncoderTest.cpp
+++ b/test/BaseEncoderTest.cpp
@@ -6,8 +6,8 @@
 #include "BaseEncoderTest.h"
 
 static int InitWithParam(ISVCEncoder* encoder, int width,
-    int height, float frameRate, SliceModeEnum sliceMode) {
-  if (SM_SINGLE_SLICE == sliceMode) {
+    int height, float frameRate, SliceModeEnum sliceMode, bool denoise, int deblock) {
+  if (SM_SINGLE_SLICE == sliceMode && !denoise && deblock == 1) {
     SEncParamBase param;
     memset (&param, 0, sizeof(SEncParamBase));
 
@@ -27,6 +27,8 @@ static int InitWithParam(ISVCEncoder* encoder, int width,
     param.iPicHeight = height;
     param.iTargetBitrate = 5000000;
     param.iInputCsp = videoFormatI420;
+    param.bEnableDenoise = denoise;
+    param.iLoopFilterDisableIdc = deblock;
 
     param.sSpatialLayers[0].iVideoWidth = width;
     param.sSpatialLayers[0].iVideoHeight = height;
@@ -55,8 +57,8 @@ void BaseEncoderTest::TearDown() {
 }
 
 void BaseEncoderTest::EncodeStream(InputStream* in, int width, int height,
-    float frameRate, SliceModeEnum slices, Callback* cbk) {
-  int rv = InitWithParam(encoder_, width, height, frameRate, slices);
+    float frameRate, SliceModeEnum slices, bool denoise, int deblock, Callback* cbk) {
+  int rv = InitWithParam(encoder_, width, height, frameRate, slices, denoise, deblock);
   ASSERT_TRUE(rv == cmResultSuccess);
 
   // I420: 1(Y) + 1/4(U) + 1/4(V)
@@ -89,8 +91,8 @@ void BaseEncoderTest::EncodeStream(InputStream* in, int width, int height,
 }
 
 void BaseEncoderTest::EncodeFile(const char* fileName, int width, int height,
-    float frameRate, SliceModeEnum slices, Callback* cbk) {
+    float frameRate, SliceModeEnum slices, bool denoise, int deblock, Callback* cbk) {
   FileInputStream fileStream;
   ASSERT_TRUE(fileStream.Open(fileName));
-  EncodeStream(&fileStream, width, height, frameRate, slices, cbk);
+  EncodeStream(&fileStream, width, height, frameRate, slices, denoise, deblock, cbk);
 }

--- a/test/BaseEncoderTest.h
+++ b/test/BaseEncoderTest.h
@@ -14,8 +14,8 @@ class BaseEncoderTest {
   BaseEncoderTest();
   void SetUp();
   void TearDown();
-  void EncodeFile(const char* fileName, int width, int height, float frameRate, SliceModeEnum slices, Callback* cbk);
-  void EncodeStream(InputStream* in, int width, int height, float frameRate, SliceModeEnum slices, Callback* cbk);
+  void EncodeFile(const char* fileName, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int deblock, Callback* cbk);
+  void EncodeStream(InputStream* in, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int deblock, Callback* cbk);
 
  private:
   ISVCEncoder* encoder_;

--- a/test/decode_encode_test.cpp
+++ b/test/decode_encode_test.cpp
@@ -95,7 +95,7 @@ TEST_P(DecodeEncodeTest, CompareOutput) {
   DecodeEncodeFileParam p = GetParam();
 
   ASSERT_TRUE(Open(p.fileName));
-  EncodeStream(this, p.width, p.height, p.frameRate, SM_SINGLE_SLICE, this);
+  EncodeStream(this, p.width, p.height, p.frameRate, SM_SINGLE_SLICE, false, 1, this);
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
   if (!HasFatalFailure()) {

--- a/test/encoder_test.cpp
+++ b/test/encoder_test.cpp
@@ -32,6 +32,8 @@ struct EncodeFileParam {
   int height;
   float frameRate;
   SliceModeEnum slices;
+  bool denoise;
+  int deblocking;
 };
 
 class EncoderOutputTest : public ::testing::WithParamInterface<EncodeFileParam>,
@@ -54,7 +56,7 @@ class EncoderOutputTest : public ::testing::WithParamInterface<EncodeFileParam>,
 
 TEST_P(EncoderOutputTest, CompareOutput) {
   EncodeFileParam p = GetParam();
-  EncodeFile(p.fileName, p.width, p.height, p.frameRate, p.slices, this);
+  EncodeFile(p.fileName, p.width, p.height, p.frameRate, p.slices, p.denoise, p.deblocking, this);
 
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
@@ -66,19 +68,27 @@ TEST_P(EncoderOutputTest, CompareOutput) {
 static const EncodeFileParam kFileParamArray[] = {
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "06441376891cbc237a36e59b62131cd94ff9cb19", 320, 192, 12.0f, SM_SINGLE_SLICE
+      "06441376891cbc237a36e59b62131cd94ff9cb19", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/CiscoVT2people_160x96_6fps.yuv",
-      "4f3759fc44125b27a179ebff158dbba9e431bd0b", 160, 96, 6.0f, SM_SINGLE_SLICE
+      "4f3759fc44125b27a179ebff158dbba9e431bd0b", 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/Static_152_100.yuv",
-      "af5c6a41b567ce1b2cb6fd427f4379473d3b829f", 152, 100, 6.0f, SM_SINGLE_SLICE
+      "af5c6a41b567ce1b2cb6fd427f4379473d3b829f", 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "be0079b022b18fdce04570db24e4327ca26a0ecb", 320, 192, 12.0f, SM_ROWMB_SLICE // One slice per MB row
+      "be0079b022b18fdce04570db24e4327ca26a0ecb", 320, 192, 12.0f, SM_ROWMB_SLICE, false, 1 // One slice per MB row
+  },
+  {
+      "res/CiscoVT2people_320x192_12fps.yuv",
+      "f4649601ca15f9693671d7e161e9daa8efd3a7a1", 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1
+  },
+  {
+      "res/CiscoVT2people_320x192_12fps.yuv",
+      "e4bcd744d2e6f885f6c0dbe5d52818ba64d986d9", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 0
   },
 };
 


### PR DESCRIPTION
This increases the coverage of assembly routines (and encoder
features in general) tested by the codec unit test.

https://rbcommons.com/s/OpenH264/r/197/
