### PR TITLE
[Encoder] add setoption of 'isLosslessLink' for further strategy tuning

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -102,6 +102,9 @@ typedef enum {
   ENCODER_OPTION_TRACE_LEVEL,
   ENCODER_OPTION_TRACE_CALLBACK, // a void (*)(void* context, int level, const char* message) function which receives log messages
   ENCODER_OPTION_TRACE_CALLBACK_CONTEXT,
+
+  // advanced algorithmetic settings
+  ENCODER_OPTION_IS_LOSSLESS_LINK,
 } ENCODER_OPTION;
 
 /* Option types introduced in decoder application */

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -118,6 +118,9 @@ iCountThreadsNum;                       //              # derived from disable_m
 int8_t		iDecompStages;		// GOP size dependency
 int32_t  iMaxNumRefFrame;
 
+//setting this according to link type in use MAY invoke some algorithms targeting higher coding efficiency
+bool bIsLossLessLink;
+
  public:
 TagWelsSvcCodingParam() {
   FillDefault();
@@ -217,7 +220,7 @@ void FillDefault() {
     sSpatialLayers[0].sSliceCfg.sSliceArgument.uiSliceMbNum[idx] = 960;
   sSpatialLayers[0].iDLayerQp = SVC_QUALITY_BASE_QP;
 
-
+  bIsLossLessLink = false;
 }
 
 int32_t ParamBaseTranscode (const SEncParamBase& pCodingParam) {

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -902,8 +902,13 @@ int CWelsH264SVCEncoder::SetOption (ENCODER_OPTION eOptionId, void* pOption) {
   }
   break;
   case ENCODER_OPTION_COMPLEXITY: {
-    int32_t iValue = * ((int32_t*)pOption);
+    int32_t iValue = * (static_cast<int32_t*>(pOption));
     m_pEncContext->pSvcParam->iComplexityMode = (ECOMPLEXITY_MODE)iValue;
+  }
+  break;
+  case ENCODER_OPTION_IS_LOSSLESS_LINK: {
+    bool bValue = * (static_cast<bool*>(pOption));
+    m_pEncContext->pSvcParam->bIsLossLessLink = bValue;
   }
   break;
   default:


### PR DESCRIPTION
reviewed at: https://rbcommons.com/s/OpenH264/r/791/
