### PR TITLE
mark decoder always ECed status until correct IDR comes

### DIFF
--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -317,6 +317,7 @@ int32_t iFeedbackVclNalInAu;
 int32_t iFeedbackTidInAu;
 
 bool bAuReadyFlag;   // true: one au is ready for decoding; false: default value
+bool bDecErrorConedFlag; //true: current decoder is error coned
 
 //trace handle
 void*      pTraceHandle;

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -294,6 +294,7 @@ void WelsOpenDecoder (PWelsDecoderContext pCtx) {
   pCtx->bReferenceLostAtT0Flag	= true;	// should be true to waiting IDR at incoming AU bits following, 6/4/2010
 #endif //LONG_TERM_REF
   pCtx->bNewSeqBegin = true;
+  pCtx->bDecErrorConedFlag = false; //default: decoder normal status
 }
 
 /*!

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -76,6 +76,8 @@ static inline int32_t DecodeFrameConstruction (PWelsDecoderContext pCtx, uint8_t
     bFrameCompleteFlag = false; //return later after output buffer is done
     if (pCtx->bInstantDecFlag) //no-delay decoding, wait for new slice
       return -1;
+  } else if (pCurDq->sLayerInfo.sNalHeaderExt.bIdrFlag && (pCtx->iErrorCode == dsErrorFree)) { //complete non-ECed IDR frame done
+      pCtx->bDecErrorConedFlag = false;
   }
 
   pCtx->iTotalNumMbRec = 0;
@@ -1959,7 +1961,6 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
         if (NeedErrorCon (pCtx)) {
           ImplementErrorCon (pCtx);
           pCtx->iTotalNumMbRec = pCtx->pSps->iMbWidth * pCtx->pSps->iMbHeight;
-          pCtx->iErrorCode |= dsDataErrorConcealed;
         }
       }
 
@@ -2009,7 +2010,6 @@ bool CheckAndDoEC (PWelsDecoderContext pCtx, uint8_t** ppDst, SBufferInfo* pDstI
       pCtx->iPrevFrameNum = pCtx->sLastSliceHeader.iFrameNum; //save frame_num
       if (pCtx->bLastHasMmco5)
         pCtx->iPrevFrameNum = 0;
-      pCtx->iErrorCode |= dsDataErrorConcealed;
     }
   }
   return ERR_NONE;

--- a/codec/decoder/core/src/error_concealment.cpp
+++ b/codec/decoder/core/src/error_concealment.cpp
@@ -181,6 +181,8 @@ void ImplementErrorCon (PWelsDecoderContext pCtx) {
   } else if (ERROR_CON_SLICE_COPY == pCtx->iErrorConMethod) {
     DoErrorConSliceCopy (pCtx);
   } //TODO add other EC methods here in the future
+  pCtx->iErrorCode |= dsDataErrorConcealed;
+  pCtx->bDecErrorConedFlag = true;
 }
 
 } // namespace WelsDec

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -414,6 +414,11 @@ DECODING_STATE CWelsDecoder::DecodeFrame2 (const unsigned char* kpSrc,
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "decode failed, failure type:%d \n",
              m_pDecContext->iErrorCode);
     return (DECODING_STATE)m_pDecContext->iErrorCode;
+  } else { //decoding correct, but may have ECed status
+    if (m_pDecContext->bDecErrorConedFlag) {
+      m_pDecContext->iErrorCode |= dsDataErrorConcealed;
+      return dsDataErrorConcealed;
+    }
   }
 
   return dsErrorFree;


### PR DESCRIPTION
If Error concealment is triggered, keep sending error info until correct complete IDR picture is decoded.
detailed see:
https://rbcommons.com/s/OpenH264/r/630/
