### PR TITLE
Fix building gtest on MSVC 2010 and newer

### DIFF
--- a/build/platform-msvc-common.mk
+++ b/build/platform-msvc-common.mk
@@ -19,7 +19,10 @@ CC=cl
 CXX=cl
 AR=lib
 CXX_O=-Fo$@
-CFLAGS += -nologo -W3 -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -DGTEST_HAS_TR1_TUPLE=1 -DGTEST_USE_OWN_TR1_TUPLE=1
+# -DGTEST_HAS_TR1_TUPLE=0 is temporarily broken in gtest,
+# using _VARIADIC_MAX=10 to fix building on MSVC 2012 meanwhile.
+# Once gtest works with the former again, it should be preferred.
+CFLAGS += -nologo -W3 -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -D_VARIADIC_MAX=10
 CXX_LINK_O=-nologo -Fe$@
 AR_OPTS=-nologo -out:$@
 CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -GF -Gm- -GS -Gy -DNDEBUG


### PR DESCRIPTION
The previous define change in 1e607d71 only made it work on MSVC
2005 and 2008, but broke things even more for 2010 and newer.
(One shouldn't override the internal details about which tuple
implementation to use, since one implementation don't work on
all versions.) Since we don't need or use the gtest tuple code,
the simplest workaround used to be just to disable it altogether,
but that was broken in r682 in gtest.

This has been tested and works on MSVC 2005, 2008, 2010, 2012 and
2013.
