### PR TITLE
Attempt to change to root dir before executing python script

### DIFF
--- a/build/mktargets.sh
+++ b/build/mktargets.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" >/dev/null 2>&1
 python build/mktargets.py --directory codec/decoder --library decoder
 python build/mktargets.py --directory codec/encoder --library encoder --exclude DllEntry.cpp
 python build/mktargets.py --directory codec/common --library common --exclude asm_inc.asm --exclude arm_arch_common_macro.S
@@ -10,3 +11,4 @@ python build/mktargets.py --directory test/encoder --prefix encoder_unittest
 python build/mktargets.py --directory test/decoder --prefix decoder_unittest
 python build/mktargets.py --directory test/api --prefix api_test
 python build/mktargets.py --directory gtest --library gtest --out build/gtest-targets.mk --cpp-suffix .cc --include gtest-all.cc
+cd - >/dev/null 2>&1


### PR DESCRIPTION
When inside a git repo, attempt to change to the root dir
before running python script. Prevents a bunch of errors
when mktargets.sh is executed from the wrong dir.
