### PR TITLE
Check for WELS_CPU_NEON before calling DeblockingBSCalcEnc_neon

### DIFF
--- a/codec/encoder/core/inc/wels_func_ptr_def.h
+++ b/codec/encoder/core/inc/wels_func_ptr_def.h
@@ -94,6 +94,7 @@ typedef void (*PChromaDeblockingLT4Func) (uint8_t* iSampleCb, uint8_t* iSampleCr
     int32_t iBeta, int8_t* iTc);
 typedef void (*PChromaDeblockingEQ4Func) (uint8_t* iSampleCb, uint8_t* iSampleCr, int32_t iStride, int32_t iAlpha,
     int32_t iBeta);
+typedef void (*PDeblockingBSCalc) (SWelsFuncPtrList* pFunc, SMB* pCurMb, uint8_t uiBS[2][4][4], Mb_Type uiCurMbType, int32_t iMbStride, int32_t iLeftFlag, int32_t iTopFlag);
 
 typedef struct tagDeblockingFunc {
   PLumaDeblockingLT4Func    pfLumaDeblockingLT4Ver;
@@ -105,6 +106,8 @@ typedef struct tagDeblockingFunc {
   PChromaDeblockingEQ4Func  pfChromaDeblockingEQ4Ver;
   PChromaDeblockingLT4Func  pfChromaDeblockingLT4Hor;
   PChromaDeblockingEQ4Func  pfChromaDeblockingEQ4Hor;
+
+  PDeblockingBSCalc         pfDeblockingBSCalc;
 } DeblockingFunc;
 
 typedef  void (*PSetNoneZeroCountZeroFunc) (int8_t* pNonZeroCount);


### PR DESCRIPTION
Checking HAVE_NEON is not enough; e.g. android devices with
armeabi-v7a are not required to have NEON, so every use of such
functions should be check WELS_CPU_NEON in the cpu features
as well.
