### PR TITLE
Fix WelsHadamardQuant2x2*_AArch64_neon

### DIFF
--- a/codec/encoder/core/arm64/reconstruct_aarch64_neon.S
+++ b/codec/encoder/core/arm64/reconstruct_aarch64_neon.S
@@ -646,7 +646,7 @@ WELS_ASM_AARCH64_FUNC_BEGIN WelsHadamardQuant2x2SkipKernel_AArch64_neon
     HDM_QUANT_2x2_TOTAL_16BITS  v1, v0, v2      // output v0
 
     abs   v1.4h, v0.4h
-    cmhi  v1.4h, v1.4h, v4.4h         // abs(dct[i])>threshold;
+    cmhi  v0.4h, v1.4h, v4.4h         // abs(dct[i])>threshold;
     mov   w0, v0.s[0]
     mov   w1, v0.s[1]
     orr   w0, w0, w1
@@ -687,7 +687,7 @@ WELS_ASM_AARCH64_FUNC_BEGIN WelsHadamardQuant2x2_AArch64_neon
     DC_ZERO_COUNT_IN_DUALWORD   v1, h0, v3
 
     mov     x0, v0.d[0]
-    mov     x1, #16
+    mov     x1, #4
     subs    x0, x1, x0
 WELS_ASM_AARCH64_FUNC_END
 


### PR DESCRIPTION
In WelsHadamardQuant2x2SkipKernel_AArch64_neon, write the output
of cmhi into v0 - this is the register that is assumed to hold
the output.

In WelsHadamardQuant2x2_AArch64_neon, subtract the count of zero
elements from 4, not from 16.

This makes the encoding unit tests pass again.

Review at https://rbcommons.com/s/OpenH264/r/624/.
