### PR TITLE
Use GetDefaultParams instead of memset to initialize SEncParamExt in the console test app

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -204,8 +204,6 @@ int ParseConfig (CReadConfig& cRdCfg, SSourcePicture* pSrcPic, SEncParamExt& pSv
   int32_t iRet = 0;
   int8_t iLayerCount = 0;
 
-//	memset(&pSvcParam, 0, sizeof(WelsSVCParamConfig));
-
   while (!cRdCfg.EndOfFile()) {
     long iRd = cRdCfg.ReadLine (&strTag[0]);
     if (iRd > 0) {
@@ -669,7 +667,7 @@ int ProcessEncoding (ISVCEncoder* pPtrEnc, int argc, char** argv, bool bConfigFi
   int iParsedNum = 1;
 
   memset (&sFbi, 0, sizeof (SFrameBSInfo));
-  memset (&sSvcParam, 0, sizeof (SEncParamExt));
+  pPtrEnc->GetDefaultParams(&sSvcParam);
   memset (&fs.sRecFileName[0][0], 0, sizeof (fs.sRecFileName));
 
   FillSpecificParameters (sSvcParam);


### PR DESCRIPTION
Most of the default parameters still are overwritten with hardcoded
values in FillSpecificParameters though, but this makes sure that
defaults are applied for any new fields at least.
