### PR TITLE
    use function pointer in reference frame management

### DIFF
--- a/codec/encoder/core/inc/ref_list_mgr_svc.h
+++ b/codec/encoder/core/inc/ref_list_mgr_svc.h
@@ -77,11 +77,11 @@ void WelsResetRefList (sWelsEncCtx* pCtx);
 /*
  *	update reference picture list
  */
-bool WelsUpdateRefList (sWelsEncCtx* pCtx);
+bool WelsUpdateRefList (void* pCtx);
 /*
  *	build reference picture list
  */
-bool WelsBuildRefList (sWelsEncCtx* pCtx, const int32_t kiPOC);
+bool WelsBuildRefList (void* pCtx, const int32_t kiPOC,int32_t iBestLtrRefIdx);
 
 /*
  *	update syntax for reference base related
@@ -96,7 +96,9 @@ bool CheckCurMarkFrameNumUsed (sWelsEncCtx* pCtx);
 /*
 *	decide whether current frame include long term reference mark and update long term reference mark syntax
 */
-void WelsMarkPic (sWelsEncCtx* pCtx);
+void WelsMarkPic (void* pCtx);
+
+void InitRefListMgrFunc(SWelsFuncPtrList* pFuncList,EUsageType eUsageType);
 
 #ifdef LONG_TERM_REF_DUMP
 void dump_ref (sWelsEncCtx* ctx);

--- a/codec/encoder/core/inc/wels_func_ptr_def.h
+++ b/codec/encoder/core/inc/wels_func_ptr_def.h
@@ -168,6 +168,10 @@ typedef int32_t (*PGetVarianceFromIntraVaaFunc) (uint8_t* pSampelY, const int32_
 typedef uint8_t (*PGetMbSignFromInterVaaFunc) (int32_t* pSad8x8);
 typedef void (*PUpdateMbMvFunc) (SMVUnitXY* pMvUnit, const SMVUnitXY ksMv);
 
+typedef bool (*PBuildRefListFunc)(void* pCtx, const int32_t iPOC,int32_t iBestLtrRefIdx);
+typedef void (*PMarkPicFunc)(void* pCtx);
+typedef bool (*PUpdateRefListFunc) (void* pCtx);
+
 struct TagWelsFuncPointerList {
   PExpandPictureFunc			pfExpandLumaPicture;
   PExpandPictureFunc
@@ -247,6 +251,10 @@ struct TagWelsFuncPointerList {
   PSetMemoryZero				pfSetMemZeroSize8;			// for size is times to 8
   PSetMemoryZero				pfSetMemZeroSize64Aligned16;			// for size is times of 64, and address is align to 16
   PSetMemoryZero				pfSetMemZeroSize64;			// for size is times of 64, and don't know address is align to 16 or not
+
+  PBuildRefListFunc     pBuildRefList;
+  PMarkPicFunc          pMarkPic;
+  PUpdateRefListFunc    pUpdateRefList;
 };
 
 }	//end of namespace WelsSVCEnc {

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -44,7 +44,7 @@
 #include "get_intra_predictor.h"
 
 #include "deblocking.h"
-
+#include "ref_list_mgr_svc.h"
 #include "mc.h"
 #include "sample.h"
 
@@ -207,7 +207,7 @@ int32_t InitFunctionPointers (SWelsFuncPtrList* pFuncList, SWelsSvcCodingParam* 
   WelsBlockFuncInit (&pFuncList->pfSetNZCZero, uiCpuFlag);
 
   InitFillNeighborCacheInterFunc (pFuncList, pParam->bEnableBackgroundDetection);
-
+  InitRefListMgrFunc(pFuncList,pParam->iUsageType);
   return iReturn;
 }
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2886,8 +2886,8 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
 
     WelsInitCurrentLayer (pCtx, iCurWidth, iCurHeight);
 
-    WelsMarkPic (pCtx);
-    if (!WelsBuildRefList (pCtx, pCtx->iPOC)) {
+    pCtx->pFuncList->pMarkPic(pCtx);
+    if (!pCtx->pFuncList->pBuildRefList (pCtx, pCtx->iPOC,0)) {
       // Force coding IDR as followed
       ForceCodingIDR (pCtx);
       WelsLog (pCtx, WELS_LOG_WARNING, "WelsEncoderEncodeExt(), WelsBuildRefList failed for P frames, pCtx->iNumRef0= %d. ForceCodingIDR!\n",
@@ -3139,7 +3139,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo * pFbi, const SSou
 
     // reference picture list update
     if (eNalRefIdc != NRI_PRI_LOWEST) {
-      if (!WelsUpdateRefList (pCtx)) {
+      if (!pCtx->pFuncList->pUpdateRefList (pCtx)) {
         // Force coding IDR as followed
         ForceCodingIDR (pCtx);
         WelsLog (pCtx, WELS_LOG_WARNING, "WelsEncoderEncodeExt(), WelsUpdateRefList failed. ForceCodingIDR!\n");

--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -324,7 +324,8 @@ static inline void PrefetchNextBuffer (sWelsEncCtx* pCtx) {
 /*
  *	update reference picture list
  */
-bool WelsUpdateRefList (sWelsEncCtx* pCtx) {
+bool WelsUpdateRefList (void* pEncCtx) {
+  sWelsEncCtx* pCtx     = (sWelsEncCtx*)pEncCtx;
   SRefList* pRefList		= pCtx->ppRefPicListExt[pCtx->uiDependencyId];
   SLTRState* pLtr			= &pCtx->pLtr[pCtx->uiDependencyId];
   SDLayerParam* pParamD	= &pCtx->pSvcParam->sDependencyLayers[pCtx->uiDependencyId];
@@ -423,7 +424,8 @@ bool CheckCurMarkFrameNumUsed (sWelsEncCtx* pCtx) {
 
   return true;
 }
-void WelsMarkPic (sWelsEncCtx* pCtx) {
+void WelsMarkPic (void* pEncCtx) {
+  sWelsEncCtx* pCtx = (sWelsEncCtx* )pEncCtx;
   SLTRState* pLtr = &pCtx->pLtr[pCtx->uiDependencyId];
   const int32_t kiCountSliceNum			= GetCurrentSliceNum (pCtx->pCurDqLayer->pSliceEncCtx);
   int32_t iGoPFrameNumInterval = ((pCtx->pSvcParam->uiGopSize >> 1) > 1) ? (pCtx->pSvcParam->uiGopSize >> 1) : (1);
@@ -536,7 +538,8 @@ void FilterLTRMarkingFeedback (sWelsEncCtx* pCtx, SLTRMarkingFeedback* pLTRMarki
 /*
  *	build reference picture list
  */
-bool WelsBuildRefList (sWelsEncCtx* pCtx, const int32_t iPOC) {
+bool WelsBuildRefList (void* pEncCtx, const int32_t iPOC,int32_t iBestLtrRefIdx) {
+  sWelsEncCtx* pCtx     = (sWelsEncCtx*)pEncCtx;
   SRefList* pRefList		=  pCtx->ppRefPicListExt[pCtx->uiDependencyId];
   SLTRState* pLtr			= &pCtx->pLtr[pCtx->uiDependencyId];
   const int32_t kiNumRef	= pCtx->pSvcParam->iNumRefFrame;
@@ -634,5 +637,32 @@ void WelsUpdateRefSyntax (sWelsEncCtx* pCtx, const int32_t iPOC, const int32_t u
     }
   }
 }
-
+bool WelsUpdateRefListScreen (void* pCtx)
+{
+  return true;
+}
+bool WelsBuildRefListScreen (void* pCtx, const int32_t iPOC,int32_t iBestLtrRefIdx)
+{
+  return true;
+}
+void WelsMarkPicScreen (void* pCtx)
+{
+  return;
+}
+void InitRefListMgrFunc(SWelsFuncPtrList* pFuncList,EUsageType eUsageType)
+{
+   if(eUsageType == SCREEN_CONTENT_REAL_TIME)
+   {
+     pFuncList->pBuildRefList =   WelsBuildRefListScreen;
+     pFuncList->pMarkPic      =   WelsMarkPicScreen;
+     pFuncList->pUpdateRefList=   WelsUpdateRefListScreen;
+   }
+   else
+   {
+     pFuncList->pBuildRefList =   WelsBuildRefList;
+     pFuncList->pMarkPic      =   WelsMarkPic;
+     pFuncList->pUpdateRefList=   WelsUpdateRefList;
+   }
+}
 } // namespace WelsSVCEnc
+


### PR DESCRIPTION
reviewed at : https://rbcommons.com/s/OpenH264/r/273/
1. there are many differences in reference management module for screen content and video camera
   it is better to use the different functions for these two usage types.
2. this review doesn't contain the implementation for screen content. will do it in the next update.
