### PR TITLE
Simplify the travis configuration, reduce duplicated rebuilds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,7 @@ install:
   - make gmp-bootstrap
   - make gtest-bootstrap
 script:
-  - make -B ENABLE64BIT=Yes
-  - make -B ENABLE64BIT=Yes plugin
-  - make -B ENABLE64BIT=Yes test
-  - make -B ENABLE64BIT=Yes BUILDTYPE=Debug
-  - make -B ENABLE64BIT=Yes BUILDTYPE=Debug plugin
-  - make -B ENABLE64BIT=Yes test
-  - make -B ENABLE64BIT=No
-  - make -B ENABLE64BIT=No plugin
-  - make -B ENABLE64BIT=No test
-  - make -B ENABLE64BIT=No BUILDTYPE=Debug
-  - make -B ENABLE64BIT=No BUILDTYPE=Debug plugin
-  - make -B ENABLE64BIT=No test
+  - make -B ENABLE64BIT=Yes BUILDTYPE=Release all plugin test
+  - make -B ENABLE64BIT=Yes BUILDTYPE=Debug all plugin test
+  - make -B ENABLE64BIT=No BUILDTYPE=Release all plugin test
+  - make -B ENABLE64BIT=No BUILDTYPE=Debug all plugin test


### PR DESCRIPTION
The -B make option rebuilds everything from scratch - thus a "make -B",
"make -B test" sequence would first build everything from scratch, then
rebuild (almost) everything and run the tests.

The previous sequence, with "make -B test" without specifying
BUILDTYPE=Debug, meant that it rebuilt a new release build instead
and tested that, thus never actually testing the debug build.

This should reduce the time used for compilation in travis runs
to less than half.

Also explicitly specify BUILDTYPE=Release, for clarity.

Review at https://rbcommons.com/s/OpenH264/r/598/.
