### PR TITLE
    move some common functions to common.cpp and add some functions in c...

### DIFF
--- a/codec/build/win32/enc/WelsEncCore.vcproj
+++ b/codec/build/win32/enc/WelsEncCore.vcproj
@@ -1056,6 +1056,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\common\src\sad_common.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\encoder\core\src\sample.cpp"
 				>
 			</File>
@@ -1570,6 +1574,10 @@
 			</File>
 			<File
 				RelativePath="..\..\..\encoder\core\inc\ref_list_mgr_svc.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\..\common\inc\sad_common.h"
 				>
 			</File>
 			<File

--- a/codec/common/inc/sad_common.h
+++ b/codec/common/inc/sad_common.h
@@ -1,0 +1,96 @@
+/*!
+ * \copy
+ *     Copyright (c)  2013, Cisco Systems
+ *     All rights reserved.
+ *
+ *     Redistribution and use in source and binary forms, with or without
+ *     modification, are permitted provided that the following conditions
+ *     are met:
+ *
+ *        * Redistributions of source code must retain the above copyright
+ *          notice, this list of conditions and the following disclaimer.
+ *
+ *        * Redistributions in binary form must reproduce the above copyright
+ *          notice, this list of conditions and the following disclaimer in
+ *          the documentation and/or other materials provided with the
+ *          distribution.
+ *
+ *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *     COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *     POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef WELS_SAD_COMMON_H_
+#define WELS_SAD_COMMON_H_
+
+#include "typedefs.h"
+
+
+//===================SAD=====================//
+int32_t WelsSampleSad16x16_c (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad16x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x16_c (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
+//int32_t WelsSampleSad8x4( uint8_t *, int32_t, uint8_t *, int32_t );
+//int32_t WelsSampleSad4x8( uint8_t *, int32_t, uint8_t *, int32_t );
+int32_t WelsSampleSad4x4_c (uint8_t*, int32_t, uint8_t*, int32_t);
+
+
+
+void WelsSampleSadFour16x16_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
+void WelsSampleSadFour16x8_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
+void WelsSampleSadFour8x16_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
+void WelsSampleSadFour8x8_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
+void WelsSampleSadFour4x4_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
+
+#if defined(__cplusplus)
+extern "C" {
+#endif//__cplusplus
+
+#if defined (X86_ASM)
+
+int32_t WelsSampleSad4x4_mmx (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad16x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad16x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x8_sse21 (uint8_t*, int32_t, uint8_t*, int32_t);
+
+void WelsSampleSadFour16x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour16x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour8x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour8x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour4x4_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+
+#endif//X86_ASM
+
+#if defined (HAVE_NEON)
+
+int32_t WelsSampleSad4x4_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad16x16_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad16x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x16_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+int32_t WelsSampleSad8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+
+void WelsSampleSadFour16x16_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour16x8_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour8x16_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+void WelsSampleSadFour4x4_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
+
+#endif
+
+#if defined(__cplusplus)
+}
+#endif//__cplusplus
+
+#endif //SAMPLE_H_

--- a/codec/common/src/sad_common.cpp
+++ b/codec/common/src/sad_common.cpp
@@ -1,0 +1,107 @@
+/*!
+ * \copy
+ *     Copyright (c)  2009-2013, Cisco Systems
+ *     All rights reserved.
+ *
+ *     Redistribution and use in source and binary forms, with or without
+ *     modification, are permitted provided that the following conditions
+ *     are met:
+ *
+ *        * Redistributions of source code must retain the above copyright
+ *          notice, this list of conditions and the following disclaimer.
+ *
+ *        * Redistributions in binary form must reproduce the above copyright
+ *          notice, this list of conditions and the following disclaimer in
+ *          the documentation and/or other materials provided with the
+ *          distribution.
+ *
+ *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *     COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *     POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * \file	sample.c
+ *
+ * \brief	compute SAD and SATD
+ *
+ * \date	2009.06.02 Created
+ *
+ *************************************************************************************
+ */
+
+#include "sad_common.h"
+#include "macros.h"
+
+int32_t WelsSampleSad4x4_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
+  int32_t iSadSum = 0;
+  int32_t i = 0;
+  uint8_t* pSrc1 = pSample1;
+  uint8_t* pSrc2 = pSample2;
+  for (i = 0; i < 4; i++) {
+    iSadSum += WELS_ABS ((pSrc1[0] - pSrc2[0]));
+    iSadSum += WELS_ABS ((pSrc1[1] - pSrc2[1]));
+    iSadSum += WELS_ABS ((pSrc1[2] - pSrc2[2]));
+    iSadSum += WELS_ABS ((pSrc1[3] - pSrc2[3]));
+
+    pSrc1 += iStride1;
+    pSrc2 += iStride2;
+  }
+
+  return iSadSum;
+}
+
+int32_t WelsSampleSad8x8_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
+  int32_t iSadSum = 0;
+  int32_t i = 0;
+  uint8_t* pSrc1 = pSample1;
+  uint8_t* pSrc2 = pSample2;
+  for (i = 0; i < 8; i++) {
+    iSadSum += WELS_ABS ((pSrc1[0] - pSrc2[0]));
+    iSadSum += WELS_ABS ((pSrc1[1] - pSrc2[1]));
+    iSadSum += WELS_ABS ((pSrc1[2] - pSrc2[2]));
+    iSadSum += WELS_ABS ((pSrc1[3] - pSrc2[3]));
+    iSadSum += WELS_ABS ((pSrc1[4] - pSrc2[4]));
+    iSadSum += WELS_ABS ((pSrc1[5] - pSrc2[5]));
+    iSadSum += WELS_ABS ((pSrc1[6] - pSrc2[6]));
+    iSadSum += WELS_ABS ((pSrc1[7] - pSrc2[7]));
+
+    pSrc1 += iStride1;
+    pSrc2 += iStride2;
+  }
+
+  return iSadSum;
+}
+int32_t WelsSampleSad16x8_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
+  int32_t iSadSum = 0;
+
+  iSadSum += WelsSampleSad8x8_c (pSample1,     iStride1, pSample2,     iStride2);
+  iSadSum += WelsSampleSad8x8_c (pSample1 + 8, iStride1, pSample2 + 8, iStride2);
+
+  return iSadSum;
+}
+int32_t WelsSampleSad8x16_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
+  int32_t iSadSum = 0;
+  iSadSum += WelsSampleSad8x8_c (pSample1,                   iStride1, pSample2,                   iStride2);
+  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3), iStride1, pSample2 + (iStride2 << 3), iStride2);
+
+  return iSadSum;
+}
+int32_t WelsSampleSad16x16_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
+  int32_t iSadSum = 0;
+  iSadSum += WelsSampleSad8x8_c (pSample1,                     iStride1, pSample2,                     iStride2);
+  iSadSum += WelsSampleSad8x8_c (pSample1 + 8,                   iStride1, pSample2 + 8,                   iStride2);
+  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3),   iStride1, pSample2 + (iStride2 << 3),   iStride2);
+  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3) + 8, iStride1, pSample2 + (iStride2 << 3) + 8, iStride2);
+
+  return iSadSum;
+}
+

--- a/codec/common/targets.mk
+++ b/codec/common/targets.mk
@@ -4,6 +4,7 @@ COMMON_CPP_SRCS=\
 	$(COMMON_SRCDIR)/src/crt_util_safe_x.cpp\
 	$(COMMON_SRCDIR)/src/deblocking_common.cpp\
 	$(COMMON_SRCDIR)/src/logging.cpp\
+	$(COMMON_SRCDIR)/src/sad_common.cpp\
 	$(COMMON_SRCDIR)/src/WelsThreadLib.cpp\
 
 COMMON_OBJS += $(COMMON_CPP_SRCS:.cpp=.$(OBJ))

--- a/codec/encoder/core/inc/sample.h
+++ b/codec/encoder/core/inc/sample.h
@@ -47,15 +47,6 @@ enum {
 //    BLOCK_4x8   = 6,
 };
 
-//===================SAD=====================//
-int32_t WelsSampleSad16x16_c (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad16x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x16_c (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
-//int32_t WelsSampleSad8x4( uint8_t *, int32_t, uint8_t *, int32_t );
-//int32_t WelsSampleSad4x8( uint8_t *, int32_t, uint8_t *, int32_t );
-int32_t WelsSampleSad4x4_c (uint8_t*, int32_t, uint8_t*, int32_t);
-
 //======================SATD======================//
 int32_t WelsSampleSatd16x16_c (uint8_t*, int32_t, uint8_t*, int32_t);
 int32_t WelsSampleSatd16x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
@@ -65,11 +56,6 @@ int32_t WelsSampleSatd8x8_c (uint8_t*, int32_t, uint8_t*, int32_t);
 //int32_t WelsSampleSatd4x8( uint8_t *, int32_t, uint8_t *, int32_t );
 int32_t WelsSampleSatd4x4_c (uint8_t*, int32_t, uint8_t*, int32_t);
 
-void WelsSampleSadFour16x16_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
-void WelsSampleSadFour16x8_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
-void WelsSampleSadFour8x16_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
-void WelsSampleSadFour8x8_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
-void WelsSampleSadFour4x4_c (uint8_t* iSample1, int32_t iStride1, uint8_t* iSample2, int32_t iStride2, int32_t* pSad);
 
 #if defined(__cplusplus)
 extern "C" {
@@ -77,17 +63,6 @@ extern "C" {
 
 #if defined (X86_ASM)
 
-int32_t WelsSampleSad4x4_mmx (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad16x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad16x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x8_sse21 (uint8_t*, int32_t, uint8_t*, int32_t);
-
-void WelsSampleSadFour16x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour16x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour8x16_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour8x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour4x4_sse2 (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
 
 int32_t WelsSampleSatd8x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
 int32_t WelsSampleSatd16x8_sse2 (uint8_t*, int32_t, uint8_t*, int32_t);
@@ -112,17 +87,6 @@ int32_t WelsIntraChroma8x8Combined3Satd_sse41 (uint8_t*, int32_t, uint8_t*, int3
 
 #if defined (HAVE_NEON)
 
-int32_t WelsSampleSad4x4_neon (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad16x16_neon (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad16x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x16_neon (uint8_t*, int32_t, uint8_t*, int32_t);
-int32_t WelsSampleSad8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
-
-void WelsSampleSadFour16x16_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour16x8_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour8x16_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
-void WelsSampleSadFour4x4_neon (uint8_t*, int32_t, uint8_t*, int32_t, int32_t*);
 
 int32_t WelsSampleSatd8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
 int32_t WelsSampleSatd16x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);

--- a/codec/encoder/core/src/sample.cpp
+++ b/codec/encoder/core/src/sample.cpp
@@ -39,75 +39,12 @@
  */
 
 #include "sample.h"
+#include "sad_common.h"
 
 #include "mc.h"
 #include "cpu_core.h"
 
 namespace WelsSVCEnc {
-int32_t WelsSampleSad4x4_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
-  int32_t iSadSum = 0;
-  int32_t i = 0;
-  uint8_t* pSrc1 = pSample1;
-  uint8_t* pSrc2 = pSample2;
-  for (i = 0; i < 4; i++) {
-    iSadSum += WELS_ABS ((pSrc1[0] - pSrc2[0]));
-    iSadSum += WELS_ABS ((pSrc1[1] - pSrc2[1]));
-    iSadSum += WELS_ABS ((pSrc1[2] - pSrc2[2]));
-    iSadSum += WELS_ABS ((pSrc1[3] - pSrc2[3]));
-
-    pSrc1 += iStride1;
-    pSrc2 += iStride2;
-  }
-
-  return iSadSum;
-}
-
-int32_t WelsSampleSad8x8_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
-  int32_t iSadSum = 0;
-  int32_t i = 0;
-  uint8_t* pSrc1 = pSample1;
-  uint8_t* pSrc2 = pSample2;
-  for (i = 0; i < 8; i++) {
-    iSadSum += WELS_ABS ((pSrc1[0] - pSrc2[0]));
-    iSadSum += WELS_ABS ((pSrc1[1] - pSrc2[1]));
-    iSadSum += WELS_ABS ((pSrc1[2] - pSrc2[2]));
-    iSadSum += WELS_ABS ((pSrc1[3] - pSrc2[3]));
-    iSadSum += WELS_ABS ((pSrc1[4] - pSrc2[4]));
-    iSadSum += WELS_ABS ((pSrc1[5] - pSrc2[5]));
-    iSadSum += WELS_ABS ((pSrc1[6] - pSrc2[6]));
-    iSadSum += WELS_ABS ((pSrc1[7] - pSrc2[7]));
-
-    pSrc1 += iStride1;
-    pSrc2 += iStride2;
-  }
-
-  return iSadSum;
-}
-int32_t WelsSampleSad16x8_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
-  int32_t iSadSum = 0;
-
-  iSadSum += WelsSampleSad8x8_c (pSample1,     iStride1, pSample2,     iStride2);
-  iSadSum += WelsSampleSad8x8_c (pSample1 + 8, iStride1, pSample2 + 8, iStride2);
-
-  return iSadSum;
-}
-int32_t WelsSampleSad8x16_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
-  int32_t iSadSum = 0;
-  iSadSum += WelsSampleSad8x8_c (pSample1,                   iStride1, pSample2,                   iStride2);
-  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3), iStride1, pSample2 + (iStride2 << 3), iStride2);
-
-  return iSadSum;
-}
-int32_t WelsSampleSad16x16_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
-  int32_t iSadSum = 0;
-  iSadSum += WelsSampleSad8x8_c (pSample1,                     iStride1, pSample2,                     iStride2);
-  iSadSum += WelsSampleSad8x8_c (pSample1 + 8,                   iStride1, pSample2 + 8,                   iStride2);
-  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3),   iStride1, pSample2 + (iStride2 << 3),   iStride2);
-  iSadSum += WelsSampleSad8x8_c (pSample1 + (iStride1 << 3) + 8, iStride1, pSample2 + (iStride2 << 3) + 8, iStride2);
-
-  return iSadSum;
-}
-
 int32_t WelsSampleSatd4x4_c (uint8_t* pSample1, int32_t iStride1, uint8_t* pSample2, int32_t iStride2) {
   int32_t iSatdSum = 0;
   int32_t pSampleMix[4][4] = {{ 0 }};

--- a/codec/processing/build/win32/WelsVP_2008.vcproj
+++ b/codec/processing/build/win32/WelsVP_2008.vcproj
@@ -380,6 +380,10 @@
 			UniqueIdentifier="{4FC737F1-C7A5-4376-A066-2A32D752A2FF}"
 			>
 			<File
+				RelativePath="..\..\src\common\common.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\common\src\cpu.cpp"
 				>
 			</File>
@@ -388,7 +392,7 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\..\common\src\WelsThreadLib.cpp"
+				RelativePath="..\..\..\common\src\sad_common.cpp"
 				>
 			</File>
 			<File
@@ -397,6 +401,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\common\WelsFrameWorkEx.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\..\common\src\WelsThreadLib.cpp"
 				>
 			</File>
 		</Filter>
@@ -446,6 +454,10 @@
 			Name="Header Files"
 			>
 			<File
+				RelativePath="..\..\src\common\common.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\common\inc\cpu.h"
 				>
 			</File>
@@ -454,7 +466,7 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\..\common\inc\WelsThreadLib.h"
+				RelativePath="..\..\..\common\inc\sad_common.h"
 				>
 			</File>
 			<File
@@ -467,6 +479,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\common\WelsFrameWork.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\..\common\inc\WelsThreadLib.h"
 				>
 			</File>
 		</Filter>
@@ -683,14 +699,6 @@
 			</File>
 			<File
 				RelativePath="..\..\src\scenechangedetection\SceneChangeDetection.h"
-				>
-			</File>
-			<File
-				RelativePath="..\..\src\scenechangedetection\SceneChangeDetectionCommon.cpp"
-				>
-			</File>
-			<File
-				RelativePath="..\..\src\scenechangedetection\SceneChangeDetectionCommon.h"
 				>
 			</File>
 		</Filter>

--- a/codec/processing/src/common/common.h
+++ b/codec/processing/src/common/common.h
@@ -1,6 +1,6 @@
 /*!
  * \copy
- *     Copyright (c)  2013, Cisco Systems
+ *     Copyright (c)  2011-2013, Cisco Systems
  *     All rights reserved.
  *
  *     Redistribution and use in source and binary forms, with or without
@@ -28,32 +28,42 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
+ * \file	        :  SceneChangeDetectionCommon.h
+ *
+ * \brief	    :  scene change detection class of wels video processor class
+ *
+ * \date         :  2011/03/14
+ *
+ * \description  :  1. rewrite the package code of scene change detection class
+ *
  */
 
-#include "SceneChangeDetectionCommon.h"
+#ifndef WELSVP_SCENECHANGEDETECTIONCOMMON_H
+#define WELSVP_SCENECHANGEDETECTIONCOMMON_H
+
+#include "util.h"
+#include "memory.h"
+#include "WelsFrameWork.h"
+#include "IWelsVP.h"
+#include "sad_common.h"
 
 WELSVP_NAMESPACE_BEGIN
 
+typedef  int32_t (SadFunc) (uint8_t* pSrcY, int32_t iSrcStrideY, uint8_t* pRefY, int32_t iRefStrideY);
 
-int32_t WelsSampleSad8x8_c (uint8_t* pSrcY, int32_t iSrcStrideY, uint8_t* pRefY, int32_t iRefStrideY) {
-  int32_t iSadSum = 0;
-  uint8_t* pSrcA = pSrcY;
-  uint8_t* pSrcB = pRefY;
-  for (int32_t i = 0; i < 8; i++) {
-    iSadSum += WELS_ABS ((pSrcA[0] - pSrcB[0]));
-    iSadSum += WELS_ABS ((pSrcA[1] - pSrcB[1]));
-    iSadSum += WELS_ABS ((pSrcA[2] - pSrcB[2]));
-    iSadSum += WELS_ABS ((pSrcA[3] - pSrcB[3]));
-    iSadSum += WELS_ABS ((pSrcA[4] - pSrcB[4]));
-    iSadSum += WELS_ABS ((pSrcA[5] - pSrcB[5]));
-    iSadSum += WELS_ABS ((pSrcA[6] - pSrcB[6]));
-    iSadSum += WELS_ABS ((pSrcA[7] - pSrcB[7]));
+typedef SadFunc*   SadFuncPtr;
 
-    pSrcA += iSrcStrideY;
-    pSrcB += iRefStrideY;
-  }
+typedef int32_t (Sad16x16Func) ( uint8_t * pSrcY, int32_t iSrcStrideY, uint8_t *pRefY, int32_t iRefStrideY );
+typedef Sad16x16Func      *PSad16x16Func;
 
-  return iSadSum;
-}
+typedef void (GetIntraPred)(uint8_t *pPred, uint8_t *pRef, const int32_t kiStride);
+
+typedef GetIntraPred  *GetIntraPredPtr;
+
+GetIntraPred     WelsI16x16LumaPredV_c;
+GetIntraPred     WelsI16x16LumaPredH_c;
+
 
 WELSVP_NAMESPACE_END
+
+#endif

--- a/codec/processing/src/scenechangedetection/SceneChangeDetection.h
+++ b/codec/processing/src/scenechangedetection/SceneChangeDetection.h
@@ -47,7 +47,7 @@
 #include "cpu.h"
 #include "WelsFrameWork.h"
 #include "IWelsVP.h"
-#include "SceneChangeDetectionCommon.h"
+#include "common.h"
 
 #define HIGH_MOTION_BLOCK_THRESHOLD 320
 #define SCENE_CHANGE_MOTION_RATIO_LARGE   0.85f

--- a/codec/processing/targets.mk
+++ b/codec/processing/targets.mk
@@ -2,6 +2,7 @@ PROCESSING_SRCDIR=codec/processing
 PROCESSING_CPP_SRCS=\
 	$(PROCESSING_SRCDIR)/src/adaptivequantization/AdaptiveQuantization.cpp\
 	$(PROCESSING_SRCDIR)/src/backgrounddetection/BackgroundDetection.cpp\
+	$(PROCESSING_SRCDIR)/src/common/common.cpp\
 	$(PROCESSING_SRCDIR)/src/common/memory.cpp\
 	$(PROCESSING_SRCDIR)/src/common/WelsFrameWork.cpp\
 	$(PROCESSING_SRCDIR)/src/common/WelsFrameWorkEx.cpp\
@@ -13,7 +14,6 @@ PROCESSING_CPP_SRCS=\
 	$(PROCESSING_SRCDIR)/src/imagerotate/imagerotate.cpp\
 	$(PROCESSING_SRCDIR)/src/imagerotate/imagerotatefuncs.cpp\
 	$(PROCESSING_SRCDIR)/src/scenechangedetection/SceneChangeDetection.cpp\
-	$(PROCESSING_SRCDIR)/src/scenechangedetection/SceneChangeDetectionCommon.cpp\
 	$(PROCESSING_SRCDIR)/src/vaacalc/vaacalcfuncs.cpp\
 	$(PROCESSING_SRCDIR)/src/vaacalc/vaacalculation.cpp\
 


### PR DESCRIPTION
review at https://rbcommons.com/s/OpenH264/r/252/
1. move series of SAD functions to common module, which are used in encoder/vp module.
2. keep pred function in vp/common module 
