### PR TITLE
add set method for scene change detection

### DIFF
--- a/codec/processing/src/scenechangedetection/SceneChangeDetection.h
+++ b/codec/processing/src/scenechangedetection/SceneChangeDetection.h
@@ -172,6 +172,13 @@ class CSceneChangeDetection : public IStrategy {
     return RET_SUCCESS;
   }
 
+  EResult Set(int32_t iType, void * pParam) {
+    if( pParam == NULL ){
+      return RET_INVALIDPARAM;
+    }
+    m_sSceneChangeParam = *(SSceneChangeResult*)pParam;
+    return RET_SUCCESS;
+  }
  private:
   SSceneChangeResult m_sSceneChangeParam;
   T          m_cDetector;


### PR DESCRIPTION
the set method here is target to give the memory pointer to the scene change detection object,  by the compiler default copy (weak copy),   as the requirement from the algorithm, it need multiple static block idc memories for multi-reference, and the memory is maintained out of the processing module.   

Review: 
https://rbcommons.com/s/OpenH264/r/238/
