### PR TITLE
Enable the arm assembly in msvc-arm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Building the Library
 --------------------
 NASM needed to be installed for assembly code: workable version 2.07 or above, nasm can downloaded from http://www.nasm.us/
 
+To build the arm assembly for Windows Phone, gas-preprocessor is required. It can be downloaded from git://git.libav.org/gas-preprocessor.git
+
 For Android Builds
 ------------------
 To build for android platform, You need to install android sdk and ndk. You also need to export **ANDROID_SDK**/tools to PATH. On Linux, this can be done by

--- a/build/platform-msvc-arm.mk
+++ b/build/platform-msvc-arm.mk
@@ -1,5 +1,7 @@
 include build/platform-msvc-common.mk
+ARCH=arm
+include build/platform-arch.mk
 CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -MD -DWIN32
 LDFLAGS +=
-USE_ASM = No
+CCAS = gas-preprocessor.pl -as-type armasm -force-thumb -- armasm
 


### PR DESCRIPTION
This requires using the external gas-preprocessor tool that
converts the gnu assembler format sources to armasm format at
build time. This allows keeping the source files in one single
format but only converting while building.
