### PR TITLE
Automatically pick the latest installed iOS SDK when building with make

### DIFF
--- a/build/platform-ios.mk
+++ b/build/platform-ios.mk
@@ -2,12 +2,12 @@ ARCH = armv7
 include build/platform-darwin.mk
 CXX = clang++
 CC = clang
-SDK = 7.0
 ifneq ($(filter %86 x86_64, $(ARCH)),)
 SDKTYPE = iPhoneSimulator
 else
 SDKTYPE = iPhoneOS
 endif
+SDK = $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-version)
 SDK_MIN = 5.1
 
 SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/$(SDKTYPE).platform/Developer/SDKs/$(SDKTYPE)$(SDK).sdk


### PR DESCRIPTION
This avoids having to update the makefile just to change the SDK
version whenever the iOS SDK is updated (since the previous
version is removed on updates).
