### PR TITLE
Don't load undefined bits into rcx before calling the cpuid instruction

### DIFF
--- a/codec/common/x86/cpuid.asm
+++ b/codec/common/x86/cpuid.asm
@@ -81,7 +81,7 @@ WELS_EXTERN WelsCPUId
     push     rdx
 
     mov      eax,     ecx
-    mov      rcx,     [r9]
+    mov      ecx,     [r9]
     cpuid
     mov      [r9],    ecx
     mov      [r8],    ebx
@@ -100,7 +100,7 @@ WELS_EXTERN WelsCPUId
     push     rdx
 
     mov      eax,     edi
-    mov      rcx,     [rcx]
+    mov      ecx,     [rcx]
     cpuid
     mov      [r8],    edx
     pop      rdx


### PR DESCRIPTION
The pFeatureC pointer is an uint32_t pointer.

This avoids loading potentially uninitialized data into the upper
half of the rcx register, fixing valgrind warnings in some build
setups.
