### PR TITLE
Format x86 assembly constants in a yasm compatible manner

### DIFF
--- a/codec/decoder/core/asm/dct.asm
+++ b/codec/decoder/core/asm/dct.asm
@@ -47,9 +47,9 @@
 ;*******************************************************************************
 %macro MMX_SumSubDiv2 3
     movq    %3, %2
-    psraw   %3, $1
+    psraw   %3, $01
     paddw   %3, %1
-    psraw   %1, $1
+    psraw   %1, $01
     psubw   %1, %2
 %endmacro
 
@@ -71,7 +71,7 @@
     movd       %2, %5
     punpcklbw  %2, %4
     paddw      %1, %3
-    psraw      %1, $6
+    psraw      %1, $06
     paddsw     %1, %2
     packuswb   %1, %2
     movd       %5, %1


### PR DESCRIPTION
This is similar to what was done in a6463be0cc7 - yasm requires
these constants to have a zero after $.
