### PR TITLE
Add a missing .endm in the gnu version of macros

### DIFF
--- a/codec/processing/src/arm64/vaa_calc_aarch64_neon.S
+++ b/codec/processing/src/arm64/vaa_calc_aarch64_neon.S
@@ -77,6 +77,7 @@
     ABS_SUB_SUM_16BYTES \arg0, \arg1
     ABS_SUB_SUM_16BYTES \arg0, \arg1
     ABS_SUB_SUM_16BYTES \arg0, \arg1
+.endm
 #endif
 
 /*


### PR DESCRIPTION
Review at https://rbcommons.com/s/OpenH264/r/711/.
