### PR TITLE
Don't call srand(time()) inside utility functions inside tests

### DIFF
--- a/test/api/DataGenerator.cpp
+++ b/test/api/DataGenerator.cpp
@@ -1,5 +1,4 @@
 #include <string.h>//memset/memcpy
-#include <time.h>
 #include "utils/DataGenerator.h"
 #include "utils/BufferedData.h"
 #include "utils/FileInputStream.h"
@@ -27,7 +26,6 @@ bool YUVPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, 
     return false;
   }
   if (fileStream.read (sBuf.data(), kiFrameSize) == kiFrameSize) {
-    srand ((uint32_t)time (NULL));
     int32_t iStartPosX = rand() % (SRC_FRAME_WIDTH - iWidth);
     int32_t iStartPosY = rand() % (SRC_FRAME_HEIGHT - iHeight);
     uint8_t* pSrcPointer = sBuf.data() + iStartPosX + iStartPosY * SRC_FRAME_WIDTH;
@@ -43,9 +41,8 @@ bool YUVPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, 
   return false;
 }
 
-void RandomPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride, int32_t iIdx) {
+void RandomPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride) {
   uint8_t* pLocalPointer = pPointer;
-  srand ((uint32_t) (time (NULL) + iIdx));
   for (int32_t j = 0; j < iHeight; j++) {
     for (int32_t i = 0; i < iWidth; i++) {
       pLocalPointer[i] = rand() % 256;

--- a/test/api/simple_test.cpp
+++ b/test/api/simple_test.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <stdlib.h>
+#include <time.h>
 #if defined (ANDROID_NDK)
 #include <stdio.h>
 #endif
@@ -15,6 +17,7 @@ int main (int argc, char** argv) {
   sprintf (xmlPath, "xml:%s", argv[1]);
   ::testing::GTEST_FLAG (output) = xmlPath;
 #endif
+  srand ((unsigned int)time (NULL));
   ::testing::InitGoogleTest (&argc, argv);
 
   return RUN_ALL_TESTS();

--- a/test/common/ExpandPicture.cpp
+++ b/test/common/ExpandPicture.cpp
@@ -117,7 +117,6 @@ TEST (ExpandPicture, ExpandPictureLuma) {
       uiCpuFlag = WelsCPUFeatureDetect (&iCpuCores);
     }
     InitExpandPictureFunc (&sExpandPicFunc, uiCpuFlag);
-    srand ((unsigned int)time (0));
     for (int32_t iTestIdx = 0; iTestIdx < EXPAND_PIC_TEST_NUM; iTestIdx++) {
       int32_t iPicWidth = 16 + (rand() % 200) * 16;
       int32_t iPicHeight = 16 + (rand() % 100) * 16;
@@ -160,7 +159,6 @@ TEST (ExpandPicture, ExpandPictureChroma) {
       uiCpuFlag = WelsCPUFeatureDetect (&iCpuCores);
     }
     InitExpandPictureFunc (&sExpandPicFunc, uiCpuFlag);
-    srand ((unsigned int)time (0));
 
     for (int32_t iTestIdx = 0; iTestIdx < EXPAND_PIC_TEST_NUM; iTestIdx++) {
       int32_t iPicWidth = (8 + (rand() % 200) * 8);
@@ -207,7 +205,6 @@ TEST (ExpandPicture, ExpandPicForMotion) {
       uiCpuFlag = WelsCPUFeatureDetect (&iCpuCores);
     }
     InitExpandPictureFunc (&sExpandPicFunc, uiCpuFlag);
-    srand ((unsigned int)time (0));
     uint8_t* pPicAnchorBuffer = NULL;
     uint8_t* pPicTestBuffer = NULL;
     uint8_t* pPicAnchor[3] = {NULL, NULL, NULL};

--- a/test/decoder/DecUT_ErrorConcealment.cpp
+++ b/test/decoder/DecUT_ErrorConcealment.cpp
@@ -1,6 +1,4 @@
 #include<gtest/gtest.h>
-#include <stdlib.h>
-#include <time.h>
 
 #include "wels_common_basis.h"
 #include "mem_align.h"
@@ -49,7 +47,6 @@ int32_t InitAndAllocInputData (PECInputCtx& pECCtx) {
     return 1;
   memset (pECCtx, 0, sizeof (SECInputCtx));
 
-  srand ((uint32_t)time (NULL));
   pECCtx->iMbWidth = rand() % MAX_MB_WIDTH; //give a constrained max width
   pECCtx->iMbHeight = rand() % MAX_MB_HEIGHT; //give a constrained max height
   pECCtx->iLinesize[0] = pECCtx->iMbWidth << 4;
@@ -103,7 +100,6 @@ int32_t InitAndAllocInputData (PECInputCtx& pECCtx) {
 }
 
 void InitECCopyData (PECInputCtx pECCtx) {
-  srand ((uint32_t)time (NULL));
   const int32_t kiMbNum = pECCtx->iMbWidth * pECCtx->iMbHeight;
   int i;
   //init pMbCorrectlyDecodedFlag

--- a/test/decoder/DecUT_IdctResAddPred.cpp
+++ b/test/decoder/DecUT_IdctResAddPred.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <time.h>
 #include "macros.h"
 #include "decode_mb_aux.h"
 using namespace WelsDec;
@@ -51,7 +50,6 @@ TEST(DecoderDecodeMbAux, pred) {\
   int16_t iRefRS[16];\
   uint8_t uiRefPred[16*kiStride];\
   int32_t iRunTimes = 1000;\
-  srand((unsigned int)time(NULL));\
   while(iRunTimes--) {\
     for(int i = 0; i < 4; i++)\
       for(int j = 0; j < 4; j++)\

--- a/test/decoder/DecUT_IntraPrediction.cpp
+++ b/test/decoder/DecUT_IntraPrediction.cpp
@@ -1,5 +1,4 @@
 #include<gtest/gtest.h>
-#include <time.h>
 #include "cpu.h"
 #include "cpu_core.h"
 #include "get_intra_predictor.h"
@@ -21,7 +20,6 @@ if (ASM) {\
     return; \
   } \
 }\
-  srand((unsigned int)time(NULL)); \
   while(iRunTimes--) {\
   for (int i = 0; i < 12; i++) {\
     pRefBuffer[kiStride * 3 + i] = pPredBuffer[kiStride * 3 + i] = rand() & 255; \
@@ -391,7 +389,6 @@ if (ASM) { \
     return; \
   } \
 } \
-srand((unsigned int)time(NULL)); \
 while(iRunTimes--) {\
 for (int i = 0; i < 17; i ++) {\
   pRefBuffer[i] = pPredBuffer[i] = rand() & 255; \
@@ -529,7 +526,6 @@ if (ASM) { \
     return ; \
   } \
 }\
-srand((unsigned int)time(NULL)); \
 while(iRunTimes--) {\
 for (int i = 0; i < 17; i ++) {\
   pRefBuffer[i] = pPredBuffer[i] = rand() & 255; \

--- a/test/decoder/DecUT_MotionCompensation.cpp
+++ b/test/decoder/DecUT_MotionCompensation.cpp
@@ -136,7 +136,6 @@ TEST(McCopy_c,iW##x##iH) \
       uint8_t uSrcTest[MC_BUFF_HEIGHT][MC_BUFF_SRC_STRIDE];    \
       ENFORCE_STACK_ALIGN_2D(uint8_t, uDstAnchor, MC_BUFF_HEIGHT, MC_BUFF_DST_STRIDE, 16); \
       ENFORCE_STACK_ALIGN_2D(uint8_t, uDstTest, MC_BUFF_HEIGHT, MC_BUFF_DST_STRIDE, 16); \
-      srand((unsigned int)time(0));                           \
       for(int32_t j=0;j<MC_BUFF_HEIGHT;j++)                    \
       {                                                         \
         for(int32_t i=0;i<MC_BUFF_SRC_STRIDE;i++)                  \
@@ -183,7 +182,6 @@ TEST(McHorVer##a##b##_c,iW##x##iH)  \
     uSrcInputAnchor[1] = &uSrcAnchor[1][4][4]; \
     uSrcInputAnchor[2] = &uSrcAnchor[2][4][4]; \
     uSrcInputAnchor[3] = &uSrcAnchor[3][4][4]; \
-    srand((unsigned int)time(0)); \
     for(int32_t j=0;j<MC_BUFF_HEIGHT;j++)   \
     {\
       for(int32_t i=0;i<MC_BUFF_SRC_STRIDE;i++)   \
@@ -252,7 +250,6 @@ TEST(McChromaWithFragMv_##a##b##_c,iW##x##iH)  \
     ENFORCE_STACK_ALIGN_2D(uint8_t, uDstAnchor1, MC_BUFF_HEIGHT, MC_BUFF_DST_STRIDE, 16); \
     ENFORCE_STACK_ALIGN_2D(uint8_t, uDstAnchor2, MC_BUFF_HEIGHT, MC_BUFF_DST_STRIDE, 16); \
     ENFORCE_STACK_ALIGN_2D(uint8_t, uDstTest, MC_BUFF_HEIGHT, MC_BUFF_DST_STRIDE, 16); \
-    srand((unsigned int)time(0)); \
     for(int32_t j=0;j<MC_BUFF_HEIGHT;j++)   \
     {\
       for(int32_t i=0;i<MC_BUFF_SRC_STRIDE;i++)   \

--- a/test/decoder/DecUT_PredMv.cpp
+++ b/test/decoder/DecUT_PredMv.cpp
@@ -1,6 +1,4 @@
 #include<gtest/gtest.h>
-#include <stdlib.h>
-#include <time.h>
 
 #include "wels_common_basis.h"
 #include "mem_align.h"
@@ -133,7 +131,6 @@ typedef struct TagWelsMvPred {
 //mok input data
 void AssignMvInputData (SAnchorMvPred* pAncMvPred) {
   int32_t i, j, k;
-  srand ((uint32_t)time (NULL));
   //fill MV data and refIdx
   for (i = 0; i < 2; ++i) {
     for (j = 0; j < 30; ++j) {
@@ -182,7 +179,6 @@ TEST (PredMvTest, PredMv) {
   iIndex = 0;
   iBlockWidth = 4;
   i = 0;
-  srand ((uint32_t)time (NULL));
   while (i++ < kiRandTime) {
     iRef = (rand() % 18) - 2; //-2~15
     INIT_MV_DATA;
@@ -235,7 +231,6 @@ TEST (PredMvTest, PredInter16x8Mv) {
   bool bOK = true;
 
   i = 0;
-  srand ((uint32_t)time (NULL));
   while (i++ < kiRandTime) {
     iIndex = (rand() & 1) << 3; //0, 8
     iRef = (rand() % 18) - 2; //-2~15
@@ -255,7 +250,6 @@ TEST (PredMvTest, PredInter8x16Mv) {
   bool bOK = true;
 
   i = 0;
-  srand ((uint32_t)time (NULL));
   while (i++ < kiRandTime) {
     iIndex = (rand() & 1) << 2; //0, 4
     iRef = (rand() % 18) - 2; //-2~15
@@ -469,7 +463,6 @@ int32_t FreeLayerData (PDqLayer pDqLayer) {
 }
 
 void InitRandomLayerSliceIdc (PDqLayer pDqLayer) {
-  srand ((uint32_t)time (NULL));
   int32_t i = 0;
   int32_t iTotalMbNum = pDqLayer->iMbWidth * pDqLayer->iMbHeight;
   int32_t iMbFirstSliceEnd = rand() % (iTotalMbNum - 1); //assure 2 slices
@@ -482,14 +475,12 @@ void InitRandomLayerSliceIdc (PDqLayer pDqLayer) {
 }
 
 void InitRandomLayerMbType (PDqLayer pDqLayer) {
-  srand ((uint32_t)time (NULL));
   for (int32_t i = 0; i < pDqLayer->iMbWidth * pDqLayer->iMbHeight; ++i) {
     pDqLayer->pMbType[i] = (rand() & 0x0f) + 1; //1 ~ 16
   }
 }
 
 void InitRandomLayerMvData (PDqLayer pDqLayer) {
-  srand ((uint32_t)time (NULL));
   for (int32_t i = 0; i < pDqLayer->iMbWidth * pDqLayer->iMbHeight; ++i) {
     for (int32_t j = 0; j < MB_BLOCK4x4_NUM; ++j) {
       for (int32_t k = 0; k < MV_A; ++k) {
@@ -500,7 +491,6 @@ void InitRandomLayerMvData (PDqLayer pDqLayer) {
 }
 
 void InitRandomLayerRefIdxData (PDqLayer pDqLayer) {
-  srand ((uint32_t)time (NULL));
   for (int32_t i = 0; i < pDqLayer->iMbWidth * pDqLayer->iMbHeight; ++i) {
     for (int32_t j = 0; j < MB_BLOCK4x4_NUM; ++j) {
       pDqLayer->pRefIndex[0][i][j] = (rand() % 18 - 2); //-2 ~ 15

--- a/test/encoder/EncUT_DecodeMbAux.cpp
+++ b/test/encoder/EncUT_DecodeMbAux.cpp
@@ -1,6 +1,4 @@
 #include<gtest/gtest.h>
-#include<stdlib.h>
-#include<time.h>
 #include "decode_mb_aux.h"
 #include "wels_common_basis.h"
 #include "macros.h"
@@ -11,7 +9,6 @@ using namespace WelsSVCEnc;
 
 TEST (DecodeMbAuxTest, TestIhdm_4x4_dc) {
   short W[16], T[16], Y[16];
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < 16; i++)
     W[i] = rand() % 256 + 1;
 
@@ -62,7 +59,6 @@ TEST (DecodeMbAuxTest, TestIhdm_4x4_dc) {
 
 TEST (DecodeMbAuxTest, TestDequant_4x4_luma_dc) {
   short T[16], W[16];
-  srand ((uint32_t)time (NULL));
 
   for (int qp = 0; qp < 12; qp++) {
     for (int i = 0; i < 16; i++) {
@@ -79,7 +75,6 @@ TEST (DecodeMbAuxTest, TestDequant_4x4_luma_dc) {
 
 TEST (DecodeMbAuxTest, TestDequant_ihdm_4x4_c) {
   short W[16], T[16], Y[16];
-  srand ((uint32_t)time (NULL));
   const unsigned short mf = rand() % 16 + 1;
   for (int i = 0; i < 16; i++)
     W[i] = rand() % 256 + 1;
@@ -132,7 +127,6 @@ TEST (DecodeMbAuxTest, TestDequant_ihdm_4x4_c) {
 TEST (DecodeMbAuxTest, TestDequant_4x4_c) {
   short W[16], T[16];
   unsigned short mf[16];
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < 16; i++) {
     W[i] = rand() % 256 + 1;
     T[i] = W[i];
@@ -147,7 +141,6 @@ TEST (DecodeMbAuxTest, TestDequant_4x4_c) {
 TEST (DecodeMbAuxTest, TestDequant_4_4x4_c) {
   short W[64], T[64];
   unsigned short mf[16];
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < 64; i++) {
     W[i] = rand() % 256 + 1;
     T[i] = W[i];
@@ -171,7 +164,6 @@ void WelsDequantHadamard2x2DcAnchor (int16_t* pDct, int16_t iMF) {
 TEST (DecodeMbAuxTest, WelsDequantIHadamard2x2Dc) {
   int16_t iDct[4], iRefDct[4];
   int16_t iMF;
-  srand ((unsigned int)time (NULL));
   iMF = rand() & 127;
   for (int i = 0; i < 4; i++)
     iDct[i] = iRefDct[i] = (rand() & 65535) - 32768;
@@ -216,7 +208,6 @@ TEST (DecodeMbAuxTest, WelsIDctT4Rec_c) {
   ENFORCE_STACK_ALIGN_1D (int16_t, iDct, 16, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, iPred, 16 * FDEC_STRIDE, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, iRec, 16 * FDEC_STRIDE, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
       iRefDct[i * 4 + j] = iDct[i * 4 + j] = (rand() & 65535) - 32768;
@@ -245,7 +236,6 @@ TEST (DecodeMbAuxTest, WelsIDctT4Rec_mmx) {
     ENFORCE_STACK_ALIGN_1D (uint8_t, iPred, 16 * FDEC_STRIDE, 16);
     ENFORCE_STACK_ALIGN_1D (uint8_t, iRecC, 16 * FDEC_STRIDE, 16);
     ENFORCE_STACK_ALIGN_1D (uint8_t, iRecM, 16 * FDEC_STRIDE, 16);
-    srand ((unsigned int)time (NULL));
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 4; j++) {
         iDct[i * 4 + j] = (rand() & ((1 << 12) - 1)) - (1 << 11);
@@ -279,7 +269,6 @@ TEST (DecodeMbAuxTest, WelsIDctFourT4Rec_c) {
   ENFORCE_STACK_ALIGN_1D (int16_t, iDct, 64, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, iPred, 16 * FDEC_STRIDE, 16);
   ENFORCE_STACK_ALIGN_1D (uint8_t, iRec, 16 * FDEC_STRIDE, 16);
-  srand ((unsigned int)time (NULL));
   for (int k = 0; k < 4; k++)
     for (int i = 0; i < 16; i++)
       iRefDct[k][i] = iDct[k * 16 + i] = (rand() & 65535) - 32768;

--- a/test/encoder/EncUT_EncoderMb.cpp
+++ b/test/encoder/EncUT_EncoderMb.cpp
@@ -124,8 +124,8 @@ void TestQuant (uint32_t qp, uint8_t* pSrc, uint8_t* pPred, int16_t* pDct,
   const int16_t* pFfI = g_kiQuantInterFF[6 + qp];
   const int16_t* pFfP = g_kiQuantInterFF[qp];
   //quant4x4  Intra MB
-  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth, 0);
-  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth, rand());
+  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth);
+  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth);
 
   for (int16_t i = 0; i < 16; i++) {
     pDct[i] = pSrc[i] - pPred[i];
@@ -142,8 +142,8 @@ void TestQuant (uint32_t qp, uint8_t* pSrc, uint8_t* pPred, int16_t* pDct,
   }
 
   //quant4x4 DC
-  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth, 0);
-  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth, rand());
+  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth);
+  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth);
 
   for (int16_t i = 0; i < 16; i++) {
     pDct[i] = pSrc[i] - pPred[i];
@@ -160,8 +160,8 @@ void TestQuant (uint32_t qp, uint8_t* pSrc, uint8_t* pPred, int16_t* pDct,
   }
 
   //quant4x4 Inter MB
-  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth, 0);
-  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth, rand());
+  RandomPixelDataGenerator (pSrc, iWidth, iHeight, iWidth);
+  RandomPixelDataGenerator (pPred, iWidth, iHeight, iWidth);
 
   for (int16_t i = 0; i < 64; i++) {
     pDct[i] =  pSrc[i] - pPred[i];

--- a/test/encoder/EncUT_EncoderMbAux.cpp
+++ b/test/encoder/EncUT_EncoderMbAux.cpp
@@ -1,6 +1,4 @@
 #include<gtest/gtest.h>
-#include<stdlib.h>
-#include<time.h>
 #include "ls_defines.h"
 #include "encode_mb_aux.h"
 #include "wels_common_basis.h"
@@ -14,7 +12,6 @@ TEST (EncodeMbAuxTest, TestScan_4x4_ac_c) {
   ALLOC_MEMORY (int16_t, iLevel, 16);
   ALLOC_MEMORY (int16_t, iDctA, 16);
   ALLOC_MEMORY (int16_t, iDctB, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 16; i++) {
     iDctA[i] = rand() % 256 + 1;
     iDctB[i] = iDctA[i];
@@ -47,7 +44,6 @@ TEST (EncodeMbAuxTest, TestScan_4x4_ac_sse2) {
   ALLOC_MEMORY (int16_t, iLevelA, 16);
   ALLOC_MEMORY (int16_t, iLevelB, 16);
   ALLOC_MEMORY (int16_t, iDct, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 16; i++) {
     iDct[i] = rand() % 256 + 1;
   }
@@ -64,7 +60,6 @@ TEST (EncodeMbAuxTest, WelsScan4x4DcAc_sse2) {
   ALLOC_MEMORY (int16_t, iLevelA, 32);
   ALLOC_MEMORY (int16_t, iLevelB, 32);
   ALLOC_MEMORY (int16_t, iDct, 32);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 32; i++)
     iDct[i] = (rand() & 32767) - 16384;
   WelsScan4x4DcAc_sse2 (iLevelA, iDct);
@@ -81,7 +76,6 @@ TEST (EncodeMbAuxTest, TestScan_4x4_dcc) {
   ALLOC_MEMORY (int16_t, iLevel, 16);
   ALLOC_MEMORY (int16_t, iDctA, 16);
   ALLOC_MEMORY (int16_t, iDctB, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 16; i++)
     iDctA[i] = iDctB[i] = rand() % 256 + 1;
   WelsScan4x4Dc (iLevel, iDctA);
@@ -154,7 +148,6 @@ TEST (EncodeMbAuxTest, WelsDctT4_c) {
   int16_t iDctRef[4][4];
   uint8_t uiPix1[16 * FENC_STRIDE], uiPix2[16 * FDEC_STRIDE];
   int16_t iDct[16];
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 4; i++)
     for (int j = 0; j < 4; j++)
       uiPix1[i * FENC_STRIDE + j] = uiPix2[i * FDEC_STRIDE + j] = rand() & 255;
@@ -168,7 +161,6 @@ TEST (EncodeMbAuxTest, WelsDctFourT4_c) {
   int16_t iDctRef[4][4][4];
   uint8_t uiPix1[16 * FENC_STRIDE], uiPix2[16 * FDEC_STRIDE];
   int16_t iDct[16 * 4];
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 8; i++)
     for (int j = 0; j < 8; j++)
       uiPix1[i * FENC_STRIDE + j] = uiPix2[i * FDEC_STRIDE + j] = rand() & 255;
@@ -184,7 +176,6 @@ TEST (EncodeMbAuxTest, WelsDctFourT4_c) {
 TEST (EncodeMbAuxTest, WelsDctT4_mmx) {
   int16_t iDctC[16], iDctM[16];
   uint8_t uiPix1[16 * FENC_STRIDE], uiPix2[16 * FDEC_STRIDE];
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 4; i++)
     for (int j = 0; j < 4; j++)
       uiPix1[i * FENC_STRIDE + j] = uiPix2[i * FDEC_STRIDE + j] = rand() & 255;
@@ -200,7 +191,6 @@ TEST (EncodeMbAuxTest, WelsDctFourT4_sse2) {
   ALLOC_MEMORY (uint8_t, uiPix2, 16 * FDEC_STRIDE);
   ALLOC_MEMORY (int16_t, iDctC, 16 * 4);
   ALLOC_MEMORY (int16_t, iDctS, 16 * 4);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 8; i++)
     for (int j = 0; j < 8; j++)
       uiPix1[i * FENC_STRIDE + j] = uiPix2[i * FDEC_STRIDE + j] = rand() & 255;
@@ -218,7 +208,6 @@ TEST (EncodeMbAuxTest, WelsCalculateSingleCtr4x4_sse2) {
   CMemoryAlign cMemoryAlign (0);
   ALLOC_MEMORY (int16_t, iDctC, 16);
   ALLOC_MEMORY (int16_t, iDctS, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 16; i++)
     iDctC[i] = iDctS[i] = (rand() & 65535) - 32768;
   WelsCalculateSingleCtr4x4_c (iDctC);
@@ -242,7 +231,6 @@ TEST(EncodeMbAuxTest, function) { \
   ENFORCE_STACK_ALIGN_1D (uint8_t, ref_src, iSStride*height, 16); \
   ENFORCE_STACK_ALIGN_1D (uint8_t, ref_dst, iDStride*height, 16); \
   ENFORCE_STACK_ALIGN_1D (uint8_t, dst, iDStride*height, 16); \
-  srand((unsigned int)time(NULL)); \
   for(int i = 0; i < height; i++) \
     for(int j = 0; j < width; j++) \
       ref_src[i*iSStride+j] = rand() & 255; \
@@ -265,7 +253,6 @@ GENERATE_UT_FOR_COPY (16, 16, WelsCopy16x16_sse2);
 #endif
 TEST (EncodeMbAuxTest, WelsGetNoneZeroCount_c) {
   ENFORCE_STACK_ALIGN_1D (int16_t, pLevel, 16, 16);
-  srand ((unsigned int)time (NULL));
   int32_t result = 0;
   for (int i = 0; i < 16; i++) {
     pLevel[i] = (rand() & 0x07) - 4;
@@ -277,7 +264,6 @@ TEST (EncodeMbAuxTest, WelsGetNoneZeroCount_c) {
 #ifdef X86_ASM
 TEST (EncodeMbAuxTest, WelsGetNoneZeroCount_sse2) {
   ENFORCE_STACK_ALIGN_1D (int16_t, pLevel, 16, 16);
-  srand ((unsigned int)time (NULL));
   int32_t result = 0;
   for (int i = 0; i < 16; i++) {
     pLevel[i] = (rand() & 0x07) - 4;
@@ -310,7 +296,6 @@ TEST (EncodeMbAuxTest, WelsQuantFour4x4Max_c) {
   int16_t ff[8], mf[8];
   int16_t iDctA[64], iMaxA[16];
   int16_t iDctC[64], iMaxC[16];
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 8; i++) {
     ff[i] = rand() & 32767;
     mf[i] = rand() & 32767;
@@ -333,7 +318,6 @@ TEST (EncodeMbAuxTest, WelsQuantFour4x4Max_sse2) {
   ALLOC_MEMORY (int16_t, iDctS, 64);
   ALLOC_MEMORY (int16_t, iMaxC, 16);
   ALLOC_MEMORY (int16_t, iMaxS, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 8; i++) {
     ff[i] = rand() & 32767;
     mf[i] = rand() & 32767;
@@ -372,7 +356,6 @@ int32_t WelsHadamardQuant2x2SkipAnchor (int16_t* rs, int16_t ff,  int16_t mf) {
 TEST (EncodeMbAuxTest, WelsHadamardQuant2x2Skip_c) {
   int16_t iRS[64];
   int16_t ff, mf;
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 64; i++)
     iRS[i] = (rand() & 32767) - 16384;
   ff = rand() & 32767;
@@ -417,7 +400,6 @@ TEST (EncodeMbAuxTest, WelsHadamardQuant2x2_c) {
   int16_t iRsC[64], iRsA[64];
   int16_t ff, mf;
   int16_t iBlockA[16], iBlockC[16], iDctA[4], iDctC[4];
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 64; i++)
     iRsA[i] = iRsC[i] = (rand() & 32767) - 16384;
   for (int i = 0; i < 4; i++)
@@ -462,7 +444,6 @@ TEST (EncodeMbAuxTest, WelsHadamardT4Dc_c) {
   ALLOC_MEMORY (int16_t, iDct, 128 * 16);
   ALLOC_MEMORY (int16_t, iLumaDcR, 16);
   ALLOC_MEMORY (int16_t, iLumaDcC, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 128 * 16; i++)
     iDct[i] = (rand() & 32767) - 16384;
   WelsHadamardT4DcAnchor (iLumaDcR, iDct);
@@ -479,7 +460,6 @@ TEST (EncodeMbAuxTest, WelsHadamardT4Dc_sse2) {
   ALLOC_MEMORY (int16_t, iDct, 128 * 16);
   ALLOC_MEMORY (int16_t, iLumaDcC, 16);
   ALLOC_MEMORY (int16_t, iLumaDcS, 16);
-  srand ((unsigned int)time (NULL));
   for (int i = 0; i < 128 * 16; i++)
     iDct[i] = (rand() & 32767) - 16384;
   WelsHadamardT4Dc_c (iLumaDcC, iDct);

--- a/test/encoder/EncUT_MemoryAlloc.cpp
+++ b/test/encoder/EncUT_MemoryAlloc.cpp
@@ -1,5 +1,3 @@
-#include <time.h>
-
 #include "gtest/gtest.h"
 #include "memory_align.h"
 
@@ -30,7 +28,6 @@ TEST (MemoryAlignTest, GetCacheLineSize_MaxUINT) {
 //Tests of WelsMallocAndFree Begin
 TEST (MemoryAlignTest, WelsMallocAndFreeOnceFunctionVerify) {
   const uint32_t kuiTargetAlignSize[4] = {32, 16, 64, 8};
-  srand ((uint32_t)time (NULL));
   const uint32_t kuiZero = 0;
   for (int i = 0; i < 4; i++) {
     const uint32_t kuiTestAlignSize	= kuiTargetAlignSize[i];

--- a/test/encoder/EncUT_MotionEstimate.cpp
+++ b/test/encoder/EncUT_MotionEstimate.cpp
@@ -81,7 +81,6 @@ TEST_F (MotionEstimateTest, TestDiamondSearch) {
   SWelsME sMe;
   SSlice sSlice;
 
-  srand ((uint32_t)time (NULL));
   const uint8_t kuiQp = rand() % 52;
   InitMe (kuiQp, 648, m_uiMvdTableSize, m_pMvdCostTable, &sMe);
 
@@ -132,7 +131,6 @@ void MotionEstimateTest::DoLineTest (PLineFullSearchFunc func, bool vertical) {
   SWelsFuncPtrList sFuncList;
   SWelsME sMe;
 
-  srand ((uint32_t)time (NULL));
   const uint8_t kuiQp = rand() % 52;
   InitMe (kuiQp, 648, m_uiMvdTableSize, m_pMvdCostTable, &sMe);
 
@@ -314,7 +312,6 @@ TEST_F (FeatureMotionEstimateTest, TestFeatureSearch) {
   WelsInitMeFunc (&sFuncList, 0, true);
 
   SWelsME sMe;
-  srand ((uint32_t)time (NULL));
   const uint8_t kuiQp = rand() % 52;
   InitMe (kuiQp, 648, m_uiMvdTableSize, m_pMvdCostTable, &sMe);
   sMe.iCurMeBlockPixX = (m_iWidth / 2);

--- a/test/encoder/EncUT_Sample.cpp
+++ b/test/encoder/EncUT_Sample.cpp
@@ -1,7 +1,5 @@
 #include<gtest/gtest.h>
 #include<math.h>
-#include<stdlib.h>
-#include<time.h>
 
 #include "cpu_core.h"
 #include "cpu.h"
@@ -24,7 +22,6 @@ TEST (IntraSadSatdFuncTest, WelsIntra16x16Combined3Sad_ssse3) {
   uint8_t* pDec = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeDec << 5, "pDec");
   uint8_t* pEnc = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeEnc << 5, "pEnc");
   uint8_t* pDst = (uint8_t*)cMemoryAlign.WelsMalloc (512, "pDst");
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (iLineSizeDec << 5); i++)
     pDec[i] = rand() % 256;
   for (int i = 0; i < (iLineSizeEnc << 5); i++)
@@ -56,7 +53,6 @@ TEST (IntraSadSatdFuncTest, WelsIntra16x16Combined3Satd_sse41) {
   uint8_t* pDec = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeDec << 5, "pDec");
   uint8_t* pEnc = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeEnc << 5, "pEnc");
   uint8_t* pDst = (uint8_t*)cMemoryAlign.WelsMalloc (512, "pDst");
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (iLineSizeDec << 5); i++)
     pDec[i] = rand() % 256;
   for (int i = 0; i < (iLineSizeEnc << 5); i++)
@@ -88,7 +84,6 @@ TEST (IntraSadSatdFuncTest, WelsSampleSatdThree4x4_sse2) {
   uint8_t* pEnc = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeEnc << 5, "pEnc");
   uint8_t* pDst = (uint8_t*)cMemoryAlign.WelsMalloc (512, "pDst");
   WelsInitFillingPredFuncs (WELS_CPU_SSE2);
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (iLineSizeDec << 5); i++)
     pDec[i] = rand() % 256;
   for (int i = 0; i < (iLineSizeEnc << 5); i++)
@@ -121,7 +116,6 @@ TEST (IntraSadSatdFuncTest, WelsIntraChroma8x8Combined3Satd_sse41) {
   uint8_t* pDecCr = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeDec << 5, "pDecCr");
   uint8_t* pEncCr = (uint8_t*)cMemoryAlign.WelsMalloc (iLineSizeEnc << 5, "pEncCr");
   uint8_t* pDstChma = (uint8_t*)cMemoryAlign.WelsMalloc (512, "pDstChma");
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (iLineSizeDec << 5); i++) {
     pDecCb[i] = rand() % 256;
     pDecCr[i] = rand() % 256;
@@ -165,7 +159,6 @@ class SadSatdCFuncTest : public testing::Test {
   virtual void SetUp() {
     pMemAlign = new CMemoryAlign (0);
 
-    srand ((uint32_t)time (NULL));
     m_iStrideA = rand() % 256 + PIXEL_STRIDE;
     m_iStrideB = rand() % 256 + PIXEL_STRIDE;
     m_pPixSrcA = (uint8_t*)pMemAlign->WelsMalloc (m_iStrideA << 5, "Sad_m_pPixSrcA");
@@ -192,7 +185,6 @@ class SadSatdCFuncTest : public testing::Test {
 };
 
 TEST_F (SadSatdCFuncTest, WelsSampleSad4x4_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 2); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 2); i++)
@@ -211,7 +203,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSad4x4_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSad8x8_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -231,7 +222,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSad8x8_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSad16x8_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -251,7 +241,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSad16x8_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSad8x16_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -271,7 +260,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSad8x16_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSad16x16_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -291,7 +279,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSad16x16_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSatd4x4_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 2); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 2); i++)
@@ -355,7 +342,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSatd4x4_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSadFour16x16_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -379,7 +365,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSadFour16x16_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSadFour16x8_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -404,7 +389,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSadFour16x8_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSadFour8x16_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -429,7 +413,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSadFour8x16_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSadFour8x8_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -453,7 +436,6 @@ TEST_F (SadSatdCFuncTest, WelsSampleSadFour8x8_c) {
 }
 
 TEST_F (SadSatdCFuncTest, WelsSampleSadFour4x4_c) {
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -512,7 +494,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad4x4_mmx) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_MMXEXT))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 2); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 2); i++)
@@ -527,7 +508,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad8x8_sse21) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -540,7 +520,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad8x8_sse21) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad8x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -553,7 +532,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad8x16_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad16x8_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -566,7 +544,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad16x8_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad16x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -579,7 +556,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSad16x16_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd4x4_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 2); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 2); i++)
@@ -592,7 +568,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd4x4_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x8_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -605,7 +580,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x8_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -618,7 +592,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x16_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x8_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -631,7 +604,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x8_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -644,7 +616,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x16_sse2) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd4x4_sse41) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE41))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 2); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 2); i++)
@@ -657,7 +628,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd4x4_sse41) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x8_sse41) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE41))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -670,7 +640,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x8_sse41) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x16_sse41) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE41))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -683,7 +652,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd8x16_sse41) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x8_sse41) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE41))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)
@@ -696,7 +664,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x8_sse41) {
 TEST_F (SadSatdAssemblyFuncTest, WelsSampleSatd16x16_sse41) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE41))
     return;
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -710,7 +677,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSadFour16x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -739,7 +705,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSadFour16x8_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -768,7 +733,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSadFour8x16_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 5); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 5); i++)
@@ -797,7 +761,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSadFour8x8_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 4); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 4); i++)
@@ -827,7 +790,6 @@ TEST_F (SadSatdAssemblyFuncTest, WelsSampleSadFour4x4_sse2) {
   if (0 == (m_uiCpuFeatureFlag & WELS_CPU_SSE2))
     return;
 
-  srand ((uint32_t)time (NULL));
   for (int i = 0; i < (m_iStrideA << 3); i++)
     m_pPixSrcA[i] = rand() % 256;
   for (int i = 0; i < (m_iStrideB << 3); i++)

--- a/test/processing/ProcessUT_ScrollDetection.cpp
+++ b/test/processing/ProcessUT_ScrollDetection.cpp
@@ -21,7 +21,6 @@ TEST (ScrollDetectionTest, TestScroll) {
   int iWidthSets[4] = {640, 1024, 1280, 1980};
   int iHeightSets[4] = {360, 768, 720, 1080};
   int iStride = 0;
-  int iIdx = 0;
 
   for (int i = 0; i < 4; i++) {
     int iWidth = iWidthSets[i];
@@ -31,7 +30,7 @@ TEST (ScrollDetectionTest, TestScroll) {
     ASSERT_TRUE (NULL != pSrc);
     pRef = new unsigned char[iHeight * iStride];
     ASSERT_MEMORY_FAIL2X (pSrc, pRef)
-    RandomPixelDataGenerator (pRef, iWidth, iHeight, iStride, iIdx);
+    RandomPixelDataGenerator (pRef, iWidth, iHeight, iStride);
 
     int iMvRange = iHeight / 3;
     int iScrollMv = rand() % (iMvRange << 1) - iMvRange;

--- a/test/utils/DataGenerator.h
+++ b/test/utils/DataGenerator.h
@@ -5,7 +5,7 @@
 
 bool YUVPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride);
 
-void RandomPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride, int32_t iIdx);
+void RandomPixelDataGenerator (uint8_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride);
 
 void RandomResidueDataGenerator (uint16_t* pPointer, int32_t iWidth, int32_t iHeight, int32_t iStride);
 


### PR DESCRIPTION
This fixes occasional errors in MotionEstimateTest.

This also helps debugging test failures. When trying to track down
a failed test, the random values should be reproducible. This is
easy to track if srand() is called at most once within a test
run - then one can easily find one individual random seed that
triggers failures, and retry that setup multiple times until the
issue is resolved.

MotionEstimateTest was designed to allow the test to occasionally
not succeed - if it didn't succeed, it tried again, up to 100 times.
However, since the YUVPixelDataGenerator function reset the random
seed to time(), every attempt actually ran with the same random
data (as long as all 100 attempts ran within 1 second) - thus if
one attempt in MotionEstimateTest failed, all 100 of them would
fail. If the utility functions don't touch the random seed,
this is not an issue.
