### PR TITLE
Don't hardcode an include path to the xcode default toolchain

### DIFF
--- a/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
@@ -428,7 +428,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../processing/interface\"",
 					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
@@ -468,7 +467,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../processing/interface\"",
 					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
@@ -488,7 +486,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = APPLE_IOS;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../common/inc\"",
 				);
@@ -506,7 +503,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = APPLE_IOS;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode\\ 5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../common/inc\"",
 				);

--- a/codec/build/iOS/processing/processing.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/processing/processing.xcodeproj/project.pbxproj
@@ -447,7 +447,6 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = APPLE_IOS;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../processing/interface",
 					"$(SRCROOT)/../../../processing/src/common",
 					"$(SRCROOT)/../../../common/inc",
@@ -483,7 +482,6 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../processing/interface",
 					"$(SRCROOT)/../../../processing/src/common",
 					"$(SRCROOT)/../../../common/inc",


### PR DESCRIPTION
The necessary system include paths are already inherited, and manually
forcing this location can cause conflicts if using different versions
of xcode installed in parallel.

None of the other xcode projects hardcode this path.
