### PR TITLE
Don't set a custom path to browse information files, when no browse information is generated

### DIFF
--- a/codec/build/win32/dec/WelsDecCore.vcproj
+++ b/codec/build/win32/dec/WelsDecCore.vcproj
@@ -88,7 +88,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Release/WelsDecCore.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -165,7 +164,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Release/WelsDecCore.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -239,7 +237,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Debug/WelsDecCore.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -314,7 +311,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Debug/WelsDecCore.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"

--- a/codec/build/win32/dec/WelsDecPlus.vcproj
+++ b/codec/build/win32/dec/WelsDecPlus.vcproj
@@ -96,7 +96,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Release/WelsDecPlus.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -186,7 +185,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Release/WelsDecPlus.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -272,7 +270,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Debug/WelsDecPlus.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -358,7 +355,6 @@
 			/>
 			<Tool
 				Name="VCBscMakeTool"
-				OutputFile=".\..\..\..\..\bin\win32\Debug/WelsDecPlus.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"


### PR DESCRIPTION
These projects never had browse information generation enabled.

Review at https://rbcommons.com/s/OpenH264/r/655/.
