### PR TITLE
Avoid warnings when building for iOS

### DIFF
--- a/codec/common/src/crt_util_safe_x.cpp
+++ b/codec/common/src/crt_util_safe_x.cpp
@@ -234,7 +234,7 @@ int32_t WelsStrftime (char* pBuffer, int32_t iSize, const char* kpFormat, const 
 
   pTnow = localtime (&kpTp->time);
 
-  iRc = strftime (pBuffer, iSize, kpFormat, pTnow);
+  iRc = (int32_t) strftime (pBuffer, iSize, kpFormat, pTnow);
   if (iRc == 0)
     pBuffer[0] = '\0';
   return iRc;

--- a/codec/console/dec/inc/read_config.h
+++ b/codec/console/dec/inc/read_config.h
@@ -58,7 +58,7 @@ class CReadConfig {
  private:
   FILE*			m_pCfgFile;
   string			m_strCfgFileName;
-  unsigned long	m_ulLines;
+  unsigned int	m_ulLines;
 };
 
 #endif	// READ_CONFIG_H__

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -128,7 +128,7 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
   printf ("------------------------------------------------------\n");
 
   fseek (pH264File, 0L, SEEK_END);
-  iFileSize = ftell (pH264File);
+  iFileSize = (int32_t) ftell (pH264File);
   if (iFileSize <= 0) {
     fprintf (stderr, "Current Bit Stream File is too small, read error!!!!\n");
     goto label_exit;
@@ -349,7 +349,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
           } else if (strTag[0].compare ("TargetDQID") == 0) {
             sDecParam.uiTargetDqLayer	= (uint8_t)atol (strTag[1].c_str());
           } else if (strTag[0].compare ("OutColorFormat") == 0) {
-            sDecParam.iOutputColorFormat = atol (strTag[1].c_str());
+            sDecParam.iOutputColorFormat = atoi (strTag[1].c_str());
           } else if (strTag[0].compare ("ErrorConcealmentFlag") == 0) {
             sDecParam.uiEcActiveFlag	= (uint8_t)atol (strTag[1].c_str());
           } else if (strTag[0].compare ("CPULoad") == 0) {

--- a/codec/console/enc/inc/read_config.h
+++ b/codec/console/enc/inc/read_config.h
@@ -70,7 +70,7 @@ class CReadConfig {
  private:
   FILE*			m_pCfgFile;
   string			m_strCfgFileName;
-  unsigned long	m_iLines;
+  unsigned int	m_iLines;
 };
 
 #endif	// READ_CONFIG_H__

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -471,7 +471,7 @@ int ParseCommandLine (int argc, char** argv, SSourcePicture* pSrcPic, SEncParamE
       }
     } else if (!strcmp (pCommand, "-drec") && (n + 1 < argc)) {
       unsigned int	iLayer = atoi (argv[n++]);
-      const unsigned int iLen = strlen (argv[n]);
+      const unsigned int iLen = (int) strlen (argv[n]);
       if (iLen >= sizeof (sFileSet.sRecFileName[iLayer]))
         return 1;
       sFileSet.sRecFileName[iLayer][iLen] = '\0';
@@ -921,8 +921,8 @@ void LockToSingleCore() {
   return ;
 }
 
-long CreateSVCEncHandle (ISVCEncoder** ppEncoder) {
-  long ret = 0;
+int32_t CreateSVCEncHandle (ISVCEncoder** ppEncoder) {
+  int32_t ret = 0;
   ret = WelsCreateSVCEncoder (ppEncoder);
   return ret;
 }

--- a/test/build/ios/codec_unittest/codec_unittest/main.m
+++ b/test/build/ios/codec_unittest/codec_unittest/main.m
@@ -50,7 +50,7 @@ int main(int argc, char * argv[])
     sprintf(path, "%s%s",xmlWritePath,"/codec_unittest.xml");
 #endif
     argc =2;
-    argv[0]="codec_unittest";
+    argv[0]=(char*)"codec_unittest";
     argv[1]=path;
     CodecUtMain(argc,argv);
     abort();


### PR DESCRIPTION
Get rid of warnings by avoiding mixing data types unnecessarily,
and by adding casts.
