### PR TITLE
Don't build all object files with -ZW, only the one that needs it

### DIFF
--- a/build/platform-msvc-wp.mk
+++ b/build/platform-msvc-wp.mk
@@ -3,6 +3,8 @@ include build/platform-msvc-common.mk
 CFLAGS_OPT += -MD
 CFLAGS_DEBUG += -MDd
 CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP
-CXXFLAGS += -ZW
+CXXFLAGS +=
 LDFLAGS +=
+
+codec/common/src/WelsThreadLib.$(OBJ): CXXFLAGS += -ZW
 


### PR DESCRIPTION
This reduces the build time from 69 s to 30 s, reduces the size of
the built wels.lib from 30 MB to 3.9 MB, and reduces the number of
warnings when building wels.lib.
