### PR TITLE
Remove a needless, no-op change of the number of threads

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -1862,14 +1862,6 @@ int32_t InitSliceSettings (SLogContext* pLogCtx, SWelsSvcCodingParam* pCodingPar
   pCodingParam->iCountThreadsNum				= WELS_MIN (kiCpuCores, iMaxSliceCount);
   pCodingParam->iMultipleThreadIdc	= pCodingParam->iCountThreadsNum;
 
-#ifndef WELS_TESTBED	// for product release and non-SGE testing
-
-  if (kiCpuCores < 2) {	// single CPU core, make no sense for MT parallelization
-    pCodingParam->iMultipleThreadIdc	= 1;
-    pCodingParam->iCountThreadsNum				= 1;
-  }
-#endif
-
   *pMaxSliceCount					= iMaxSliceCount;
 
   return 0;


### PR DESCRIPTION
If kiCpuCores < 2, then iCountThreadsNum (and iMultipleThreadIdc)
can't be >= 2, because they're initialized with
WELS_MIN (kiCpuCores, ...) just a few lines above.

If iMultipleThreadIdc is initially set to 0 by the caller, this
removed piece of code would change it to 1, if kiCpuCores < 2.

When iMultipleThreadIdc is changed from the originally set value,
a call to WelsEncoderParamAdjust with the original parameters
would reset the whole codec since iMultipleThreadIdc differs.

This fixes running EncoderInterfaceTest.TemporalLayerSettingTest
on machines where the detected number of cores is 1.

Review at https://rbcommons.com/s/OpenH264/r/738/.
