### PR TITLE
Fix spacing in include directives

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -1,5 +1,5 @@
-#include<gtest/gtest.h>
-#include<stdlib.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
 #include "codec_api.h"
 #include "welsEncoderExt.h"
 

--- a/test/encoder/EncUT_MemoryZero.cpp
+++ b/test/encoder/EncUT_MemoryZero.cpp
@@ -1,7 +1,7 @@
-#include<gtest/gtest.h>
-#include<math.h>
-#include<stdlib.h>
-#include<time.h>
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include "cpu_core.h"
 #include "cpu.h"

--- a/test/encoder/EncUT_Reconstruct.cpp
+++ b/test/encoder/EncUT_Reconstruct.cpp
@@ -1,7 +1,7 @@
-#include<gtest/gtest.h>
-#include<math.h>
-#include<stdlib.h>
-#include<time.h>
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include "cpu_core.h"
 #include "cpu.h"


### PR DESCRIPTION
Astyle doesn't change the spacing here, but make it consistent with
all the other files.

Review at https://rbcommons.com/s/OpenH264/r/618/.
