### PR TITLE
        use the same frame type EVideoFrameType in encoder internal

### DIFF
--- a/codec/encoder/core/inc/encoder.h
+++ b/codec/encoder/core/inc/encoder.h
@@ -81,9 +81,9 @@ int32_t InitFunctionPointers (SWelsFuncPtrList* pFuncList, SWelsSvcCodingParam* 
 /*!
  * \brief	initialize frame coding
  */
-void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType);
+void InitFrameCoding (sWelsEncCtx* pEncCtx, const EVideoFrameType keFrameType);
 
-EFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum);
+EVideoFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum);
 /*!
  * \brief	Dump reconstruction for dependency layer
  */

--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -90,7 +90,7 @@ void WelsUninitEncoderExt (sWelsEncCtx** ppCtx);
  * \param	h			sWelsEncCtx*, encoder context
  * \param	pFbi			FrameBSInfo*
  * \param	kpSrcPic		Source picture
- * \return	EFrameType (WELS_FRAME_TYPE_IDR/WELS_FRAME_TYPE_I/WELS_FRAME_TYPE_P)
+ * \return	EFrameType (videoFrameTypeIDR/videoFrameTypeI/videoFrameTypeP)
  */
 int32_t WelsEncoderEncodeExt (sWelsEncCtx*, SFrameBSInfo * pFbi, const SSourcePicture* kpSrcPic);
 

--- a/codec/encoder/core/inc/wels_common_basis.h
+++ b/codec/encoder/core/inc/wels_common_basis.h
@@ -137,17 +137,6 @@ extern const EVclType g_keTypeMap[32][2];
 #define IS_VCL_NAL_AVC_BASE(t)			( (t) == NAL_UNIT_CODED_SLICE || (t) == NAL_UNIT_CODED_SLICE_IDR )
 #define IS_NEW_INTRODUCED_SVC_NAL(t)	( (t) == NAL_UNIT_PREFIX || (t) == NAL_UNIT_CODED_SLICE_EXT )
 
-/*
- *	Frame types used in internal encoder (logic level based)
- */
-enum EFrameType {
-WELS_FRAME_TYPE_AUTO	= 0x0000,	/* Let encoder engine choose the proper type, RDO or scene change based */
-WELS_FRAME_TYPE_IDR		= 0x0001,	/* IDR, I frame with parameter sets */
-WELS_FRAME_TYPE_I		= 0x0002,	/* I Frame */
-WELS_FRAME_TYPE_P		= 0x0003,	/* P Frame */
-WELS_FRAME_TYPE_B		= 0x0004,	/* B Frame */
-WELS_FRAME_TYPE_SKIP	= 0x0008
-};
 
 /* Base SSlice Types
  * Invalid in case of eSliceType exceeds 9,

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -213,14 +213,14 @@ int32_t InitFunctionPointers (SWelsFuncPtrList* pFuncList, SWelsSvcCodingParam* 
 /*!
  * \brief	initialize frame coding
  */
-void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
+void InitFrameCoding (sWelsEncCtx* pEncCtx, const EVideoFrameType keFrameType) {
   // for bitstream writing
   pEncCtx->iPosBsBuffer		= 0;	// reset bs pBuffer position
   pEncCtx->pOut->iNalIndex		= 0;	// reset NAL index
 
   InitBits (&pEncCtx->pOut->sBsWrite, pEncCtx->pOut->pBsBuffer, pEncCtx->pOut->uiSize);
 
-  if (keFrameType == WELS_FRAME_TYPE_P) {
+  if (keFrameType == videoFrameTypeP) {
     ++pEncCtx->iFrameIndex;
 
     if (pEncCtx->iPOC < (1 << pEncCtx->pSps->iLog2MaxPocLsb) - 2)     // if iPOC type is no 0, this need be modification
@@ -237,7 +237,7 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
     pEncCtx->eNalType		= NAL_UNIT_CODED_SLICE;
     pEncCtx->eSliceType	= P_SLICE;
     pEncCtx->eNalPriority	= NRI_PRI_HIGH;
-  } else if (keFrameType == WELS_FRAME_TYPE_IDR) {
+  } else if (keFrameType == videoFrameTypeIDR) {
     pEncCtx->iFrameNum		= 0;
     pEncCtx->iPOC			= 0;
     pEncCtx->bEncCurFrmAsIdrFlag = false;
@@ -252,7 +252,7 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
     // reset_ref_list
 
     // rc_init_gop
-  } else if (keFrameType == WELS_FRAME_TYPE_I) {
+  } else if (keFrameType == videoFrameTypeI) {
     if (pEncCtx->iPOC < (1 << pEncCtx->pSps->iLog2MaxPocLsb) - 2)     // if iPOC type is no 0, this need be modification
       pEncCtx->iPOC			+= 2;	// for POC type 0
     else
@@ -279,9 +279,9 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EFrameType keFrameType) {
 #endif//FRAME_INFO_OUTPUT
 }
 
-EFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum) {
+EVideoFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum) {
   SWelsSvcCodingParam* pSvcParam	= pEncCtx->pSvcParam;
-  EFrameType iFrameType = WELS_FRAME_TYPE_AUTO;
+  EVideoFrameType iFrameType = videoFrameTypeInvalid;
   bool bSceneChangeFlag = false;
 
   // perform scene change detection
@@ -297,12 +297,12 @@ EFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum) {
   //bIdrPeriodFlag: RC disable || iSpatialNum != pSvcParam->iSpatialLayerNum
   //pEncCtx->bEncCurFrmAsIdrFlag: 1. first frame should be IDR; 2. idr pause; 3. idr request
   iFrameType = (pEncCtx->pVaa->bIdrPeriodFlag || bSceneChangeFlag
-                || pEncCtx->bEncCurFrmAsIdrFlag) ? WELS_FRAME_TYPE_IDR : WELS_FRAME_TYPE_P;
+                || pEncCtx->bEncCurFrmAsIdrFlag) ? videoFrameTypeIDR : videoFrameTypeP;
 
-  if (WELS_FRAME_TYPE_P == iFrameType && pEncCtx->iSkipFrameFlag > 0) {  // for frame skip, 1/5/2010
+  if (videoFrameTypeP == iFrameType && pEncCtx->iSkipFrameFlag > 0) {  // for frame skip, 1/5/2010
     -- pEncCtx->iSkipFrameFlag;
-    iFrameType = WELS_FRAME_TYPE_SKIP;
-  } else if (WELS_FRAME_TYPE_IDR == iFrameType) {
+    iFrameType = videoFrameTypeSkip;
+  } else if (videoFrameTypeIDR == iFrameType) {
     pEncCtx->iCodingIndex = 0;
   }
 

--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -621,7 +621,7 @@ void WelsUpdateRefSyntax (sWelsEncCtx* pCtx, const int32_t iPOC, const int32_t u
     }
 
     /*syntax for dec_ref_pic_marking()*/
-    if (WELS_FRAME_TYPE_IDR == uiFrameType)		{
+    if (videoFrameTypeIDR == uiFrameType)		{
       pRefPicMark->bNoOutputOfPriorPicsFlag = false;
       pRefPicMark->bLongTermRefFlag = pCtx->pSvcParam->bEnableLongTermReference;
     } else {


### PR DESCRIPTION
review at: https://rbcommons.com/s/OpenH264/r/230/
1. remove EFrameType which is only used in encoder internal.
2. use EVideoFrameType in encoder internal which is same as encoder external
