### PR TITLE
Rename cpufeatures symbols to avoid colisions in static builds

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -59,5 +59,10 @@ encdemo: libraries
 COMMON_INCLUDES += -I$(NDKROOT)/sources/android/cpufeatures
 COMMON_OBJS += $(COMMON_SRCDIR)/cpu-features.$(OBJ)
 
+COMMON_CFLAGS += \
+	-Dandroid_getCpuIdArm=wels_getCpuIdArm -Dandroid_setCpuArm=wels_setCpuArm \
+	-Dandroid_getCpuCount=wels_getCpuCount -Dandroid_getCpuFamily=wels_getCpuFamily \
+	-Dandroid_getCpuFeatures=wels_getCpuFeatures -Dandroid_setCpu=wels_setCpu \
+
 codec/common/cpu-features.$(OBJ): $(NDKROOT)/sources/android/cpufeatures/cpu-features.c
 	$(QUIET_CC)$(CC) $(CFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c $(CXX_O) $<


### PR DESCRIPTION
This fixes potential duplicated symbols of android_getCpuIdArm
and android_setCpuArm in static builds
