### PR TITLE
Don't do deblocking across slice boundaries even in single thread mode with SM_DYN_SLICE

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -419,6 +419,10 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
 
     pSpatialLayer->iDLayerQp = pCodingParam.sSpatialLayers[iIdxSpatial].iDLayerQp;
 
+    // Don't do deblocking over slice boundaries even in single-threaded mode with SM_DYN_SLICE
+    if (pSpatialLayer->sSliceCfg.uiSliceMode == SM_DYN_SLICE && iLoopFilterDisableIdc == 0)
+      iLoopFilterDisableIdc = 2;
+
     uiProfileIdc	= PRO_SCALABLE_BASELINE;
     ++ pDlp;
     ++ pSpatialLayer;

--- a/test/api/encoder_test.cpp
+++ b/test/api/encoder_test.cpp
@@ -97,7 +97,7 @@ static const EncodeFileParam kFileParamArray[] = {
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "2bc06262d87fa0897ad4c336cc4047d5a67f7203", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_DYN_SLICE, false, 1
+    "f4377e3d23748d5f997cd286bc71cc75fbc72013", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_DYN_SLICE, false, 1
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",


### PR DESCRIPTION
This fixes test failures with the NEON version of deblocking.

Review at https://rbcommons.com/s/OpenH264/r/623/.
