### PR TITLE
Fix Android build setting minSdkVersion

### DIFF
--- a/codec/build/android/dec/AndroidManifest.xml
+++ b/codec/build/android/dec/AndroidManifest.xml
@@ -3,6 +3,7 @@
       package="com.wels.dec"
       android:versionCode="1"
       android:versionName="1.0">
+<uses-sdk android:minSdkVersion="9"/>
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
     <application android:icon="@drawable/icon" android:label="@string/app_name">
         <activity android:name=".WelsDecTest"

--- a/codec/build/android/enc/AndroidManifest.xml
+++ b/codec/build/android/enc/AndroidManifest.xml
@@ -3,6 +3,7 @@
       package="com.wels.enc"
       android:versionCode="1"
       android:versionName="1.0">
+<uses-sdk android:minSdkVersion="9"/>
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
     <application android:icon="@drawable/icon" android:label="@string/app_name">
         <activity android:name=".WelsEncTest"


### PR DESCRIPTION
Beside changing line endings in (see: 973a16) it's also
required to set a minimum Sdk version in the manifest
