### PR TITLE
Indent all WELS_ASM_FUNC_BEGIN properly

### DIFF
--- a/codec/common/deblocking_neon.S
+++ b/codec/common/deblocking_neon.S
@@ -400,7 +400,7 @@ WELS_ASM_FUNC_BEGIN DeblockLumaEq4V_neon
 WELS_ASM_FUNC_END
 
 
-    WELS_ASM_FUNC_BEGIN DeblockLumaLt4H_neon
+WELS_ASM_FUNC_BEGIN DeblockLumaLt4H_neon
     vpush	{q4-q7}
 
     vdup.u8	q11, r2
@@ -654,7 +654,7 @@ WELS_ASM_FUNC_BEGIN DeblockChromaLt4V_neon
 WELS_ASM_FUNC_END
 
 
-    WELS_ASM_FUNC_BEGIN DeblockChromaEq4V_neon
+WELS_ASM_FUNC_BEGIN DeblockChromaEq4V_neon
     vpush	{q4-q5}
 
     vdup.u8	q11, r3

--- a/codec/common/mc_neon.S
+++ b/codec/common/mc_neon.S
@@ -1748,7 +1748,7 @@ w9_h_mc_luma_loop:
 WELS_ASM_FUNC_END
 
 
-    WELS_ASM_FUNC_BEGIN McHorVer02Height17_neon
+WELS_ASM_FUNC_BEGIN McHorVer02Height17_neon
 	push		{r4}
 	ldr			r4, [sp, #4]
 


### PR DESCRIPTION
By having all of them start at the start of the line, the code
is more consistent and readable.
