### PR TITLE
Don't override the deblocking setting in the encoder test

### DIFF
--- a/test/BaseEncoderTest.h
+++ b/test/BaseEncoderTest.h
@@ -14,8 +14,8 @@ class BaseEncoderTest {
   BaseEncoderTest();
   void SetUp();
   void TearDown();
-  void EncodeFile(const char* fileName, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int deblock, int layers, Callback* cbk);
-  void EncodeStream(InputStream* in, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int deblock, int layers, Callback* cbk);
+  void EncodeFile(const char* fileName, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int layers, Callback* cbk);
+  void EncodeStream(InputStream* in, int width, int height, float frameRate, SliceModeEnum slices, bool denoise, int layers, Callback* cbk);
 
  private:
   ISVCEncoder* encoder_;

--- a/test/api/BaseEncoderTest.cpp
+++ b/test/api/BaseEncoderTest.cpp
@@ -6,8 +6,8 @@
 #include "BaseEncoderTest.h"
 
 static int InitWithParam(ISVCEncoder* encoder, int width,
-    int height, float frameRate, SliceModeEnum sliceMode, bool denoise, int deblock, int layers) {
-  if (SM_SINGLE_SLICE == sliceMode && !denoise && deblock == 1 && layers == 1) {
+    int height, float frameRate, SliceModeEnum sliceMode, bool denoise, int layers) {
+  if (SM_SINGLE_SLICE == sliceMode && !denoise && layers == 1) {
     SEncParamBase param;
     memset (&param, 0, sizeof(SEncParamBase));
 
@@ -28,7 +28,6 @@ static int InitWithParam(ISVCEncoder* encoder, int width,
     param.iTargetBitrate = 5000000;
     param.iInputCsp = videoFormatI420;
     param.bEnableDenoise = denoise;
-    param.iLoopFilterDisableIdc = deblock;
     param.iSpatialLayerNum = layers;
 
     if (sliceMode != SM_SINGLE_SLICE)
@@ -63,8 +62,8 @@ void BaseEncoderTest::TearDown() {
 }
 
 void BaseEncoderTest::EncodeStream(InputStream* in, int width, int height,
-    float frameRate, SliceModeEnum slices, bool denoise, int deblock, int layers, Callback* cbk) {
-  int rv = InitWithParam(encoder_, width, height, frameRate, slices, denoise, deblock, layers);
+    float frameRate, SliceModeEnum slices, bool denoise, int layers, Callback* cbk) {
+  int rv = InitWithParam(encoder_, width, height, frameRate, slices, denoise, layers);
   ASSERT_TRUE(rv == cmResultSuccess);
 
   // I420: 1(Y) + 1/4(U) + 1/4(V)
@@ -97,8 +96,8 @@ void BaseEncoderTest::EncodeStream(InputStream* in, int width, int height,
 }
 
 void BaseEncoderTest::EncodeFile(const char* fileName, int width, int height,
-    float frameRate, SliceModeEnum slices, bool denoise, int deblock, int layers, Callback* cbk) {
+    float frameRate, SliceModeEnum slices, bool denoise, int layers, Callback* cbk) {
   FileInputStream fileStream;
   ASSERT_TRUE(fileStream.Open(fileName));
-  EncodeStream(&fileStream, width, height, frameRate, slices, denoise, deblock, layers, cbk);
+  EncodeStream(&fileStream, width, height, frameRate, slices, denoise, layers, cbk);
 }

--- a/test/api/decode_encode_test.cpp
+++ b/test/api/decode_encode_test.cpp
@@ -95,7 +95,7 @@ TEST_P(DecodeEncodeTest, CompareOutput) {
   DecodeEncodeFileParam p = GetParam();
 
   ASSERT_TRUE(Open(p.fileName));
-  EncodeStream(this, p.width, p.height, p.frameRate, SM_SINGLE_SLICE, false, 1, 1, this);
+  EncodeStream(this, p.width, p.height, p.frameRate, SM_SINGLE_SLICE, false, 1, this);
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
   if (!HasFatalFailure()) {

--- a/test/api/encoder_test.cpp
+++ b/test/api/encoder_test.cpp
@@ -33,7 +33,6 @@ struct EncodeFileParam {
   float frameRate;
   SliceModeEnum slices;
   bool denoise;
-  int deblocking;
   int layers;
 };
 
@@ -57,7 +56,7 @@ class EncoderOutputTest : public ::testing::WithParamInterface<EncodeFileParam>,
 
 TEST_P(EncoderOutputTest, CompareOutput) {
   EncodeFileParam p = GetParam();
-  EncodeFile(p.fileName, p.width, p.height, p.frameRate, p.slices, p.denoise, p.deblocking, p.layers, this);
+  EncodeFile(p.fileName, p.width, p.height, p.frameRate, p.slices, p.denoise, p.layers, this);
 
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result(&ctx_, digest);
@@ -69,31 +68,27 @@ TEST_P(EncoderOutputTest, CompareOutput) {
 static const EncodeFileParam kFileParamArray[] = {
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "8d4c87f48e8a679c1ccbf5fe1ee040fed4776b30", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, 1
+      "8d4c87f48e8a679c1ccbf5fe1ee040fed4776b30", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/CiscoVT2people_160x96_6fps.yuv",
-      "75334dc69d95b8ac2e0a52977bba0179df4f151f", 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, 1
+      "75334dc69d95b8ac2e0a52977bba0179df4f151f", 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/Static_152_100.yuv",
-      "3467201e18a934e7f8c50f3c8f3e05f4334ad12c", 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, 1
+      "3467201e18a934e7f8c50f3c8f3e05f4334ad12c", 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "592d9cb28dbd3e6d9e04febadf62b075c1c012b7", 320, 192, 12.0f, SM_ROWMB_SLICE, false, 1, 1 // One slice per MB row
+      "a57c7cc8a00ffe8d8ca5527a13af1683a41b5150", 320, 192, 12.0f, SM_ROWMB_SLICE, false, 1 // One slice per MB row
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "49d392e826ba77cb8cd0b3f701f102a72623c1cf", 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1, 1
+      "bc9b203c1b031299df7981201c2af393994d876f", 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1
   },
   {
       "res/CiscoVT2people_320x192_12fps.yuv",
-      "8d4c87f48e8a679c1ccbf5fe1ee040fed4776b30", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 0, 1
-  },
-  {
-      "res/CiscoVT2people_320x192_12fps.yuv",
-      "ba81a0f1a14214e6d3c7f1608991b3ac97789370", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 0, 2
+      "ba81a0f1a14214e6d3c7f1608991b3ac97789370", 320, 192, 12.0f, SM_SINGLE_SLICE, false, 2
   },
 };
 


### PR DESCRIPTION
Since this is on by default now, we don't need a separate test
that has it enabled. Thus we can now remove one of the encoder
tests.

By not overriding the deblocking setting at all, the hash
changes for the other tests that use SEncParamExt.
