### PR TITLE
Fix the license link in the FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -97,7 +97,7 @@
             community as well as Unified Communication vendors. </p>
 
           <p> <strong>Q. What source code license will you use?</strong><br />
-            A: Two-Clause <a href="LICENSE.txt"></a>BSD license</a>. </p>
+            A: Two-Clause <a href="LICENSE.txt">BSD license</a>. </p>
 
           <p> <strong>Q. What platforms will you support?</strong><br />
             A: Our initial plan is to support Linux (x86 and ARM), Windows (XP


### PR DESCRIPTION
Previously there was no clickable link due to the extra </a> tag.
