### PR TITLE
  modify EncoderFrame return type.

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -64,7 +64,7 @@ class ISVCEncoder {
   virtual int EXTAPI Uninitialize() = 0;
 
   /*
-   * return: EVideoFrameType [IDR: videoFrameTypeIDR; P: videoFrameTypeP; ERROR: videoFrameTypeInvalid]
+   * return: 0 - success; otherwise -failed;
    */
   virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) = 0;
   /*

--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -75,6 +75,7 @@ typedef enum {
   cmUnkonwReason,
   cmMallocMemeError,                /*Malloc a memory error*/
   cmInitExpected,			  /*Initial action is expected*/
+  cmUnsupportedData,
 } CM_RETURN;
 
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -1730,8 +1730,8 @@ int32_t InitSliceSettings (SWelsSvcCodingParam* pCodingParam, const int32_t kiCp
       break;
     case SM_AUTO_SLICE:
       iMaxSliceCount = MAX_SLICES_NUM;
-	  pDlp->sSliceCfg.sSliceArgument.uiSliceNum = kiCpuCores;
-	  if (pDlp->sSliceCfg.sSliceArgument.uiSliceNum > iMaxSliceCount){
+      pDlp->sSliceCfg.sSliceArgument.uiSliceNum = kiCpuCores;
+      if (pDlp->sSliceCfg.sSliceArgument.uiSliceNum > iMaxSliceCount){
         pDlp->sSliceCfg.sSliceArgument.uiSliceNum = iMaxSliceCount;
       }
       if (pDlp->sSliceCfg.sSliceArgument.uiSliceNum == 1) {


### PR DESCRIPTION
 review at: https://rbcommons.com/s/OpenH264/r/198/  
   error type is more meaning for EncoderFrame.
1. use error type instead of encoder type  in EncoderFrame
