### PR TITLE
Use -DPREFIX instead of --prefix _ on OS X

### DIFF
--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -4,7 +4,7 @@ SHARED = -dynamiclib
 CFLAGS += -Werror -fPIC -DMACOS -DMT_ENABLED -MMD -MP
 LDFLAGS += -lpthread
 ifeq ($(ASM_ARCH), x86)
-ASMFLAGS += --prefix _
+ASMFLAGS += -DPREFIX
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f macho64
 else


### PR DESCRIPTION
The --prefix parameter differs between yasm and nasm; nasm
requires --prefix _ while yasm requires --prefix=_. Using the
define instead (as on windows) allows easier switching between
the two otherwise mostly compatible assemblers.

This fixes building with yasm on OS X in 32 bit mode. For 64 bit,
a few more tweaks are still required.
