### PR TITLE
remove redundant init for iRun in CAVLC

### DIFF
--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -649,6 +649,9 @@ static int32_t	CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, 
         }
       }
     } else {
+      for (int j = i; j < uiTotalCoeff; j++) {
+	iRun[j] = 0;
+      }
       return iUsedBits;
     }
 
@@ -665,7 +668,7 @@ int32_t WelsResidualBlockCavlc (SVlcTable* pVlcTable, uint8_t* pNonZeroCountCach
                                 const uint8_t* kpZigzagTable, int32_t iResidualProperty, int16_t* pTCoeff, uint8_t uiQp,
                                 PWelsDecoderContext pCtx) {
   int32_t iLevel[16], iZerosLeft, iCoeffNum;
-  int32_t  iRun[16] = {0};
+  int32_t  iRun[16];
   int32_t iCurNonZeroCacheIdx, i;
   const uint16_t* kpDequantCoeff = g_kuiDequantCoeff[uiQp];
   int8_t nA, nB, nC;


### PR DESCRIPTION
review is at: https://rbcommons.com/s/OpenH264/r/356/
