### PR TITLE
Pull gmp-api by branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SHARED=-shared
 OBJ=o
 PROJECT_NAME=openh264
 MODULE_NAME=gmpopenh264
+GMP_API_BRANCH=Firefox32
 CCASFLAGS=$(CFLAGS)
 
 ifeq (,$(wildcard ./gmp-api))
@@ -122,7 +123,8 @@ endif
 	$(QUIET)rm -f $(OBJS) $(OBJS:.$(OBJ)=.d) $(LIBRARIES) $(BINARIES)
 
 gmp-bootstrap:
-	git clone https://github.com/mozilla/gmp-api gmp-api
+	if [ ! -d gmp-api ] ; then git clone https://github.com/mozilla/gmp-api gmp-api ; fi
+	cd gmp-api && git fetch origin && git checkout $(GMP_API_BRANCH)
 
 gtest-bootstrap:
 	svn co https://googletest.googlecode.com/svn/trunk/ gtest


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/651/

We need to start pulling specific versions from github.com/mozilla/gmp-api.  Today they made the Firefox32 branch so we should be pulling down that until they land the FF33 changes.  After this lands I will be making a "v1.1-Firefox32" branch of OpenH264 as well so we can make this version correctly in the future.

I decided not to do the checkout with every 'make plugin' build but rather leave gmp-bootstrap as something that's run separately.
