### PR TITLE
Remove an unnecessary 'cd' in the mktargets.sh script

### DIFF
--- a/build/mktargets.sh
+++ b/build/mktargets.sh
@@ -11,4 +11,3 @@ python build/mktargets.py --directory test/encoder --prefix encoder_unittest
 python build/mktargets.py --directory test/decoder --prefix decoder_unittest
 python build/mktargets.py --directory test/api --prefix api_test
 python build/mktargets.py --directory gtest --library gtest --out build/gtest-targets.mk --cpp-suffix .cc --include gtest-all.cc
-cd - >/dev/null 2>&1


### PR DESCRIPTION
There's no need to return to the original directory at the end of
a script - the current working directory within the subshell that
executes the script doesn't affect the working directory in the
calling shell.
