### PR TITLE
Remove useless code

### DIFF
--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -1056,11 +1056,9 @@ void WelsBlockFuncInit (SBlockFunc*   pFunc,  int32_t iCpu) {
 
 void SetNonZeroCount_c (int16_t* pBlock, int8_t* pNonZeroCount) {
   int32_t i;
-  int32_t iIndex;
 
   for (i = 0; i < 24; i++) {
-    iIndex = g_kuiMbNonZeroCountIdx[i];
-    pNonZeroCount[iIndex] = !!pNonZeroCount[iIndex];
+    pNonZeroCount[i] = !!pNonZeroCount[i];
   }
 }
 

--- a/codec/encoder/core/src/deblocking.cpp
+++ b/codec/encoder/core/src/deblocking.cpp
@@ -784,11 +784,9 @@ void PerformDeblockingFilter (sWelsEncCtx* pEnc) {
 
 void WelsNonZeroCount_c (int8_t* pNonZeroCount) {
   int32_t i;
-  int32_t iIndex;
 
   for (i = 0; i < 24; i++) {
-    iIndex = g_kuiMbCountScan4Idx[i];
-    pNonZeroCount[iIndex] = !!pNonZeroCount[iIndex];
+    pNonZeroCount[i] = !!pNonZeroCount[i];
   }
 }
 void WelsBlockFuncInit (PSetNoneZeroCountZeroFunc* pfSetNZCZero,  int32_t iCpu) {


### PR DESCRIPTION
Remove useless code
Since 
const uint8_t g_kuiMbNonZeroCountIdx[24] = {
  //  0   1 | 4  5      luma 8_8 block           non_zero_count[16+8]
  0,  1,  4,  5,   //  2   3 | 6  7        0  |  1                  0   1   2   3
  2,  3,  6,  7,   //---------------      ---------                 4   5   6   7
  8,  9, 12, 13,   //  8   9 | 12 13       2  |  3                  8   9  10  11
  10, 11, 14, 15,   // 10  11 | 14 15-----------------------------> 12  13  14  15
  16, 17, 20, 21,   //----------------    chroma 8_8 block          16  17  18  19
  18, 19, 22, 23   // 16  17 | 20 21        0    1                 20  21  22  23
}; //decoder
and
const uint8_t g_kuiMbCountScan4Idx[24] = {
  //  0   1 | 4  5      luma 8_8 block           pNonZeroCount[16+8]
  0,  1,  4,  5,   //  2   3 | 6  7        0  |  1                  0   1   2   3
  2,  3,  6,  7,   //---------------      ---------                 4   5   6   7
  8,  9, 12, 13,   //  8   9 | 12 13       2  |  3                  8   9  10  11
  10, 11, 14, 15,   // 10  11 | 14 15-----------------------------> 12  13  14  15
  16, 17, 20, 21,   //----------------    chroma 8_8 block          16  17  18  19
  18, 19, 22, 23   // 16  17 | 20 21        0    1                 20  21  22  23
}; //encoder
contains value 0~23, it is OK to remove these code.
Review:
https://rbcommons.com/s/OpenH264/r/390/
