### PR TITLE
Abort directly on errors in the unit test in run_Test.sh

### DIFF
--- a/run_Test.sh
+++ b/run_Test.sh
@@ -29,6 +29,7 @@ runMain()
 
   if [ "${TestType}"  = "UnitTest"  ]
   then
+    set -e
     make -B ENABLE64BIT=Yes BUILDTYPE=Release all plugin test
     make -B ENABLE64BIT=Yes BUILDTYPE=Debug all plugin test
     make -B ENABLE64BIT=No BUILDTYPE=Release all plugin test


### PR DESCRIPTION
Currently it runs all four unit test builds, and an error in any
of the earlier three ones will be missed as long as the fourth one
succeeds.

Review at https://rbcommons.com/s/OpenH264/r/668/.
