### PR TITLE
Print an intX_t by casting to int64_t

### DIFF
--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -415,8 +415,8 @@ int32_t WelsDecodeSlice (PWelsDecoderContext pCtx, bool bFirstSliceInLayer, PNal
     }
     if (iUsedBits > pBs->iBits) { //When BS incomplete, as long as find it, SHOULD stop decoding to avoid mosaic or crash.
       WelsLog (pCtx, WELS_LOG_WARNING,
-               "WelsDecodeSlice()::::pBs incomplete, iUsedBits:%d > pBs->iBits:%d, MUST stop decoding.\n",
-               iUsedBits, pBs->iBits);
+               "WelsDecodeSlice()::::pBs incomplete, iUsedBits:%"PRId64" > pBs->iBits:%d, MUST stop decoding.\n",
+               (int64_t) iUsedBits, pBs->iBits);
       return -1;
     }
     iMbX = iNextMbXyIndex % pCurLayer->iMbWidth;


### PR DESCRIPTION
The internal intX_t is either int32_t or int64_t depending on
platform bitness. Since there is no existing printf format for
such an integer, cast it to an int64_t and use the right
printf format for that instead.

This avoids warnings when building with clang.
