### PR TITLE
Build the android cpu-features.o file in codec/common/src

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -67,12 +67,12 @@ clean_Android_enc:
 	cd ./codec/build/android/enc && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
 
 COMMON_INCLUDES += -I$(NDKROOT)/sources/android/cpufeatures
-COMMON_OBJS += $(COMMON_SRCDIR)/cpu-features.$(OBJ)
+COMMON_OBJS += $(COMMON_SRCDIR)/src/cpu-features.$(OBJ)
 
 COMMON_CFLAGS += \
 	-Dandroid_getCpuIdArm=wels_getCpuIdArm -Dandroid_setCpuArm=wels_setCpuArm \
 	-Dandroid_getCpuCount=wels_getCpuCount -Dandroid_getCpuFamily=wels_getCpuFamily \
 	-Dandroid_getCpuFeatures=wels_getCpuFeatures -Dandroid_setCpu=wels_setCpu \
 
-codec/common/cpu-features.$(OBJ): $(NDKROOT)/sources/android/cpufeatures/cpu-features.c
+codec/common/src/cpu-features.$(OBJ): $(NDKROOT)/sources/android/cpufeatures/cpu-features.c
 	$(QUIET_CC)$(CC) $(CFLAGS) $(INCLUDES) $(COMMON_CFLAGS) $(COMMON_INCLUDES) -c $(CXX_O) $<


### PR DESCRIPTION
Up until now it was built in codec/common (where all other common
source files were built, until they were split up into
inc/src/x86/arm/arm64).
