### PR TITLE
Fix the improper slice mmco setting

### DIFF
--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -482,9 +482,6 @@ void WelsMarkPic (void* pEncCtx) {
 
     memset (pRefPicMark, 0, sizeof (SRefPicMarking));
 
-    if (iSliceIdx != kiCountSliceNum - 1)	{ //marking syntax only exist in last slice head
-      continue;
-    }
     if (pCtx->pSvcParam->bEnableLongTermReference && pLtr->bLTRMarkingFlag) {
       if (pLtr->iLTRMarkMode == LTR_DIRECT_MARK)	{
         pRefPicMark->SMmcoRef[pRefPicMark->uiMmcoCount].iMaxLongTermFrameIdx = LONG_TERM_REF_NUM - 1;


### PR DESCRIPTION
according to the standard, MMCO commands should be included in all slices. The 'continue' is not proper.
