### PR TITLE
Fix for memory leak of input frames in encoder.

### DIFF
--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -397,6 +397,11 @@ class OpenH264VideoEncoder : public GMPVideoEncoder {
     }
 
     if (!has_frame) {
+      // This frame must be destroyed on the main thread.
+      g_platform_api->syncrunonmainthread (WrapTask (
+                                             this,
+                                             &OpenH264VideoEncoder::DestroyInputFrame_m,
+                                             inputImage));
       return;
     }
 
@@ -473,6 +478,11 @@ class OpenH264VideoEncoder : public GMPVideoEncoder {
     callback_->Encoded (f, info);
 
     stats_.FrameOut();
+  }
+
+  // These frames must be destroyed on the main thread.
+  void DestroyInputFrame_m (GMPVideoi420Frame* frame) {
+    frame->Destroy();
   }
 
   virtual GMPVideoErr SetChannelParameters (uint32_t aPacketLoss, uint32_t aRTT) {


### PR DESCRIPTION
This should fix this bug - https://bugzilla.mozilla.org/show_bug.cgi?id=1032492
Review here - https://rbcommons.com/s/OpenH264/r/576/

We were often returning without freeing the memory of the input frame.
