### PR TITLE
Use the right linker output parameters for codec_unittest.exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,5 +164,6 @@ binaries: codec_unittest$(EXEEXT)
 BINARIES += codec_unittest$(EXEEXT)
 codec_unittest$(EXEEXT): $(DECODER_UNITTEST_OBJS) $(ENCODER_UNITTEST_OBJS) $(API_TEST_OBJS) $(CODEC_UNITTEST_DEPS)
 	$(QUIET)rm -f $@
-	$(QUIET_CXX)$(CXX) -o $@ $+ $(CODEC_UNITTEST_LDFLAGS) $(LDFLAGS)
+	$(QUIET_CXX)$(CXX) $(CXX_LINK_O) $+ $(CODEC_UNITTEST_LDFLAGS) $(LDFLAGS)
+
 -include $(OBJS:.$(OBJ)=.d)


### PR DESCRIPTION
This also includes the -nologo parameter to silence extra output
from the compiler/linker.

Also add a separating empty line between the codec_unittest rule
and the include for dependency rules.
