### PR TITLE
this patch remove dependency of MSVC version

### DIFF
--- a/build/platform-msvc-arm.mk
+++ b/build/platform-msvc-arm.mk
@@ -1,4 +1,5 @@
 include build/platform-msvc-common.mk
+CFLAGS_OPT += -MD
 ARCH=arm
 include build/platform-arch.mk
 CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -MD -DWIN32

--- a/build/platform-msvc-common.mk
+++ b/build/platform-msvc-common.mk
@@ -5,7 +5,7 @@ CXX_O=-Fo$@
 CFLAGS += -nologo -W3 -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -DGTEST_HAS_TR1_TUPLE=0
 CXX_LINK_O=-nologo -Fe$@
 AR_OPTS=-nologo -out:$@
-CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -GF -Gm- -GS -Gy -MD -DNDEBUG
+CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -GF -Gm- -GS -Gy -DNDEBUG
 CFLAGS_DEBUG=-Od -Oy- -ZI -Gm -MDd -RTC1 -D_DEBUG
 CFLAGS_M32=
 CFLAGS_M64=

--- a/build/platform-msvc.mk
+++ b/build/platform-msvc.mk
@@ -1,6 +1,7 @@
 include build/platform-x86-common.mk
 include build/platform-msvc-common.mk
 LDFLAGS += user32.lib
+CFLAGS_OPT += -MT
 ifeq ($(ENABLE64BIT), Yes)
 ASMFLAGS += -f win64
 ASMFLAGS_PLATFORM = -DWIN64


### PR DESCRIPTION
the output dll now only depends on kernel32.dll
review at: https://rbcommons.com/s/OpenH264/r/313/
