### PR TITLE
Don't request executable stacks for Linux GMP plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,9 @@ $(LIBPREFIX)$(PROJECT_NAME).$(SHAREDLIBSUFFIX): $(ENCODER_OBJS) $(DECODER_OBJS) 
 ifeq ($(HAVE_GMP_API),Yes)
 plugin: $(LIBPREFIX)$(MODULE_NAME).$(SHAREDLIBSUFFIX)
 LIBRARIES += $(LIBPREFIX)$(MODULE_NAME).$(SHAREDLIBSUFFIX)
+ifeq (linux,$(OS))
+LDFLAGS += -Wl,-z,noexecstack
+endif
 else
 plugin:
 	@echo "./gmp-api : No such file or directory."


### PR DESCRIPTION
The codec seems to work without executable stack memory, and in general
executable stacks should be avoided if possible, but the assembler used
for the .asm source files requests it.  This commit adds a linker option
to override that.
