### PR TITLE
Readd a missed prototype for the WelsProcessingSampleSad8x8_neon function

### DIFF
--- a/codec/processing/src/common/common.h
+++ b/codec/processing/src/common/common.h
@@ -63,6 +63,11 @@ typedef GetIntraPred  *GetIntraPredPtr;
 GetIntraPred     WelsI16x16LumaPredV_c;
 GetIntraPred     WelsI16x16LumaPredH_c;
 
+#ifdef HAVE_NEON
+WELSVP_EXTERN_C_BEGIN
+int32_t WelsProcessingSampleSad8x8_neon (uint8_t*, int32_t, uint8_t*, int32_t);
+WELSVP_EXTERN_C_END
+#endif
 
 WELSVP_NAMESPACE_END
 


### PR DESCRIPTION
The common WelsSampleSad8x8_neon function has different alignment
requirements than WelsProcessingSampleSad8x8_neon - until it has
been sorted out that the common version can be used in the processing
lib, the separate version for processing is used.

This fixes building with neon optimizations enabled.
