### PR TITLE
Make manually edited vcproj files match what visual studio actually generates

### DIFF
--- a/codec/build/win32/dec/WelsDecCore.vcproj
+++ b/codec/build/win32/dec/WelsDecCore.vcproj
@@ -685,10 +685,10 @@
 					RelativePath="..\..\..\decoder\core\inc\bit_stream.h"
 					>
 				</File>
-                                <File
-                                        RelativePath="..\..\..\common\inc\copy_mb.h"
-                                        >
-                                </File>
+				<File
+					RelativePath="..\..\..\common\inc\copy_mb.h"
+					>
+				</File>
 				<File
 					RelativePath="..\..\..\common\inc\cpu.h"
 					>
@@ -737,10 +737,10 @@
 					RelativePath="..\..\..\decoder\core\inc\error_code.h"
 					>
 				</File>
-                                <File
-                                        RelativePath="..\..\..\decoder\core\inc\error_concealment.h"
-                                        >
-                                </File>
+				<File
+					RelativePath="..\..\..\decoder\core\inc\error_concealment.h"
+					>
+				</File>
 				<File
 					RelativePath="..\..\..\decoder\core\inc\expand_pic.h"
 					>
@@ -862,10 +862,10 @@
 					RelativePath="..\..\..\decoder\core\src\bit_stream.cpp"
 					>
 				</File>
-                                <File
-                                        RelativePath="..\..\..\common\src\copy_mb.cpp"
-                                        >
-                                </File>
+				<File
+					RelativePath="..\..\..\common\src\copy_mb.cpp"
+					>
+				</File>
 				<File
 					RelativePath="..\..\..\common\src\cpu.cpp"
 					>
@@ -902,10 +902,10 @@
 					RelativePath="..\..\..\decoder\core\src\decoder_data_tables.cpp"
 					>
 				</File>
-                                <File
-                                        RelativePath="..\..\..\decoder\core\src\error_concealment.cpp"
-                                        >
-                                </File>
+				<File
+					RelativePath="..\..\..\decoder\core\src\error_concealment.cpp"
+					>
+				</File>
 				<File
 					RelativePath="..\..\..\decoder\core\src\expand_pic.cpp"
 					>

--- a/codec/build/win32/enc/WelsEncCore.vcproj
+++ b/codec/build/win32/enc/WelsEncCore.vcproj
@@ -395,10 +395,10 @@
 					/>
 				</FileConfiguration>
 			</File>
-                        <File
-                                RelativePath="..\..\..\common\src\copy_mb.cpp"
-                                >
-                        </File>
+			<File
+				RelativePath="..\..\..\common\src\copy_mb.cpp"
+				>
+			</File>
 			<File
 				RelativePath="..\..\..\common\src\cpu.cpp"
 				>
@@ -1452,10 +1452,10 @@
 				RelativePath="..\..\..\encoder\core\inc\bit_stream.h"
 				>
 			</File>
-                        <File
-                                RelativePath="..\..\..\common\inc\copy_mb.h"
-                                >
-                        </File>
+			<File
+				RelativePath="..\..\..\common\inc\copy_mb.h"
+				>
+			</File>
 			<File
 				RelativePath="..\..\..\common\inc\cpu.h"
 				>


### PR DESCRIPTION
This changes the indentation from space to tabs, and adds missing
dos newlines to these few lines.

This makes the file be detected as using dos newlines properly in
certain editors.
