### PR TITLE
setget_dataformat_ut

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -355,7 +355,7 @@ typedef struct {
 typedef struct TagSVCDecodingParam {
   char*		pFileNameRestructed;	// File name of restructed frame used for PSNR calculation based debug
 
-  int				iOutputColorFormat;	// color space format to be outputed, EVideoFormatType specified in codec_def.h
+  EVideoFormatType eOutputColorFormat;	// color space format to be outputed, EVideoFormatType specified in codec_def.h
   unsigned int	uiCpuLoad;		// CPU load
   unsigned char	uiTargetDqLayer;	// Setting target dq layer id
 

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -349,7 +349,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
           } else if (strTag[0].compare ("TargetDQID") == 0) {
             sDecParam.uiTargetDqLayer	= (uint8_t)atol (strTag[1].c_str());
           } else if (strTag[0].compare ("OutColorFormat") == 0) {
-            sDecParam.iOutputColorFormat = atoi (strTag[1].c_str());
+            sDecParam.eOutputColorFormat = (EVideoFormatType) atoi (strTag[1].c_str());
           } else if (strTag[0].compare ("ErrorConcealmentIdc") == 0) {
             sDecParam.eEcActiveIdc = (ERROR_CON_IDC)atol (strTag[1].c_str());
           } else if (strTag[0].compare ("CPULoad") == 0) {
@@ -366,7 +366,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
     } else if (strstr (pArgV[1],
                        ".264")) { // no output dump yuv file, just try to render the decoded pictures //confirmed_safe_unsafe_usage
       strInputFile	= pArgV[1];
-      sDecParam.iOutputColorFormat          = videoFormatI420;
+      sDecParam.eOutputColorFormat          = videoFormatI420;
       sDecParam.uiTargetDqLayer	          = (uint8_t) - 1;
       sDecParam.eEcActiveIdc = ERROR_CON_SLICE_COPY;
       sDecParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;
@@ -374,7 +374,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
   } else { //iArgC > 2
     strInputFile	= pArgV[1];
     strOutputFile	= pArgV[2];
-    sDecParam.iOutputColorFormat	= videoFormatI420;
+    sDecParam.eOutputColorFormat	= videoFormatI420;
     sDecParam.uiTargetDqLayer	= (uint8_t) - 1;
     sDecParam.eEcActiveIdc = ERROR_CON_SLICE_COPY;
     sDecParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -168,13 +168,13 @@ SLogContext sLogCtx;
 // Input
 void*				pArgDec;			// structured arguments for decoder, reserved here for extension in the future
 
-SDataBuffer       	sRawData;
+SDataBuffer                     sRawData;
 
 // Configuration
-SDecodingParam*    	pParam;
+SDecodingParam*                 pParam;
 uint32_t			uiCpuFlag;			// CPU compatibility detected
 
-int32_t				iOutputColorFormat;		// color space format to be outputed
+EVideoFormatType eOutputColorFormat;		// color space format to be outputed
 VIDEO_BITSTREAM_TYPE eVideoType; //indicate the type of video to decide whether or not to do qp_delta error detection.
 bool				bHaveGotMemory;	// global memory for decoder context related ever requested?
 

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -134,7 +134,7 @@ void WelsDecoderDefaults (PWelsDecoderContext pCtx, SLogContext* pLogCtx) {
 
   pCtx->pArgDec                   = NULL;
 
-  pCtx->iOutputColorFormat		= videoFormatI420;	// yuv in default
+  pCtx->eOutputColorFormat		= videoFormatI420;	// yuv in default
   pCtx->bHaveGotMemory			= false;	// not ever request memory blocks for decoder context related
   pCtx->uiCpuFlag					= 0;
 
@@ -331,7 +331,7 @@ int32_t DecoderConfigParam (PWelsDecoderContext pCtx, const SDecodingParam* kpPa
     return 1;
 
   memcpy (pCtx->pParam, kpParam, sizeof (SDecodingParam));
-  pCtx->iOutputColorFormat	= pCtx->pParam->iOutputColorFormat;
+  pCtx->eOutputColorFormat	= pCtx->pParam->eOutputColorFormat;
   pCtx->eErrorConMethod = pCtx->pParam->eEcActiveIdc;
 
   if (VIDEO_BITSTREAM_SVC == pCtx->pParam->sVideoProperty.eVideoBsType ||
@@ -589,9 +589,15 @@ int32_t WelsDecodeBs (PWelsDecoderContext pCtx, const uint8_t* kpBsBuf, const in
 int32_t DecoderSetCsp (PWelsDecoderContext pCtx, const int32_t kiColorFormat) {
   WELS_VERIFY_RETURN_IF (1, (NULL == pCtx));
 
-  pCtx->iOutputColorFormat	= kiColorFormat;
+  pCtx->eOutputColorFormat	= (EVideoFormatType) kiColorFormat;
   if (pCtx->pParam != NULL) {
-    pCtx->pParam->iOutputColorFormat	= kiColorFormat;
+    pCtx->pParam->eOutputColorFormat	= (EVideoFormatType) kiColorFormat;
+  }
+
+  //For now, support only videoFormatI420!
+  if (kiColorFormat != (int32_t) videoFormatI420) {
+    WelsLog (& (pCtx->sLogCtx), WELS_LOG_WARNING, "Support I420 output only for now! Change to I420...\n");
+    pCtx->pParam->eOutputColorFormat = pCtx->eOutputColorFormat = videoFormatI420;
   }
 
   return 0;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -304,7 +304,7 @@ long CWelsDecoder::GetOption (DECODER_OPTION eOptID, void* pOption) {
     return cmInitParaError;
 
   if (DECODER_OPTION_DATAFORMAT == eOptID) {
-    iVal = m_pDecContext->iOutputColorFormat;
+    iVal = (int32_t) m_pDecContext->eOutputColorFormat;
     * ((int*)pOption)	= iVal;
     return cmResultSuccess;
   } else if (DECODER_OPTION_END_OF_STREAM == eOptID) {

--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -572,7 +572,7 @@ class OpenH264VideoDecoder : public GMPVideoDecoder {
 
     SDecodingParam param;
     memset (&param, 0, sizeof (param));
-    param.iOutputColorFormat = videoFormatI420;
+    param.eOutputColorFormat = videoFormatI420;
     param.uiTargetDqLayer = UCHAR_MAX;  // Default value
     param.eEcActiveIdc = ERROR_CON_SLICE_COPY; // Error concealment on.
     param.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;

--- a/test/api/BaseDecoderTest.cpp
+++ b/test/api/BaseDecoderTest.cpp
@@ -53,7 +53,7 @@ void BaseDecoderTest::SetUp() {
 
   SDecodingParam decParam;
   memset (&decParam, 0, sizeof (SDecodingParam));
-  decParam.iOutputColorFormat  = videoFormatI420;
+  decParam.eOutputColorFormat  = videoFormatI420;
   decParam.uiTargetDqLayer = UCHAR_MAX;
   decParam.eEcActiveIdc = ERROR_CON_SLICE_COPY;
   decParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;


### PR DESCRIPTION
Enable UT for decoder API data format set/get.
see:
https://rbcommons.com/s/OpenH264/r/714/
