### PR TITLE
Remove an unused error code

### DIFF
--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -69,9 +69,6 @@ typedef enum {
 typedef enum {
   cmResultSuccess,
   cmInitParaError,                  /*Parameters are invalid */
-  cmMachPerfIsBad,                  /*The performance of machine is not enough to support
-									    H264 CODEC, in this case, suggestion user use h263
-										or set fps to low like 5fps or more low*/
   cmUnkonwReason,
   cmMallocMemeError,                /*Malloc a memory error*/
   cmInitExpected,			  /*Initial action is expected*/


### PR DESCRIPTION
I don't see this error code being useful - working slowly hardly
would be a reason for the library to return and fail to do what
it was asked to do, so normal functions would never actually return
this code.
