### PR TITLE
Explicitly add .syntax unified when building for iOS

### DIFF
--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -30,6 +30,8 @@
  *
  */
 
+.syntax unified
+
 #ifdef __APPLE__
 
 .macro WELS_ASM_FUNC_BEGIN
@@ -44,7 +46,6 @@ mov pc, lr
 .endm
 #else
 
-.syntax unified
 .section .note.GNU-stack,"",%progbits // Mark stack as non-executable
 .text
 

--- a/codec/common/arm/deblocking_neon.S
+++ b/codec/common/arm/deblocking_neon.S
@@ -855,7 +855,7 @@ WELS_ASM_FUNC_END
     beq      bs_nzc_check_jump0
 
     sub      r6, $0, $2, lsl #4
-    sub      r6, $2, lsl #3
+    sub      r6, r6, $2, lsl #3
     add      r6, #12
     vld1.32  d3[1], [r6]
 


### PR DESCRIPTION
This is the default when building with the clang built-in assembler,
but not if using the external assembler - thus always specify it,
for clarity.

Also use the three-operand for of a sub instruction in BS_NZC_CHECK.
The same is already done in the gnu version of the macro.

This fixes building most of the arm assembly with Apple's external
assembler. While this isn't a necessary goal in itself, there's no
harm in doing this either.

Review at https://rbcommons.com/s/OpenH264/r/736/.
