### PR TITLE
Actually use iMinQp in WelRcPictureInitBufferBasedQp

### DIFF
--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -1012,7 +1012,7 @@ void WelRcPictureInitBufferBasedQp (void* pCtx) {
     iMinQp = MIN_SCREEN_QP;
 
   pEncCtx->iGlobalQp += pEncCtx->iDropNumber;
-  pEncCtx->iGlobalQp = WELS_CLIP3 (pEncCtx->iGlobalQp, MIN_SCREEN_QP, MAX_SCREEN_QP);
+  pEncCtx->iGlobalQp = WELS_CLIP3 (pEncCtx->iGlobalQp, iMinQp, MAX_SCREEN_QP);
 }
 void  WelsRcInitModule (void* pCtx, RC_MODES iRcMode) {
   sWelsEncCtx* pEncCtx = (sWelsEncCtx*)pCtx;


### PR DESCRIPTION
This fixes a warning in certain builds, about the variable iMinQp
being set but not used. This also probably is what was intended originally.

Review at https://rbcommons.com/s/OpenH264/r/703/.
