### PR TITLE
when sps/pps non exist, return dsNoParamSets

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -537,13 +537,15 @@ int32_t ParseSliceHeaderSyntaxs (PWelsDecoderContext pCtx, PBitStringAux pBs, co
   //add check PPS available here
   if (pCtx->bPpsAvailFlags[iPpsId] == false) {
     WelsLog (pLogCtx, WELS_LOG_ERROR, "PPS id is invalid!");
+    pCtx->iErrorCode |= dsNoParamSets;
     return GENERATE_ERROR_NO (ERR_LEVEL_SLICE_HEADER, ERR_INFO_INVALID_PPS_ID);
   }
 
   pPps    = &pCtx->sPpsBuffer[iPpsId];
 
   if (pPps->uiNumSliceGroups == 0) {
-    WelsLog (pLogCtx, WELS_LOG_WARNING, "non existing PPS referenced");
+    WelsLog (pLogCtx, WELS_LOG_WARNING, "Invalid PPS referenced");
+    pCtx->iErrorCode |= dsNoParamSets;
     return GENERATE_ERROR_NO (ERR_LEVEL_SLICE_HEADER, ERR_INFO_NO_PARAM_SETS);
   }
 
@@ -552,11 +554,13 @@ int32_t ParseSliceHeaderSyntaxs (PWelsDecoderContext pCtx, PBitStringAux pBs, co
     pSps		= &pSubsetSps->sSps;
     if (pCtx->bSubspsAvailFlags[pPps->iSpsId] == false) {
       WelsLog (pLogCtx, WELS_LOG_ERROR, "SPS id is invalid!");
+      pCtx->iErrorCode |= dsNoParamSets;
       return GENERATE_ERROR_NO (ERR_LEVEL_SLICE_HEADER, ERR_INFO_INVALID_SPS_ID);
     }
   } else {
     if (pCtx->bSpsAvailFlags[pPps->iSpsId] == false) {
       WelsLog (pLogCtx, WELS_LOG_ERROR, "SPS id is invalid!");
+      pCtx->iErrorCode |= dsNoParamSets;
       return GENERATE_ERROR_NO (ERR_LEVEL_SLICE_HEADER, ERR_INFO_INVALID_SPS_ID);
     }
     pSps		= &pCtx->sSpsBuffer[pPps->iSpsId];


### PR DESCRIPTION
when merging #1161 (into master) from #1146 (into openh264v1.1), these codes are missing due to conflicts and manual merging.
Add them back now.

After this, slice parse error will set dsBitstreamError except for these related to SPS/PPS, which set dsNoParamSets.
