### PR TITLE
Use the actual parameter types in PSearchMethodFunc instead of void pointers

### DIFF
--- a/codec/encoder/core/inc/svc_motion_estimate.h
+++ b/codec/encoder/core/inc/svc_motion_estimate.h
@@ -180,7 +180,7 @@ bool WelsMotionEstimateInitialPoint (SWelsFuncPtrList* pFuncList, SWelsME* pMe, 
  *
  * \return  NONE
  */
-void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, void* pLpme, void* pLpslice, const int32_t kiEncStride,
+void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, SWelsME* pMe, SSlice* pSlice, const int32_t kiEncStride,
                         const int32_t kiRefStride);
 
 bool WelsMeSadCostSelect (int32_t* pSadCost, const uint16_t* kpMvdCost, int32_t* pBestCost, const int32_t kiDx,

--- a/codec/encoder/core/inc/wels_func_ptr_def.h
+++ b/codec/encoder/core/inc/wels_func_ptr_def.h
@@ -146,7 +146,7 @@ typedef int32_t (*PIntraPred8x8Combined3Func) (uint8_t*, int32_t, uint8_t*, int3
 typedef uint32_t (*PSampleSadHor8Func) (uint8_t*, int32_t, uint8_t*, int32_t, uint16_t*, int32_t*);
 typedef void (*PMotionSearchFunc) (SWelsFuncPtrList* pFuncList, void* pCurDqLayer, void* pMe,
                                    void* pSlice);
-typedef void (*PSearchMethodFunc) (SWelsFuncPtrList* pFuncList, void* pMe, void* pSlice, const int32_t kiEncStride,
+typedef void (*PSearchMethodFunc) (SWelsFuncPtrList* pFuncList, SWelsME* pMe, SSlice* pSlice, const int32_t kiEncStride,
                                    const int32_t kiRefStride);
 typedef void (*PCalculateSatdFunc) (PSampleSadSatdCostFunc pSatd, void* vpMe, const int32_t kiEncStride,
                                     const int32_t kiRefStride);

--- a/codec/encoder/core/src/svc_motion_estimate.cpp
+++ b/codec/encoder/core/src/svc_motion_estimate.cpp
@@ -253,9 +253,8 @@ bool WelsMeSadCostSelect (int32_t* iSadCost, const uint16_t* kpMvdCost, int32_t*
   return (*pBestCost == iInputSadCost);
 }
 
-void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, void* pLpme, void* pLpslice,
+void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, SWelsME* pMe, SSlice* pSlice,
                         const int32_t kiStrideEnc,  const int32_t kiStrideRef) {
-  SWelsME* pMe            = (SWelsME*)pLpme;
   PSample4SadCostFunc      pSad          =  pFuncList->sSampleDealingFuncs.pfSample4Sad[pMe->uiBlockSize];
 
   uint8_t* pFref = pMe->pRefMb;
@@ -917,13 +916,10 @@ void UpdateFMESwitchNull (SDqLayer* pCurLayer) {
 /////////////////////////
 // Search function options
 /////////////////////////
-void WelsDiamondCrossSearch (SWelsFuncPtrList* pFunc, void* vpMe, void* vpSlice, const int32_t kiEncStride,
+void WelsDiamondCrossSearch (SWelsFuncPtrList* pFunc, SWelsME* pMe, SSlice* pSlice, const int32_t kiEncStride,
                              const int32_t kiRefStride) {
-  SWelsME* pMe       = static_cast<SWelsME*> (vpMe);
-  SSlice* pSlice         = static_cast<SSlice*> (vpSlice);
-
   //  Step 1: diamond search
-  WelsDiamondSearch (pFunc, vpMe, vpSlice, kiEncStride, kiRefStride);
+  WelsDiamondSearch (pFunc, pMe, pSlice, kiEncStride, kiRefStride);
 
   //  Step 2: CROSS search
   SScreenBlockFeatureStorage pRefBlockFeature; //TODO: use this structure from Ref
@@ -932,11 +928,8 @@ void WelsDiamondCrossSearch (SWelsFuncPtrList* pFunc, void* vpMe, void* vpSlice,
     WelsMotionCrossSearch (pFunc, pMe, pSlice, kiEncStride, kiRefStride);
   }
 }
-void WelsDiamondCrossFeatureSearch (SWelsFuncPtrList* pFunc, void* vpMe, void* vpSlice, const int32_t kiEncStride,
+void WelsDiamondCrossFeatureSearch (SWelsFuncPtrList* pFunc, SWelsME* pMe, SSlice* pSlice, const int32_t kiEncStride,
                                     const int32_t kiRefStride) {
-  SWelsME* pMe       = static_cast<SWelsME*> (vpMe);
-  SSlice* pSlice         = static_cast<SSlice*> (vpSlice);
-
   //  Step 1: diamond search + cross
   WelsDiamondCrossSearch (pFunc, pMe, pSlice, kiEncStride, kiRefStride);
 


### PR DESCRIPTION
Approved at https://rbcommons.com/s/OpenH264/r/407/.
