### PR TITLE
Fix building with yasm in 64 bit mode

### DIFF
--- a/codec/common/asm_inc.asm
+++ b/codec/common/asm_inc.asm
@@ -337,6 +337,12 @@ BITS 32
 
 %macro SIGN_EXTENSION 2
     %ifndef X86_32
+            movsxd %1, %2
+    %endif
+%endmacro
+
+%macro SIGN_EXTENSIONW 2
+    %ifndef X86_32
             movsx %1, %2
     %endif
 %endmacro

--- a/codec/encoder/core/asm/quant.asm
+++ b/codec/encoder/core/asm/quant.asm
@@ -103,8 +103,8 @@ align 16
 WelsQuant4x4Dc_sse2:
  		%assign push_num 0
 		LOAD_3_PARA
-		SIGN_EXTENSION r1, r1w
-		SIGN_EXTENSION r2, r2w
+		SIGN_EXTENSIONW r1, r1w
+		SIGN_EXTENSIONW r2, r2w
 		SSE2_Copy8Times xmm3, r2d
 
 		SSE2_Copy8Times xmm2, r1d
@@ -199,8 +199,8 @@ align 16
 WelsHadamardQuant2x2_mmx:
 		%assign push_num 0
 		LOAD_5_PARA
-		SIGN_EXTENSION r1, r1w
-		SIGN_EXTENSION r2, r2w
+		SIGN_EXTENSIONW r1, r1w
+		SIGN_EXTENSIONW r2, r2w
 		movd		mm0,			[r0]
 		movd		mm1,			[r0 + 0x20]
 		punpcklwd	mm0,			mm1
@@ -257,8 +257,8 @@ align 16
 WelsHadamardQuant2x2Skip_mmx:
 		%assign push_num 0
 		LOAD_3_PARA
-		SIGN_EXTENSION r1, r1w
-		SIGN_EXTENSION r2, r2w
+		SIGN_EXTENSIONW r1, r1w
+		SIGN_EXTENSIONW r2, r2w
 		movd		mm0,			[r0]
 		movd		mm1,			[r0 + 0x20]
 		punpcklwd	mm0,			mm1


### PR DESCRIPTION
Use movsxd in SIGN_EXTENSION

This is what nasm ended up assembling movsx with 32 bit input to
anyway.

Keep using plain movsx for 16 bit input.

This fixes building with yasm in 64 bit mode.
