### PR TITLE
Fix occasional errors in the motion estimation tests by correcting the range limits

### DIFF
--- a/test/encoder/EncUT_MotionEstimate.cpp
+++ b/test/encoder/EncUT_MotionEstimate.cpp
@@ -316,7 +316,7 @@ TEST_F(MotionEstimateTest, TestVerticalSearch_SSE41)
     //it is possible that ref at differnt position is identical, but that should be under a low probability
   }
 }
-/*
+
 TEST_F(MotionEstimateTest, TestHorizontalSearch_SSE41)
 {
   const int32_t kiMaxBlock16Sad = 72000;//a rough number
@@ -382,5 +382,4 @@ TEST_F(MotionEstimateTest, TestHorizontalSearch_SSE41)
     //it is possible that ref at differnt position is identical, but that should be under a low probability
   }
 }
-*/
 #endif


### PR DESCRIPTION
Also take a disabled test into use now that the occasional errors have been sorted out.
