### PR TITLE
remove thread cpu core bind

### DIFF
--- a/codec/encoder/core/inc/mt_defs.h
+++ b/codec/encoder/core/inc/mt_defs.h
@@ -54,10 +54,6 @@
 
 #define DYNAMIC_DETECT_CPU_CORES
 
-//#if defined(WIN32)
-//#define BIND_CPU_CORES_TO_THREADS	// if it is not defined here mean cross cpu cores load balance automatically
-//#endif//WIN32
-
 #define THRESHOLD_RMSE_CORE8	0.0320f	// v1.1: 0.0320f; v1.0: 0.02f
 #define THRESHOLD_RMSE_CORE4	0.0215f	// v1.1: 0.0215f; v1.0: 0.03f
 #define THRESHOLD_RMSE_CORE2	0.0200f	// v1.1: 0.0200f; v1.0: 0.04f

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -951,29 +951,10 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
 int32_t CreateSliceThreads (sWelsEncCtx* pCtx) {
   const int32_t kiThreadCount = pCtx->pSvcParam->iCountThreadsNum;
   int32_t iIdx = 0;
-#if defined(_WIN32) && defined(BIND_CPU_CORES_TO_THREADS)
-  DWORD  dwProcessAffinity;
-  DWORD  dwSystemAffinity;
-  GetProcessAffinityMask (GetCurrentProcess(), &dwProcessAffinity, &dwSystemAffinity);
-#endif//WIN32 && BIND_CPU_CORES_TO_THREADS
 
   while (iIdx < kiThreadCount) {
     WelsThreadCreate (&pCtx->pSliceThreading->pThreadHandles[iIdx], CodingSliceThreadProc,
                       &pCtx->pSliceThreading->pThreadPEncCtx[iIdx], 0);
-#if defined(_WIN32) && defined(BIND_CPU_CORES_TO_THREADS)
-    if (dwProcessAffinity > 1
-        && pCtx->pSliceThreading->pThreadHandles[iIdx] != NULL) {	// multiple cores and thread created successfully
-      DWORD  dw = 0;
-      DWORD  dwAffinityMask = 1 << iIdx;
-      if (dwAffinityMask & dwProcessAffinity) { // check if cpu is available
-        dw = SetThreadAffinityMask (pCtx->pSliceThreading->pThreadHandles[iIdx], dwAffinityMask);  //1 << iIdx
-        if (dw == 0) {
-          char str[64] = {0};
-          WelsSnprintf (str, 64, "SetThreadAffinityMask iIdx:%d", iIdx);
-        }
-      }
-    }
-#endif//WIN32 && BIND_CPU_CORES_TO_THREADS
 
     ++ iIdx;
   }


### PR DESCRIPTION
Remove thread/cpu core bind.  
Os is smart enough to schedule threads,  we needn't  bind thread to specific core.  It will only decrease parallel performance.   
