### PR TITLE
Print the random seed at startup

### DIFF
--- a/test/api/simple_test.cpp
+++ b/test/api/simple_test.cpp
@@ -1,9 +1,8 @@
 #include <gtest/gtest.h>
 #include <stdlib.h>
 #include <time.h>
-#if defined (ANDROID_NDK)
 #include <stdio.h>
-#endif
+#include <string.h>
 
 
 #if (defined(ANDROID_NDK)||defined(APPLE_IOS))
@@ -17,8 +16,12 @@ int main (int argc, char** argv) {
   sprintf (xmlPath, "xml:%s", argv[1]);
   ::testing::GTEST_FLAG (output) = xmlPath;
 #endif
-  srand ((unsigned int)time (NULL));
   ::testing::InitGoogleTest (&argc, argv);
+  unsigned int seed = (unsigned int) time (NULL);
+  if (argc >= 2 && !strncmp (argv[1], "--seed=", 7))
+    seed = atoi (argv[1] + 7);
+  printf ("Random seed: %u\n", seed);
+  srand (seed);
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Also add an option for overriding the seed at startup.

This allows reproducing temporary issues by rerunning the test suite
with the same random seed.

Note that if tests are added or removed (or tests are skipped by passing
the --gtest_filter option), or if running on a different libc, the same
seed might result in different random values.

Review at https://rbcommons.com/s/OpenH264/r/723/.
