### PR TITLE
Check that a working android toolchain was found

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -46,6 +46,10 @@ CXXFLAGS += -fno-rtti -fno-exceptions
 LDFLAGS += --sysroot=$(SYSROOT)
 SHLDFLAGS = -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,-soname,lib$(PROJECT_NAME).so
 
+ifneq ($(CXX),$(wildcard $(CXX)))
+$(error Compiler not found, bad NDKROOT or ARCH?)
+endif
+
 STL_INCLUDES = \
     -I$(NDKROOT)/sources/cxx-stl/stlport/stlport
 STL_LIB = \


### PR DESCRIPTION
If the user selects a nonexistent ARCH, previously the call that
sets TOOLCHAINPREFIX would set it to contain a long error message,
which makes it quite hard to figure out what actually went wrong.

Instead check that CXX=$(TOLCHAINPREFIX)g++ actually points to a
working executable, and abort immediately if this isn't true.

Review at https://rbcommons.com/s/OpenH264/r/698/.
