### PR TITLE
Update the generic 32 bit arm linux cpu feature detection to support 64 bit kernels

### DIFF
--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -258,9 +258,10 @@ uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
   int flags = 0;
   while (fgets (buf, sizeof (buf), f)) {
     if (!strncmp (buf, "Features", strlen ("Features"))) {
-      if (strstr (buf, " neon "))
+      // The asimd and fp features are listed on 64 bit ARMv8 kernels
+      if (strstr (buf, " neon ") || strstr(buf, " asimd "))
         flags |= WELS_CPU_NEON;
-      if (strstr (buf, " vfpv3 "))
+      if (strstr (buf, " vfpv3 ") || strstr(buf, " fp "))
         flags |= WELS_CPU_VFPv3;
       break;
     }


### PR DESCRIPTION
On 64 bit kernels, /proc/cpuinfo doesn't list the same old features
as on 32 bit kernels, since most of them are mandatory on 64 bit arm
systems, see [1] for details.

If running a 32 bit arm binary on such a kernel, we need to detect
the features slightly differently, either by using other names
listed in the Features field on these devices, by checking the
"CPU architecture" field and always enabling these if the architecture
is >= 8, or by parsing /proc/self/auxv or using the getauxval function.

[1] http://marc.info/?l=linux-arm-kernel&m=139087240101974
