### PR TITLE
Only build the needed binaries in run_PrepareAllTestData.sh

### DIFF
--- a/test/encoder_binary_comparison/run_PrepareAllTestData.sh
+++ b/test/encoder_binary_comparison/run_PrepareAllTestData.sh
@@ -44,11 +44,11 @@ runBuildCodec()
   if [ "${BitType}" -eq 64   ]
   then
     make clean
-    make -B ENABLE64BIT=Yes
+    make -B ENABLE64BIT=Yes h264dec h264enc
   elif [ "${BitType}" -eq 32   ]
   then
     make clean
-    make -B ENABLE64BIT=No
+    make -B ENABLE64BIT=No h264dec h264enc
   else
     echo "usage: runBuildCodec  \64/32  #bits"
     exit 1


### PR DESCRIPTION
Previously this did a full make, including all of gtest and the unit
test suite. This was done before every build, even for the binary
comparison tests which doesn't use the unit test.

This reduces the runtime of run_PrepareAllTestData.sh from 52 to 10
seconds in one setup.

Review at https://rbcommons.com/s/OpenH264/r/643/.
