### PR TITLE
Set the encDemo header paths on the target level

### DIFF
--- a/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
+++ b/codec/build/iOS/enc/encDemo/encDemo.xcodeproj/project.pbxproj
@@ -426,12 +426,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/../../../../api/svc\"",
-					"\"$(SRCROOT)/../../../../processing/interface\"",
-					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
-				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -465,12 +459,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/../../../../api/svc\"",
-					"\"$(SRCROOT)/../../../../processing/interface\"",
-					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
-				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -488,6 +476,8 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../common/inc\"",
+					"\"$(SRCROOT)/../../../../processing/interface\"",
+					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
 				);
 				INFOPLIST_FILE = "encDemo/encDemo-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -505,6 +495,8 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../../../../api/svc\"",
 					"\"$(SRCROOT)/../../../../common/inc\"",
+					"\"$(SRCROOT)/../../../../processing/interface\"",
+					"\"$(SRCROOT)/../../../../encoder/core/inc\"",
 				);
 				INFOPLIST_FILE = "encDemo/encDemo-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Currently half of them are set on the project level, and half of them
on the target level.

In all other projects within OpenH264, they're set on the target level.

Review at https://rbcommons.com/s/OpenH264/r/685/.
