### PR TITLE
Remove leftover include directories

### DIFF
--- a/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
@@ -430,7 +430,6 @@
 					"$(inherited)",
 					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
-					"\"$(SRCROOT)/../../../../common\"",
 					"\"$(SRCROOT)/../../../../processing/interface\"",
 					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
 				);
@@ -471,7 +470,6 @@
 					"$(inherited)",
 					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
-					"\"$(SRCROOT)/../../../../common\"",
 					"\"$(SRCROOT)/../../../../processing/interface\"",
 					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
 				);


### PR DESCRIPTION
codec/common no longer contains headers, they're all in
codec/common/inc now.
