### PR TITLE
Fix generating the version header when building outside of the source tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ MODULE_INCLUDES += -I$(SRC_PATH)gmp-api
 
 all:	General_ver libraries binaries
 General_ver:
-	sh ./codec/common/generate_version.sh
+	$(QUIET)cd $(SRC_PATH) && sh ./codec/common/generate_version.sh
 
 clean:
 ifeq (android,$(OS))


### PR DESCRIPTION
Also silence this command in silent builds.

Review at https://rbcommons.com/s/OpenH264/r/680/.
