### PR TITLE
Add a stub makefile target for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,9 @@ BINARIES += codec_unittest$(EXEEXT)
 codec_unittest$(EXEEXT): $(DECODER_UNITTEST_OBJS) $(ENCODER_UNITTEST_OBJS) $(PROCESSING_UNITTEST_OBJS) $(API_TEST_OBJS) $(CODEC_UNITTEST_DEPS)
 	$(QUIET)rm -f $@
 	$(QUIET_CXX)$(CXX) $(CXX_LINK_O) $+ $(CODEC_UNITTEST_LDFLAGS) $(LDFLAGS)
+else
+binaries:
+	@:
 endif
 
 -include $(OBJS:.$(OBJ)=.d)


### PR DESCRIPTION
This avoids the following error when doing "make OS=ios" if gtest
isn't installed:

make: **\* No rule to make target `binaries', needed by`all'.  Stop.

This fixes issue #752.
