### PR TITLE
Stop referring to a removed make variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The codec and demo can be built by
 'make OS=android NDKROOT=**ANDROID_NDK** TARGET= **ANDROID_TARGET**'
 
 Valid **ANDROID_TARGET** can be found in **ANDROID_SDK**/platforms, such as android-12.
-You can also set ARCH, NDKLEVEL, GCCVERSION according to your device and NDK version.
+You can also set ARCH, NDKLEVEL according to your device and NDK version.
 ARCH specifies the architecture of android device. Currently only arm and x86 are supported, the default is arm.
 NDKLEVEL specifies android api level, the api level can be 12-19, the default is 12.
 


### PR DESCRIPTION
Nothing uses the make variable GCCVERSION any longer, since we just
query the NDK for the default compiler.

Review at https://rbcommons.com/s/OpenH264/r/743/.
