### PR TITLE
Remove a stray option set on only one MSVC project

### DIFF
--- a/codec/build/win32/dec/decConsole.vcproj
+++ b/codec/build/win32/dec/decConsole.vcproj
@@ -226,7 +226,6 @@
 				AssemblerListingLocation=".\..\..\..\obj\decConsole\Debug/"
 				ObjectFile=".\..\..\..\obj\decConsole\Debug/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decConsole\Debug/"
-				BrowseInformation="1"
 				WarningLevel="3"
 				DebugInformationFormat="4"
 			/>
@@ -312,7 +311,6 @@
 				AssemblerListingLocation=".\..\..\..\obj\decConsole\Debug/"
 				ObjectFile=".\..\..\..\obj\decConsole\Debug/"
 				ProgramDataBaseFileName=".\..\..\..\obj\decConsole\Debug/"
-				BrowseInformation="1"
 				WarningLevel="3"
 				DebugInformationFormat="3"
 			/>


### PR DESCRIPTION
No other projects create browse information, and browse information
for the decConsole project alone doesn't help much. This is also
only enabled in debug mode, further indicating that this option is
only enabled accidentally, not by purpose.

Review at https://rbcommons.com/s/OpenH264/r/656/.
