### PR TITLE
update the default value for bPrefixNalAddingCtrl and iLoopFilterDisableIdc

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -160,7 +160,7 @@ static void FillDefault (SEncParamExt& param) {
   // false: Streaming Video Sharing; true: Video Conferencing Meeting;
 
   /* Deblocking loop filter */
-  param.iLoopFilterDisableIdc		= 1;	// 0: on, 1: off, 2: on except for slice boundaries
+  param.iLoopFilterDisableIdc		= 0;	// 0: on, 1: off, 2: on except for slice boundaries
   param.iLoopFilterAlphaC0Offset	= 0;	// AlphaOffset: valid range [-6, 6], default 0
   param.iLoopFilterBetaOffset		= 0;	// BetaOffset:	valid range [-6, 6], default 0
 
@@ -175,7 +175,7 @@ static void FillDefault (SEncParamExt& param) {
   param.bEnableFrameSkip		= true;		// frame skipping
   param.bEnableLongTermReference	= false;	// long term reference control
   param.bEnableSpsPpsIdAddition	= true;		// pSps pPps id addition control
-  param.bPrefixNalAddingCtrl		= true;		// prefix NAL adding control
+  param.bPrefixNalAddingCtrl		= false;		// prefix NAL adding control
   param.iSpatialLayerNum		= 1;		// number of dependency(Spatial/CGS) layers used to be encoded
   param.iTemporalLayerNum			= 1;		// number of temporal layer specified
 

--- a/test/api/decode_encode_test.cpp
+++ b/test/api/decode_encode_test.cpp
@@ -104,8 +104,8 @@ TEST_P(DecodeEncodeTest, CompareOutput) {
 }
 
 static const DecodeEncodeFileParam kFileParamArray[] = {
-  {"res/test_vd_1d.264", "c04a5978eb715837c29463e79b6598a05136829f", 320, 192, 12.0f},
-  {"res/test_vd_rc.264", "40d8eb5a54d358c663f836c689a158c326de4b1c", 320, 192, 12.0f},
+  {"res/test_vd_1d.264", "028b5de8a9110223fc611d8a490c7bbb75d93974", 320, 192, 12.0f},
+  {"res/test_vd_rc.264", "31b4b12d0f91b5407f39ad6f8622cab1366bff2b", 320, 192, 12.0f},
 };
 
 INSTANTIATE_TEST_CASE_P(DecodeEncodeFile, DecodeEncodeTest,

--- a/test/api/encoder_test.cpp
+++ b/test/api/encoder_test.cpp
@@ -69,27 +69,27 @@ TEST_P(EncoderOutputTest, CompareOutput) {
 static const EncodeFileParam kFileParamArray[] = {
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "06441376891cbc237a36e59b62131cd94ff9cb19", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, 1
+      "8d4c87f48e8a679c1ccbf5fe1ee040fed4776b30", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, 1
   },
   {
       "res/CiscoVT2people_160x96_6fps.yuv",
-      "4f3759fc44125b27a179ebff158dbba9e431bd0b", 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, 1
+      "75334dc69d95b8ac2e0a52977bba0179df4f151f", 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, 1
   },
   {
       "res/Static_152_100.yuv",
-      "af5c6a41b567ce1b2cb6fd427f4379473d3b829f", 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, 1
+      "3467201e18a934e7f8c50f3c8f3e05f4334ad12c", 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "be0079b022b18fdce04570db24e4327ca26a0ecb", 320, 192, 12.0f, SM_ROWMB_SLICE, false, 1, 1 // One slice per MB row
+      "592d9cb28dbd3e6d9e04febadf62b075c1c012b7", 320, 192, 12.0f, SM_ROWMB_SLICE, false, 1, 1 // One slice per MB row
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "f4649601ca15f9693671d7e161e9daa8efd3a7a1", 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1, 1
+      "49d392e826ba77cb8cd0b3f701f102a72623c1cf", 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "e4bcd744d2e6f885f6c0dbe5d52818ba64d986d9", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 0, 1
+      "8d4c87f48e8a679c1ccbf5fe1ee040fed4776b30", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 0, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",


### PR DESCRIPTION
Approved at: https://rbcommons.com/s/OpenH264/r/330/
1. update the default value of iLoopFilterDisableIdc as 0. In order to get the better quality, it is better to turn on deblocking filter 
2. update the default value of bPrefixNalAddingCtrl as false.  For NAL 14 is SVC NAL type, not AVC. but when the user only sets base parameter, we should remove this NAL type.
1. update hash code because the default values change.
