### PR TITLE
Set a sensible total bitrate when testing multilayer encoding

### DIFF
--- a/test/api/BaseEncoderTest.cpp
+++ b/test/api/BaseEncoderTest.cpp
@@ -47,6 +47,7 @@ static int InitWithParam(ISVCEncoder* encoder, EUsageType usageType,int width,
         param.uiMaxNalSize = 1500;
       }
     }
+    param.iTargetBitrate *= param.iSpatialLayerNum;
 
     return encoder->InitializeExt(&param);
   }


### PR DESCRIPTION
The previous encoder parameters triggered warning logging in
the encoder.
