### PR TITLE
Don't hardcode the valid architectures in one xcode project

### DIFF
--- a/codec/build/iOS/processing/processing.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/processing/processing.xcodeproj/project.pbxproj
@@ -459,7 +459,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "armv7 armv7s arm64";
 			};
 			name = Debug;
 		};
@@ -495,7 +494,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "armv7 armv7s arm64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
There's no reason to hardcode these here - these are the default.
(We keep the intentionally hardcoded default arch in the
codec_unittest project though.)

Review at https://rbcommons.com/s/OpenH264/r/662/.
