### PR TITLE
    interface update

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -91,6 +91,7 @@ typedef enum {
   ENCODER_LTR_MARKING_FEEDBACK,
   ENCOCER_LTR_MARKING_PERIOD,
   ENCODER_OPTION_LTR,
+  ENCODER_OPTION_COMPLEXITY,
 
   ENCODER_OPTION_ENABLE_SSEI,               //enable SSEI: true--enable ssei; false--disable ssei
   ENCODER_OPTION_ENABLE_PREFIX_NAL_ADDING,   //enable prefix: true--enable prefix; false--disable prefix
@@ -272,12 +273,16 @@ typedef enum {
   SCREEN_CONTENT_REAL_TIME,//screen content signal
 } EUsageType;
 
+typedef enum {
+  LOW_COMPLEXITY, //the lowest compleixty,the fastest speed,
+  MEDIUM_COMPLEXITY, //medium complexity, medium speed,medium quality
+  HIGH_COMPLEXITY, //high complexity, lowest speed, high quality
+} ECOMPLEXITY_MODE;
 // TODO:  Refine the parameters definition.
 // SVC Encoding Parameters
 typedef struct TagEncParamBase {
   EUsageType
   iUsageType;	//application type;// CAMERA_VIDEO_REAL_TIME: //camera video signal; SCREEN_CONTENT_REAL_TIME: screen content signal;
-  int		iInputCsp;	// color space of input sequence
 
   int		iPicWidth;			// width of picture in samples
   int		iPicHeight;			// height of picture in samples
@@ -291,7 +296,6 @@ typedef struct TagEncParamBase {
 typedef struct TagEncParamExt {
   EUsageType
   iUsageType;	//application type;// CAMERA_VIDEO_REAL_TIME: //camera video signal; SCREEN_CONTENT_REAL_TIME: screen content signal;
-  int		iInputCsp;	// color space of input sequence
 
   int		iPicWidth;			// width of picture in samples
   int		iPicHeight;			// height of picture in samples
@@ -303,9 +307,9 @@ typedef struct TagEncParamExt {
   int		iSpatialLayerNum;	// layer number at spatial level
   SSpatialLayerConfig sSpatialLayers[MAX_SPATIAL_LAYER_NUM];
 
+  ECOMPLEXITY_MODE iComplexityMode;
   unsigned int		uiIntraPeriod;		// period of Intra frame
   int		        iNumRefFrame;		// number of reference frame used
-  unsigned int	    uiFrameToBeCoded;	// frame to be encoded (at input frame rate)
   bool    bEnableSpsPpsIdAddition;
   bool    bPrefixNalAddingCtrl;
   bool	  bEnableSSEI;

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -99,6 +99,7 @@ typedef struct tagFilesSet {
   string strSeqFile;    // for cmd lines
   string strLayerCfgFile[MAX_DEPENDENCY_LAYER];
   char   sRecFileName[MAX_DEPENDENCY_LAYER][MAX_FNAME_LEN];
+  uint32_t uiFrameToBeCoded;
 } SFilesSet;
 
 
@@ -224,7 +225,7 @@ int ParseConfig (CReadConfig& cRdCfg, SSourcePicture* pSrcPic, SEncParamExt& pSv
       } else if (strTag[0].compare ("MaxFrameRate") == 0) {
         pSvcParam.fMaxFrameRate	= (float)atof (strTag[1].c_str());
       } else if (strTag[0].compare ("FramesToBeEncoded") == 0) {
-        pSvcParam.uiFrameToBeCoded	= atoi (strTag[1].c_str());
+        sFileSet.uiFrameToBeCoded	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("TemporalLayerNum") == 0) {
         pSvcParam.iTemporalLayerNum	= atoi (strTag[1].c_str());
       } else if (strTag[0].compare ("IntraPeriod") == 0) {
@@ -403,7 +404,7 @@ int ParseCommandLine (int argc, char** argv, SSourcePicture* pSrcPic, SEncParamE
       pSrcPic->iPicHeight = atoi (argv[n++]);
 
     else if (!strcmp (pCommand, "-frms") && (n < argc))
-      pSvcParam.uiFrameToBeCoded = atoi (argv[n++]);
+      sFileSet.uiFrameToBeCoded = atoi (argv[n++]);
 
     else if (!strcmp (pCommand, "-numtl") && (n < argc))
       pSvcParam.iTemporalLayerNum = atoi (argv[n++]);
@@ -581,11 +582,10 @@ int FillSpecificParameters (SEncParamExt& sParam) {
   sParam.bEnableFrameSkip           = 1; // frame skipping
   sParam.bEnableLongTermReference  = 0; // long term reference control
   sParam.iLtrMarkPeriod = 30;
-  sParam.iInputCsp			= videoFormatI420;			// color space of input sequence
   sParam.uiIntraPeriod		= 320;		// period of Intra frame
   sParam.bEnableSpsPpsIdAddition = 1;
   sParam.bPrefixNalAddingCtrl = 0;
-
+  sParam.iComplexityMode = MEDIUM_COMPLEXITY;
   int iIndexLayer = 0;
   sParam.sSpatialLayers[iIndexLayer].uiProfileIdc	= PRO_BASELINE;
   sParam.sSpatialLayers[iIndexLayer].iVideoWidth	= 160;
@@ -736,7 +736,7 @@ int ProcessEncoding (ISVCEncoder* pPtrEnc, int argc, char** argv, bool bConfigFi
   sSvcParam.iPicWidth = (!sSvcParam.iPicWidth) ? iSourceWidth : sSvcParam.iPicWidth;
   sSvcParam.iPicHeight = (!sSvcParam.iPicHeight) ? iSourceHeight : sSvcParam.iPicHeight;
 
-  iTotalFrameMax = (int32_t)sSvcParam.uiFrameToBeCoded;
+  iTotalFrameMax = (int32_t)fs.uiFrameToBeCoded;
 
   if (cmResultSuccess != pPtrEnc->InitializeExt (&sSvcParam)) {	// SVC encoder initialization
     fprintf (stderr, "SVC encoder Initialize failed\n");
@@ -789,8 +789,8 @@ int ProcessEncoding (ISVCEncoder* pPtrEnc, int argc, char** argv, bool bConfigFi
   }
 
   iFrameIdx = 0;
-  while (iFrameIdx < iTotalFrameMax && (((int32_t)sSvcParam.uiFrameToBeCoded <= 0)
-                                        || (iFrameIdx < (int32_t)sSvcParam.uiFrameToBeCoded))) {
+  while (iFrameIdx < iTotalFrameMax && (((int32_t)fs.uiFrameToBeCoded <= 0)
+                                        || (iFrameIdx < (int32_t)fs.uiFrameToBeCoded))) {
 
 #ifdef ONLY_ENC_FRAMES_NUM
     // Only encoded some limited frames here

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -133,9 +133,8 @@ static void FillDefault (SEncParamExt& param) {
   param.iPicHeight	= 0;	//   actual input picture height
 
   param.fMaxFrameRate		= MAX_FRAME_RATE;	// maximal frame rate [Hz / fps]
-  param.iInputCsp			= videoFormatI420;	// input sequence color space in default
-  param.uiFrameToBeCoded	= (uint32_t) - 1;		// frame to be encoded (at input frame rate)
 
+  param.iComplexityMode = MEDIUM_COMPLEXITY;
   param.iTargetBitrate			= 0;	// overall target bitrate introduced in RC module
   param.iMaxBitrate             = MAX_BIT_RATE;
   param.iMultipleThreadIdc		= 1;
@@ -203,7 +202,7 @@ void FillDefault() {
   iCountThreadsNum		= 1;	//		# derived from disable_multiple_slice_idc (=0 or >1) means;
 
   iDecompStages				= 0;	// GOP size dependency, unknown here and be revised later
-
+  iComplexityMode = MEDIUM_COMPLEXITY;
   memset (sDependencyLayers, 0, sizeof (SSpatialLayerInternal)*MAX_DEPENDENCY_LAYER);
   memset (sSpatialLayers, 0 , sizeof (SSpatialLayerConfig)*MAX_SPATIAL_LAYER_NUM);
 
@@ -223,7 +222,6 @@ void FillDefault() {
 
 int32_t ParamBaseTranscode (const SEncParamBase& pCodingParam) {
 
-  iInputCsp		= pCodingParam.iInputCsp;		// color space of input sequence
   fMaxFrameRate		= WELS_CLIP3 (pCodingParam.fMaxFrameRate, MIN_FRAME_RATE, MAX_FRAME_RATE);
   iTargetBitrate	= pCodingParam.iTargetBitrate;
   iUsageType = pCodingParam.iUsageType;
@@ -271,7 +269,6 @@ int32_t ParamBaseTranscode (const SEncParamBase& pCodingParam) {
 }
 void GetBaseParams (SEncParamBase* pCodingParam) {
   pCodingParam->iUsageType     = iUsageType;
-  pCodingParam->iInputCsp      = iInputCsp;
   pCodingParam->iPicWidth      = iPicWidth;
   pCodingParam->iPicHeight     = iPicHeight;
   pCodingParam->iTargetBitrate = iTargetBitrate;
@@ -281,12 +278,10 @@ void GetBaseParams (SEncParamBase* pCodingParam) {
 int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
   float fParamMaxFrameRate		= WELS_CLIP3 (pCodingParam.fMaxFrameRate, MIN_FRAME_RATE, MAX_FRAME_RATE);
 
-  iInputCsp		= pCodingParam.iInputCsp;		// color space of input sequence
-  uiFrameToBeCoded	= (uint32_t) -
-                      1;		// frame to be encoded (at input frame rate), -1 dependents on length of input sequence
   iUsageType = pCodingParam.iUsageType;
   iPicWidth   = pCodingParam.iPicWidth;
   iPicHeight  = pCodingParam.iPicHeight;
+  iComplexityMode = pCodingParam.iComplexityMode;
 
   SUsedPicRect.iLeft = 0;
   SUsedPicRect.iTop  = 0;
@@ -297,7 +292,8 @@ int32_t ParamTranscode (const SEncParamExt& pCodingParam) {
 
   /* Deblocking loop filter */
   iLoopFilterDisableIdc	= pCodingParam.iLoopFilterDisableIdc;	// 0: on, 1: off, 2: on except for slice boundaries,
-  if (iLoopFilterDisableIdc == 0 && iMultipleThreadIdc != 1) // Loop filter requested to be enabled, with threading enabled
+  if (iLoopFilterDisableIdc == 0
+      && iMultipleThreadIdc != 1) // Loop filter requested to be enabled, with threading enabled
     iLoopFilterDisableIdc = 2; // Disable loop filter on slice boundaries since that's not allowed with multithreading
   iLoopFilterAlphaC0Offset = pCodingParam.iLoopFilterAlphaC0Offset;	// AlphaOffset: valid range [-6, 6], default 0
   iLoopFilterBetaOffset = pCodingParam.iLoopFilterBetaOffset;	// BetaOffset:	valid range [-6, 6], default 0

--- a/codec/encoder/core/inc/svc_mode_decision.h
+++ b/codec/encoder/core/inc/svc_mode_decision.h
@@ -69,7 +69,7 @@ void SetMvBaseEnhancelayer (SWelsMD* pMd, SMB* pCurMb, const SMB* kpRefMb);
 // MD from background detection
 //////////////
 bool WelsMdInterJudgeBGDPskip (void* pEnc, void* pMd, SSlice* pSlice, SMB* pCurMb, SMbCache* pMbCache,
-                                     bool* bKeepSkip);
+                               bool* bKeepSkip);
 bool WelsMdInterJudgeBGDPskipFalse (void* pEnc, void* pMd, SSlice* pSlice, SMB* pCurMb, SMbCache* pMbCache,
                                     bool* bKeepSkip);
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3712,7 +3712,7 @@ int32_t WelsEncoderParamAdjust (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pNewPa
 
     // we can not use direct struct based memcpy due some fields need keep unchanged as before
     pOldParam->fMaxFrameRate	= pNewParam->fMaxFrameRate;		// maximal frame rate [Hz / fps]
-    pOldParam->iInputCsp			= pNewParam->iInputCsp;			// color space of input sequence
+    pOldParam->iComplexityMode	= pNewParam->iComplexityMode;			// color space of input sequence
     pOldParam->uiIntraPeriod		= pNewParam->uiIntraPeriod;		// intra period (multiple of GOP size as desired)
     pOldParam->bEnableSpsPpsIdAddition = pNewParam->bEnableSpsPpsIdAddition;
     pOldParam->bPrefixNalAddingCtrl = pNewParam->bPrefixNalAddingCtrl;

--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -232,7 +232,6 @@ class OpenH264VideoEncoder : public GMPVideoEncoder {
 
     // TODO(ekr@rtfm.com). Scary conversion from unsigned char to float below.
     param.fMaxFrameRate = static_cast<float> (codecSettings.mMaxFramerate);
-    param.iInputCsp = videoFormatI420;
 
     rv = encoder_->Initialize (&param);
     if (rv) {

--- a/test/api/BaseEncoderTest.cpp
+++ b/test/api/BaseEncoderTest.cpp
@@ -16,7 +16,6 @@ static int InitWithParam (ISVCEncoder* encoder, EUsageType usageType, int width,
     param.iPicWidth = width;
     param.iPicHeight = height;
     param.iTargetBitrate = 5000000;
-    param.iInputCsp = videoFormatI420;
 
     return encoder->Initialize (&param);
   } else {
@@ -28,7 +27,6 @@ static int InitWithParam (ISVCEncoder* encoder, EUsageType usageType, int width,
     param.iPicWidth = width;
     param.iPicHeight = height;
     param.iTargetBitrate = 5000000;
-    param.iInputCsp = videoFormatI420;
     param.bEnableDenoise = denoise;
     param.iSpatialLayerNum = layers;
 

--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -41,7 +41,6 @@ class EncoderInterfaceTest : public ::testing::Test {
 
 void EncoderInterfaceTest::TemporalLayerSettingTest() {
 
-  pParamExt->iInputCsp = 23;
   pParamExt->iPicWidth = m_iWidth;
   pParamExt->iPicHeight = m_iHeight;
   pParamExt->iTargetBitrate = 60000;


### PR DESCRIPTION
reviewed at: https://rbcommons.com/s/OpenH264/r/635/
1. add iComplexityMode to set encoder complexity flexibly by app.
2. remove uiFrameToBeCoded which isn't used in encoder core
3. remove iInputCsp because encoder only supports I420, and this parameter means output setting
4. astyle files.  this is very strange that there are some files changed when astyle them 
