### PR TITLE
Update info file for bugzilla 1037754 - no longer need to advertise VP8.

### DIFF
--- a/gmpopenh264.info
+++ b/gmpopenh264.info
@@ -1,4 +1,4 @@
 Name: gmpopenh264
 Description: GMP Plugin for OpenH264.
 Version: 1.0
-APIs: encode-video[h264:vp8], decode-video[h264:vp8]
+APIs: encode-video[h264], decode-video[h264]


### PR DESCRIPTION
Pull req for v1.1-Firefox33
Now that 1037754 has landed we no longer need to advertise vp8 as well as h264 in the info file.
https://bugzilla.mozilla.org/show_bug.cgi?id=1037754
