### PR TITLE
Avoid writing in array index [-1] in DecUT_IntraPrediction

### DIFF
--- a/test/decoder/DecUT_IntraPrediction.cpp
+++ b/test/decoder/DecUT_IntraPrediction.cpp
@@ -391,15 +391,15 @@ if (ASM) { \
 } \
 while(iRunTimes--) {\
 for (int i = 0; i < 17; i ++) {\
-  pRefBuffer[i] = pPredBuffer[i] = rand() & 255; \
-  pRefBuffer[i * kiStride - 1] = pPredBuffer[i * kiStride - 1] = rand() & 255; \
+  pRefBuffer[kiStride + i] = pPredBuffer[kiStride + i] = rand() & 255; \
+  pRefBuffer[(i+1) * kiStride - 1] = pPredBuffer[(i+1) * kiStride - 1] = rand() & 255; \
 }\
-pred(&pPredBuffer[kiStride], kiStride); \
-ref(&pRefBuffer[kiStride], kiStride); \
+pred(&pPredBuffer[2*kiStride], kiStride); \
+ref(&pRefBuffer[2*kiStride], kiStride); \
 bool ok = true; \
 for (int i = 0; i < 8; i ++)\
   for(int j = 0; j < 8; j ++)\
-    if (pPredBuffer[(i+1) * kiStride + j] != pRefBuffer[(i+1) * kiStride + j]) {\
+    if (pPredBuffer[(i+2) * kiStride + j] != pRefBuffer[(i+2) * kiStride + j]) {\
       ok = false; \
       break; \
     } \
@@ -528,15 +528,15 @@ if (ASM) { \
 }\
 while(iRunTimes--) {\
 for (int i = 0; i < 17; i ++) {\
-  pRefBuffer[i] = pPredBuffer[i] = rand() & 255; \
-  pRefBuffer[i * kiStride - 1] = pPredBuffer[i * kiStride - 1] = rand() & 255; \
+  pRefBuffer[kiStride + i] = pPredBuffer[kiStride + i] = rand() & 255; \
+  pRefBuffer[(i+1) * kiStride - 1] = pPredBuffer[(i+1) * kiStride - 1] = rand() & 255; \
 }\
-pred(&pPredBuffer[kiStride], kiStride); \
-ref(&pRefBuffer[kiStride], kiStride); \
+pred(&pPredBuffer[2*kiStride], kiStride); \
+ref(&pRefBuffer[2*kiStride], kiStride); \
 bool ok = true; \
 for (int i = 0; i < 16; i ++)\
   for(int j = 0; j < 16; j ++)\
-    if (pPredBuffer[(i+1) * kiStride + j] != pRefBuffer[(i+1) * kiStride + j]) {\
+    if (pPredBuffer[(i+2) * kiStride + j] != pRefBuffer[(i+2) * kiStride + j]) {\
       ok = false; \
       break; \
     } \


### PR DESCRIPTION
This fixes running the tests when built with clang in debug mode.

This was accidentally broken in 6e815e708 when switched to using
ENFORCE_STACK_ALIGN_1D instead of manually aligning the buffers.

Previously the aligned pointer always had at least 16 bytes of
extra space in the stack before the pointer, so using [-1] was ok,
while now when using ENFORCE_STACK_ALIGN_1D, it's only guaranteed
that the pointer itself is aligned, but not that there's any extra
space before the pointer. Therefore, we need to manually offset
everything by one kiStride extra. (This already was accounted for
in the total number of bytes allocated for the array.)

Review at https://rbcommons.com/s/OpenH264/r/599/.
