### PR TITLE
Only force iLoopFilterDisableIdc to 2 if multithreading has been enabled

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -293,9 +293,11 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
   SUsedPicRect.iWidth = ((iPicWidth >> 1) << 1);
   SUsedPicRect.iHeight = ((iPicHeight >> 1) << 1);
 
+  iMultipleThreadIdc = pCodingParam.iMultipleThreadIdc;
+
   /* Deblocking loop filter */
   iLoopFilterDisableIdc	= pCodingParam.iLoopFilterDisableIdc;	// 0: on, 1: off, 2: on except for slice boundaries,
-  if (iLoopFilterDisableIdc == 0) // Loop filter requested to be enabled
+  if (iLoopFilterDisableIdc == 0 && iMultipleThreadIdc != 1) // Loop filter requested to be enabled, with threading enabled
     iLoopFilterDisableIdc = 2; // Disable loop filter on slice boundaries since that's not allowed with multithreading
   iLoopFilterAlphaC0Offset = pCodingParam.iLoopFilterAlphaC0Offset;	// AlphaOffset: valid range [-6, 6], default 0
   iLoopFilterBetaOffset = pCodingParam.iLoopFilterBetaOffset;	// BetaOffset:	valid range [-6, 6], default 0
@@ -331,8 +333,6 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
   /* Enable int32_t term reference */
   bEnableLongTermReference	= pCodingParam.bEnableLongTermReference ? true : false;
   iLtrMarkPeriod = pCodingParam.iLtrMarkPeriod;
-
-  iMultipleThreadIdc = pCodingParam.iMultipleThreadIdc;
 
   /* For ssei information */
   bEnableSSEI		= pCodingParam.bEnableSSEI;

--- a/test/api/encoder_test.cpp
+++ b/test/api/encoder_test.cpp
@@ -97,7 +97,7 @@ static const EncodeFileParam kFileParamArray[] = {
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "f4377e3d23748d5f997cd286bc71cc75fbc72013", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_DYN_SLICE, false, 1
+    "2bc06262d87fa0897ad4c336cc4047d5a67f7203", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_DYN_SLICE, false, 1
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",


### PR DESCRIPTION
Previously these lines were within an #ifdef MT_ENABLED block,
but now that threading is enabled by default, we should probably
only do it if threading has been requested.
