### PR TITLE
Ignore failures in cleaning android projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ codec_unittest$(EXEEXT): $(LIBPREFIX)ut.$(SHAREDLIBSUFFIX)
 
 clean_Android: clean_Android_ut
 clean_Android_ut:
-	cd ./test/build/android && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
+	-cd ./test/build/android && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
 
 else
 codec_unittest$(EXEEXT): $(DECODER_UNITTEST_OBJS) $(ENCODER_UNITTEST_OBJS) $(PROCESSING_UNITTEST_OBJS) $(API_TEST_OBJS) $(COMMON_UNITTEST_OBJS) $(CODEC_UNITTEST_DEPS)

--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -62,9 +62,9 @@ encdemo: libraries
 clean_Android: clean_Android_dec clean_Android_enc
 
 clean_Android_dec:
-	cd ./codec/build/android/dec && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
+	-cd ./codec/build/android/dec && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
 clean_Android_enc:
-	cd ./codec/build/android/enc && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
+	-cd ./codec/build/android/enc && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
 
 COMMON_INCLUDES += -I$(NDKROOT)/sources/android/cpufeatures
 COMMON_OBJS += $(COMMON_SRCDIR)/cpu-features.$(OBJ)


### PR DESCRIPTION
If the android test projects hasn't been built yet, the "make clean"
command will stop at "ant clean" (which fails since build.xml doesn't
exist yet). If this happens, one still would want to run the "make
clean" command to the end, cleaning up any possible intermediate object
files (e.g. from a build for a different platform).
