### PR TITLE
Add ifdef HAVE_NEON around the contents of arm_arch_common_macro.S

### DIFF
--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -30,6 +30,8 @@
  *
  */
 
+#ifdef HAVE_NEON
+
 .syntax unified
 
 #ifdef __APPLE__
@@ -62,4 +64,6 @@ mov pc, lr
 mov pc, lr
 .endfunc
 .endm
+#endif
+
 #endif


### PR DESCRIPTION
This file is built on its own from within the xcode projects,
even though it isn't necessary. Previously its contents was just
empty, but now a .syntax unified was added, which failed the build
when building for arm64.

Make this file a no-op, just like the other arm assembly source files,
unless HAVE_NEON is defined.

Review at https://rbcommons.com/s/OpenH264/r/757/.
