### PR TITLE
fix build failure without gtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,11 @@ include build/gtest-targets.mk
 include test/api/targets.mk
 include test/decoder/targets.mk
 include test/encoder/targets.mk
-endif
-
 binaries: codec_unittest$(EXEEXT)
 BINARIES += codec_unittest$(EXEEXT)
 codec_unittest$(EXEEXT): $(DECODER_UNITTEST_OBJS) $(ENCODER_UNITTEST_OBJS) $(API_TEST_OBJS) $(CODEC_UNITTEST_DEPS)
 	$(QUIET)rm -f $@
 	$(QUIET_CXX)$(CXX) $(CXX_LINK_O) $+ $(CODEC_UNITTEST_LDFLAGS) $(LDFLAGS)
+endif
 
 -include $(OBJS:.$(OBJ)=.d)


### PR DESCRIPTION
review is here: https://rbcommons.com/s/OpenH264/r/256/
This patch fixed the build failure issue without gtest. Now codec_unittest is built only when gtest exists
