### PR TITLE
Explicitly request 2 threads when testing slice threading

### DIFF
--- a/test/api/BaseEncoderTest.cpp
+++ b/test/api/BaseEncoderTest.cpp
@@ -31,6 +31,9 @@ static int InitWithParam(ISVCEncoder* encoder, int width,
     param.iLoopFilterDisableIdc = deblock;
     param.iSpatialLayerNum = layers;
 
+    if (sliceMode != SM_SINGLE_SLICE)
+      param.iMultipleThreadIdc = 2;
+
     for (int i = 0; i < param.iSpatialLayerNum; i++) {
       param.sSpatialLayers[i].iVideoWidth = width >> (param.iSpatialLayerNum - 1 - i);
       param.sSpatialLayers[i].iVideoHeight = height >> (param.iSpatialLayerNum - 1 - i);


### PR DESCRIPTION
Previously the default value of iMultipleThreadIdc was 0,
which made sure threads were used for the test with multiple
slices (if run on a multicore machine). Now the default is 1,
so multiple threads has to be requested.

Explicitly request 2 threads, to make sure the threading code is
tested, even on machines with only one core.
