### PR TITLE
remove multiplication overflow warning by ULL instead of LL

### DIFF
--- a/codec/encoder/core/src/get_intra_predictor.cpp
+++ b/codec/encoder/core/src/get_intra_predictor.cpp
@@ -441,7 +441,7 @@ void WelsIChormaPredH_c (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride) 
 #ifdef _MSC_VER
     uint64_t kuiSrc64 = (uint64_t) (0x0101010101010101U * kuiLeft);
 #else
-    uint64_t kuiSrc64 = (uint64_t) (0x0101010101010101LL * kuiLeft);
+    uint64_t kuiSrc64 = (uint64_t) (0x0101010101010101ULL * kuiLeft);
 #endif
     ST64 (pPred + iI8x8Stridex7, kuiSrc64);
 
@@ -522,8 +522,8 @@ void WelsIChormaPredDcLeft_c (uint8_t* pPred, uint8_t* pRef, const int32_t kiStr
   const uint64_t kuiTopMean64	= (uint64_t) (0x0101010101010101U * kuiTopMean);
   const uint64_t kuiBottomMean64	= (uint64_t) (0x0101010101010101U * kuiBottomMean);
 #else
-  const uint64_t kuiTopMean64	= (uint64_t) (0x0101010101010101LL * kuiTopMean);
-  const uint64_t kuiBottomMean64	= (uint64_t) (0x0101010101010101LL * kuiBottomMean);
+  const uint64_t kuiTopMean64	= (uint64_t) (0x0101010101010101ULL * kuiTopMean);
+  const uint64_t kuiBottomMean64	= (uint64_t) (0x0101010101010101ULL * kuiBottomMean);
 #endif
   ST64 (pPred   , kuiTopMean64);
   ST64 (pPred + 8 , kuiTopMean64);
@@ -556,7 +556,7 @@ void WelsIChormaPredDcNA_c (uint8_t* pPred, uint8_t* pRef, const int32_t kiStrid
 #ifdef _MSC_VER
   const uint64_t kuiDcValue64 = (uint64_t)0x8080808080808080U;
 #else
-  const uint64_t kuiDcValue64 = (uint64_t)0x8080808080808080LL;
+  const uint64_t kuiDcValue64 = (uint64_t)0x8080808080808080ULL;
 #endif
   ST64 (pPred   , kuiDcValue64);
   ST64 (pPred + 8 , kuiDcValue64);
@@ -594,7 +594,7 @@ void WelsI16x16LumaPredH_c (uint8_t* pPred, uint8_t* pRef, const int32_t kiStrid
 #ifdef _MSC_VER
     const uint64_t kuiV64	= (uint64_t) (0x0101010101010101U * kuiSrc8);
 #else
-    const uint64_t kuiV64	= (uint64_t) (0x0101010101010101LL * kuiSrc8);
+    const uint64_t kuiV64	= (uint64_t) (0x0101010101010101ULL * kuiSrc8);
 #endif
     ST64 (&pPred[iPredStridex15], kuiV64);
     ST64 (&pPred[iPredStridex15 + 8], kuiV64);

--- a/codec/processing/src/common/common.cpp
+++ b/codec/processing/src/common/common.cpp
@@ -60,7 +60,7 @@ void WelsI16x16LumaPredH_c (uint8_t* pPred, uint8_t* pRef, const int32_t kiStrid
 #ifdef _MSC_VER
     const uint64_t kuiV64	= (uint64_t) (0x0101010101010101U * kuiSrc8);
 #else
-    const uint64_t kuiV64	= (uint64_t) (0x0101010101010101LL * kuiSrc8);
+    const uint64_t kuiV64	= (uint64_t) (0x0101010101010101ULL * kuiSrc8);
 #endif
     ST64 (&pPred[iPredStridex15], kuiV64);
     ST64 (&pPred[iPredStridex15 + 8], kuiV64);


### PR DESCRIPTION
see:
https://rbcommons.com/s/OpenH264/r/519/
