### PR TITLE
Get the actual used parameters in the codec in TemporalLayerSettingTest

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -163,10 +163,11 @@ TEST_F (EncoderInterfaceTest, TemporalLayerSettingTest) {
     EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
     EXPECT_EQ (sFbi.eFrameType, static_cast<int> (videoFrameTypeP));
 
-    memcpy (pOption, pParamExt, sizeof (SEncParamExt));
+    ENCODER_OPTION eOptionId = ENCODER_OPTION_SVC_ENCODE_PARAM_EXT;
+    iResult = pPtrEnc->GetOption (eOptionId, pOption);
+    EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
     pOption ->iTemporalLayerNum = 4;
 
-    ENCODER_OPTION eOptionId = ENCODER_OPTION_SVC_ENCODE_PARAM_EXT;
     iResult = pPtrEnc->SetOption (eOptionId, pOption);
     EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
 


### PR DESCRIPTION
Make sure that pOptions is initialized to the parameters that
the codec actually uses, not the ones that we initially tried
to set.

When calling SetOption to update the codec parameters, this may
cause a reset of the whole codec if e.g. the number of threads
differs from what is set within the codec itself.

If the number of threads was changed by the codec internally
when inited (e.g. changed from 0 to 1), WelsEncoderParamAdjust
may think the whole codec needs to be reset.

This fixes running EncoderInterfaceTest.TemporalLayerSettingTest
on machines where the detected number of cores is 1.

Review at https://rbcommons.com/s/OpenH264/r/737/.
