### PR TITLE
fix vlc overflow

### DIFF
--- a/codec/encoder/core/inc/rc.h
+++ b/codec/encoder/core/inc/rc.h
@@ -66,8 +66,6 @@ enum {
   VGOP_SIZE             = 8,
 
   //qp information
-  FIX_MIN_QP_MODE       = 10, //qp <10 will cause level code overflow in cavlc coding which isn't suppored in baseline profile
-  FIX_MAX_QP_MODE       = 51,
   GOM_MIN_QP_MODE       = 12,
   GOM_MAX_QP_MODE       = 36,
   MAX_LOW_BR_QP			= 42,

--- a/codec/encoder/core/inc/set_mb_syn_cavlc.h
+++ b/codec/encoder/core/inc/set_mb_syn_cavlc.h
@@ -79,8 +79,8 @@ void  InitCoeffFunc (const uint32_t uiCpuFlag);
 
 void  InitCavlcTable();
 
-void  WriteBlockResidualCavlc (int16_t* pCoffLevel, int32_t iEndIdx, int32_t iCalRunLevelFlag,
-                               int32_t iResidualProperty, int8_t iNC, SBitStringAux* pBs);
+int32_t  WriteBlockResidualCavlc (int16_t* pCoffLevel, int32_t iEndIdx, int32_t iCalRunLevelFlag,
+                                  int32_t iResidualProperty, int8_t iNC, SBitStringAux* pBs);
 
 #if defined(__cplusplus)
 extern "C" {

--- a/codec/encoder/core/inc/svc_enc_slice_segment.h
+++ b/codec/encoder/core/inc/svc_enc_slice_segment.h
@@ -95,6 +95,7 @@ typedef struct TagDynamicSlicingStack {
   int32_t		iBsStackLeftBits;
 
   int32_t		iMbSkipRunStack;
+  uint8_t   uiLastMbQp;
 } SDynamicSlicingStack;
 
 /*!

--- a/codec/encoder/core/inc/svc_mode_decision.h
+++ b/codec/encoder/core/inc/svc_mode_decision.h
@@ -57,6 +57,7 @@ void WelsMdInterMbEnhancelayer (void* pEnc, void* pMd, SSlice* pSlice, SMB* pCur
 
 SMB* GetRefMb (SDqLayer* pCurLayer, SMB* pCurMb);
 void SetMvBaseEnhancelayer (SWelsMD* pMd, SMB* pCurMb, const SMB* kpRefMb);
+void SetBlockStaticIdcToMd (void* pVaa, void* pMd, SMB* pCurMb, void* pDqLay);
 }
 #endif //SVC_MODE_DECISION_H
 

--- a/codec/encoder/core/inc/svc_set_mb_syn_cavlc.h
+++ b/codec/encoder/core/inc/svc_set_mb_syn_cavlc.h
@@ -50,7 +50,7 @@
 
 namespace WelsSVCEnc {
 
-void WelsWriteMbResidual (SMbCache* sMbCacheInfo, SMB* pCurMb, SBitStringAux* pBs);
+int32_t WelsWriteMbResidual (SMbCache* sMbCacheInfo, SMB* pCurMb, SBitStringAux* pBs);
 
 void WelsSpatialWriteSubMbPred (sWelsEncCtx* pEncCtx, SSlice* pSlice, SMB* pCurMb);
 

--- a/codec/encoder/core/inc/wels_const.h
+++ b/codec/encoder/core/inc/wels_const.h
@@ -202,6 +202,7 @@ enum {
   ENC_RETURN_CORRECTED = 0x08, //unexpected value but corrected by encoder
   ENC_RETURN_INVALIDINPUT = 0x10, //invalid input
   ENC_RETURN_MEMOVERFLOWFOUND = 0x20,
+  ENC_RETURN_VLCOVERFLOWFOUND = 0x40
 };
 //TODO: need to complete the return checking in encoder and fill in more types if needed
 

--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -74,6 +74,7 @@ typedef struct {
   SPicture*   pRefPicture;
   int32_t     iSrcListIdx;   //idx in  h->spatial_pic[base_did];
   bool        bSceneLtrFlag;
+  unsigned char*		pBestBlockStaticIdc;
 } SRefInfoParam;
 
 typedef struct {

--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -928,7 +928,7 @@ void  WelsRcPictureInitDisable (void* pCtx) {
     pEncCtx->iGlobalQp = WELS_CLIP3 (WELS_ROUND (pEncCtx->iGlobalQp -
                                      pEncCtx->pVaa->sAdaptiveQuantParam.dAverMotionTextureIndexToDeltaQp), GOM_MIN_QP_MODE, GOM_MAX_QP_MODE);
   } else {
-    pEncCtx->iGlobalQp = WELS_CLIP3 (pEncCtx->iGlobalQp, FIX_MIN_QP_MODE, FIX_MAX_QP_MODE);
+    pEncCtx->iGlobalQp = WELS_CLIP3 (pEncCtx->iGlobalQp, 0, 51);
   }
 
   pWelsSvcRc->iAverageFrameQp = pEncCtx->iGlobalQp;
@@ -940,14 +940,16 @@ void  WelsRcPictureInfoUpdateDisable (void* pCtx, int32_t layer_size) {
 void  WelsRcMbInitDisable (void* pCtx, SMB* pCurMb, SSlice* pSlice) {
   sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;
   int32_t iLumaQp					= pEncCtx->iGlobalQp;
+
   SDqLayer* pCurLayer				= pEncCtx->pCurDqLayer;
   const uint8_t kuiChromaQpIndexOffset = pCurLayer->sLayerInfo.pPpsP->uiChromaQpIndexOffset;
+
 
   if (pEncCtx->pSvcParam->bEnableAdaptiveQuant && (pEncCtx->eSliceType == P_SLICE)) {
     iLumaQp   = (int8_t)WELS_CLIP3 (iLumaQp +
                                     pEncCtx->pVaa->sAdaptiveQuantParam.pMotionTextureIndexToDeltaQp[pCurMb->iMbXY], GOM_MIN_QP_MODE, 51);
   } else {
-    iLumaQp = WELS_CLIP3 (iLumaQp, FIX_MIN_QP_MODE, FIX_MAX_QP_MODE);
+    iLumaQp = WELS_CLIP3 (iLumaQp, 0, 51);
   }
   pCurMb->uiChromaQp = g_kuiChromaQpTable[CLIP3_QP_0_51 (iLumaQp + kuiChromaQpIndexOffset)];
   pCurMb->uiLumaQp = iLumaQp;

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -927,6 +927,7 @@ void CWelsPreProcess::SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSce
     SRefInfoParam* pRefSaved) {
   pRefSaved->iSrcListIdx = pRefPicInfo->iSrcListIdx;
   pRefSaved->bSceneLtrFlag = pRefPicInfo->bSceneLtrFlag;
+  pRefSaved->pBestBlockStaticIdc = sSceneChangeResult.pStaticBlockIdc;
 }
 
 void CWelsPreProcess::SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef) {
@@ -974,8 +975,6 @@ ESceneChangeIdc CWelsPreProcess::DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPi
   SPicture* pRefPic = NULL;
   SRefInfoParam* pRefPicInfo = NULL;
   uint8_t*  pCurBlockStaticPointer = NULL;
-  uint8_t*  pBestStrBlockStaticPointer = NULL;
-  uint8_t*  pBestLtrBlockStaticPointer = NULL;
 
   const int32_t iNegligibleMotionBlocks = (static_cast<int32_t> ((pCurPicture->iWidthInPixel >> 3) *
                                           (pCurPicture->iHeightInPixel >> 3) * STATIC_SCENE_MOTION_RATIO));
@@ -1046,12 +1045,10 @@ ESceneChangeIdc CWelsPreProcess::DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPi
         SaveBestRefToJudgement (iRefPicAvQP, iFrameComplexity, &sLtrJudgement);
         SaveBestRefToLocal (pRefPicInfo, sSceneChangeResult, &sLtrSaved);
         bBestRefIsLtr = bCurRefIsLtr;
-        pBestStrBlockStaticPointer = sSceneChangeResult.pStaticBlockIdc;
       }
       if (bCurRefIsLtr && JudgeBestRef (pRefPic, sSceneLtrJudgement, iFrameComplexity, bIsClosestLtrFrame)) {
         SaveBestRefToJudgement (iRefPicAvQP, iFrameComplexity, &sSceneLtrJudgement);
         SaveBestRefToLocal (pRefPicInfo, sSceneChangeResult, &sSceneLtrSaved);
-        pBestLtrBlockStaticPointer = sSceneChangeResult.pStaticBlockIdc;
       }
 
       if (iMotionBlockNum <= iNegligibleMotionBlocks) {
@@ -1072,6 +1069,7 @@ ESceneChangeIdc CWelsPreProcess::DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPi
            pCtx->iCodingIndex);
 
   SaveBestRefToVaa (sLtrSaved, & (pVaaExt->sVaaStrBestRefCandidate[0]));
+  pVaaExt->pVaaBestBlockStaticIdc = sLtrSaved.pBestBlockStaticIdc;
 
   if (0 == iAvailableSceneRefNum) {
     SaveBestRefToVaa (sSceneLtrSaved, & (pVaaExt->sVaaStrBestRefCandidate[1]));

--- a/codec/processing/src/common/util.h
+++ b/codec/processing/src/common/util.h
@@ -67,8 +67,15 @@ WELSVP_NAMESPACE_BEGIN
 
 #define WELS_MAX(x, y)	((x) > (y) ? (x) : (y))
 #define WELS_MIN(x, y)	((x) < (y) ? (x) : (y))
+
+#ifndef WELS_SIGN
 #define WELS_SIGN(a)	((int32_t)(a) >> 31)
+#endif
+
+#ifndef WELS_ABS
 #define WELS_ABS(a)		((WELS_SIGN(a) ^ (int32_t)(a)) - WELS_SIGN(a))
+#endif
+
 #define WELS_CLAMP(x, minv, maxv)  WELS_MIN(WELS_MAX(x, minv), maxv)
 
 #define ALIGNBYTES         (16)       /* Worst case is requiring alignment to an 16 byte boundary */


### PR DESCRIPTION
approved at: https://rbcommons.com/s/OpenH264/r/460/
1. if vlc overflow, re-encoding this macroblock by adding 2 for mb_quant.
2. remove temporally fix quant macro
3. merge "removing warnings" into this branch in util.h
