### PR TITLE
remove unused argument pBlock

### DIFF
--- a/codec/decoder/core/arm/block_add_neon.S
+++ b/codec/decoder/core/arm/block_add_neon.S
@@ -103,7 +103,7 @@
 // r1    int8_t* non_zero_count,
 WELS_ASM_FUNC_BEGIN SetNonZeroCount_neon
 
-	vld1.64	{d0-d2}, [r1]
+	vld1.64	{d0-d2}, [r0]
 
 	vceq.s8	q0, q0, #0
 	vceq.s8	d2, d2, #0
@@ -112,7 +112,7 @@ WELS_ASM_FUNC_BEGIN SetNonZeroCount_neon
 	vabs.s8	q0, q0
 	vabs.s8	d2, d2
 
-	vst1.64	{d0-d2}, [r1]
+	vst1.64	{d0-d2}, [r0]
 WELS_ASM_FUNC_END
 
 

--- a/codec/decoder/core/inc/decode_slice.h
+++ b/codec/decoder/core/inc/decode_slice.h
@@ -64,14 +64,14 @@ extern "C" {
 #endif//__cplusplus
 
 #if defined(HAVE_NEON)
-void SetNonZeroCount_neon (int16_t* pBlock, int8_t* pNonZeroCount);
+void SetNonZeroCount_neon (int8_t* pNonZeroCount);
 #endif
 
 #ifdef __cplusplus
 }
 #endif//__cplusplus
 
-void SetNonZeroCount_c (int16_t* pBlock, int8_t* pNonZeroCount);
+void SetNonZeroCount_c (int8_t* pNonZeroCount);
 
 void WelsBlockFuncInit (SBlockFunc* pFunc,  int32_t iCpu);
 

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -140,7 +140,7 @@ typedef struct TagDeblockingFunc {
   PChromaDeblockingEQ4Func  pfChromaDeblockingEQ4Hor;
 } SDeblockingFunc, *PDeblockingFunc;
 
-typedef void (*PWelsNonZeroCountFunc) (int16_t* pBlock, int8_t* pNonZeroCount);
+typedef void (*PWelsNonZeroCountFunc) (int8_t* pNonZeroCount);
 
 typedef  struct  TagBlockFunc {
   PWelsNonZeroCountFunc		pWelsSetNonZeroCountFunc;

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -183,8 +183,7 @@ int32_t WelsMbInterConstruction (PWelsDecoderContext pCtx, PDqLayer pCurLayer) {
   GetInterPred (pDstY, pDstCb, pDstCr, pCtx);
   WelsMbInterSampleConstruction (pCtx, pCurLayer, pDstY, pDstCb, pDstCr, iLumaStride, iChromaStride);
 
-  pCtx->sBlockFunc.pWelsSetNonZeroCountFunc (NULL,
-      pCurLayer->pNzc[pCurLayer->iMbXyIndex]); // set all none-zero nzc to 1; dbk can be opti!
+  pCtx->sBlockFunc.pWelsSetNonZeroCountFunc (pCurLayer->pNzc[pCurLayer->iMbXyIndex]); // set all none-zero nzc to 1; dbk can be opti!
   return 0;
 }
 
@@ -1054,7 +1053,7 @@ void WelsBlockFuncInit (SBlockFunc*   pFunc,  int32_t iCpu) {
 #endif
 }
 
-void SetNonZeroCount_c (int16_t* pBlock, int8_t* pNonZeroCount) {
+void SetNonZeroCount_c (int8_t* pNonZeroCount) {
   int32_t i;
 
   for (i = 0; i < 24; i++) {


### PR DESCRIPTION
The argument pBlock is not used, so it is safe to remove it.
