### PR TITLE
Simplify the compiler flags for the android test projects

### DIFF
--- a/codec/build/android/dec/jni/welsdecdemo.mk
+++ b/codec/build/android/dec/jni/welsdecdemo.mk
@@ -37,11 +37,7 @@ LOCAL_C_INCLUDES := \
 #
 # Compile Flags and Link Libraries
 #
-LOCAL_CFLAGS := -O3 -DANDROID_NDK
-
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-LOCAL_ARM_MODE := arm
-endif
+LOCAL_CFLAGS := -DANDROID_NDK
 
 LOCAL_LDLIBS := -llog
 LOCAL_SHARED_LIBRARIES := wels

--- a/codec/build/android/enc/jni/welsencdemo.mk
+++ b/codec/build/android/enc/jni/welsencdemo.mk
@@ -41,11 +41,7 @@ LOCAL_C_INCLUDES := \
 #
 # Compile Flags and Link Libraries
 #
-LOCAL_CFLAGS := -O3 -DANDROID_NDK
-
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-LOCAL_ARM_MODE := arm
-endif
+LOCAL_CFLAGS := -DANDROID_NDK
 
 LOCAL_LDLIBS := -llog
 LOCAL_SHARED_LIBRARIES := wels

--- a/test/build/android/jni/Android.mk
+++ b/test/build/android/jni/Android.mk
@@ -30,11 +30,7 @@ LOCAL_C_INCLUDES := \
 #
 # Compile Flags and Link Libraries
 #
-LOCAL_CFLAGS := -O3 -DANDROID_NDK
-
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-LOCAL_ARM_MODE := arm
-endif
+LOCAL_CFLAGS := -DANDROID_NDK
 
 LOCAL_LDLIBS := -llog
 LOCAL_SHARED_LIBRARIES := libUT


### PR DESCRIPTION
These parts aren't performance critical, thus overriding the
compiler optimization flags (and arm instruction mode) isn't
necessary.
