### PR TITLE
Remove some unnecessary ifdefs

### DIFF
--- a/codec/console/dec/src/read_config.cpp
+++ b/codec/console/dec/src/read_config.cpp
@@ -37,10 +37,9 @@
  *      08/18/2008 Created
  *
  *****************************************************************************/
-#if !defined(_WIN32) || !defined(_MSC_VER)
+
 #include <string.h>
 #include <stdio.h>
-#endif
 
 
 


### PR DESCRIPTION
These headers are standard headers that are available in MSVC as well.
There's nothing ifdeffed in the implementation of this file that would
explain why these headers only are required in these configurations.
