### PR TITLE
Ignore a special case for expand chroma picture under X86_ASM to fix issue #947

### DIFF
--- a/test/decoder/DecUT_ExpandPicture.cpp
+++ b/test/decoder/DecUT_ExpandPicture.cpp
@@ -156,6 +156,10 @@ TEST (ExpandPicture, ExpandPictureChroma) {
 
     for (int32_t iTestIdx = 0; iTestIdx < EXPAND_PIC_TEST_NUM; iTestIdx++) {
       int32_t iPicWidth = (8 + (rand() % 200) * 8);
+      if(uiCpuFlag && WELS_CPU_SSE2)
+      {
+        iPicWidth = WELS_MAX(iPicWidth, 16);
+      }
       int32_t iPicHeight = (8 + (rand() % 100) * 8);
 
       int32_t iStride = (iPicWidth + H264_PADDING_LENGTH_CHROMA * 2 + 8) >> 4 << 4;


### PR DESCRIPTION
Review at: https://rbcommons.com/s/OpenH264/r/504/
To fix issue #947.
