### PR TITLE
Check for $(CXX).exe as well when checking for the android toolchain

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -47,7 +47,9 @@ LDFLAGS += --sysroot=$(SYSROOT)
 SHLDFLAGS = -Wl,--no-undefined -Wl,-z,relro -Wl,-z,now -Wl,-soname,lib$(PROJECT_NAME).so
 
 ifneq ($(CXX),$(wildcard $(CXX)))
+ifneq ($(CXX).exe,$(wildcard $(CXX).exe))
 $(error Compiler not found, bad NDKROOT or ARCH?)
+endif
 endif
 
 STL_INCLUDES = \


### PR DESCRIPTION
This fixes building for android on windows.

Building for android on windows still requires MSYS for running make,
but running the ndk-build of the sample projects from within MSYS
doesn't seem to work, so one still needs to build it in two steps,
first make OS=android ... libopenh264.so from within MSYS, then
building the sample projects manually.

Review at https://rbcommons.com/s/OpenH264/r/747/.
