### PR TITLE
Set DebugInformationFormat consistently in all projects

### DIFF
--- a/codec/build/win32/dec/WelsDecCore.vcproj
+++ b/codec/build/win32/dec/WelsDecCore.vcproj
@@ -64,7 +64,7 @@
 				ObjectFile=".\..\..\..\obj\decoder\core\release/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decoder\core\release/"
 				WarningLevel="3"
-				DebugInformationFormat="0"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -142,7 +142,7 @@
 				ObjectFile=".\..\..\..\obj\decoder\core\release/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decoder\core\release/"
 				WarningLevel="3"
-				DebugInformationFormat="0"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/codec/build/win32/dec/decConsole.vcproj
+++ b/codec/build/win32/dec/decConsole.vcproj
@@ -59,6 +59,7 @@
 				ObjectFile=".\..\..\..\obj\decConsole\Release/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decConsole\Release/"
 				WarningLevel="3"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -149,6 +150,7 @@
 				ObjectFile=".\..\..\..\obj\decConsole\Release/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decConsole\Release/"
 				WarningLevel="3"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/codec/processing/build/win32/WelsVP.vcproj
+++ b/codec/processing/build/win32/WelsVP.vcproj
@@ -228,7 +228,7 @@
 				EnableFunctionLevelLinking="false"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				DebugInformationFormat="0"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -318,7 +318,7 @@
 				EnableFunctionLevelLinking="false"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				DebugInformationFormat="0"
+				DebugInformationFormat="3"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"


### PR DESCRIPTION
Use the "Program Database (/Zi)" in release mode and in debug
mode for x64, use "Program Database for Edit & Continue (/ZI)"
in debug mode for Win32.

This is how new visual studio projects are set by default.

Review at https://rbcommons.com/s/OpenH264/r/640/.
