### PR TITLE
[Encoder] remove unsupported lines in cfg to avoid misleading

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -333,7 +333,7 @@ typedef struct TagEncParamExt {
 
   /*LTR settings*/
   bool     bEnableLongTermReference; // 1: on, 0: off
-  int	   iLTRRefNum;
+  int	   iLTRRefNum; //TODO: not supported to set it arbitrary yet
   unsigned int      iLtrMarkPeriod;
 
   /* multi-thread settings*/

--- a/testbin/welsenc.cfg
+++ b/testbin/welsenc.cfg
@@ -49,7 +49,6 @@ EnableAdaptiveQuantization			1			# Enable Adaptive Quantization (1: enable, 0: d
 
 #============================== LONG TERM REFERENCE CONTROL ==============================
 EnableLongTermReference             1              # Enable Long Term Reference (1: enable, 0: disable)
-LongTermReferenceNumber             2			   # long term reference number (1-4):screen content (1-2):camera video
 LtrMarkPeriod                       30             # Long Term Reference Marking Period
 
 #============================== LAYER DEFINITION ==============================

--- a/testbin/welsenc_arbitrary_res.cfg
+++ b/testbin/welsenc_arbitrary_res.cfg
@@ -49,7 +49,6 @@ EnableAdaptiveQuantization			1			# Enable Adaptive Quantization (1: enable, 0: d
 
 #============================== LONG TERM REFERENCE CONTROL ==============================
 EnableLongTermReference             0              # Enable Long Term Reference (1: enable, 0: disable)
-LongTermReferenceNumber             2			   # long term reference number (1-4):screen content (1-2):camera video
 LtrMarkPeriod                       30             # Long Term Reference Marking Period
 
 #============================== LAYER DEFINITION ==============================

--- a/testbin/welsenc_ios.cfg
+++ b/testbin/welsenc_ios.cfg
@@ -50,7 +50,6 @@ EnableAdaptiveQuantization			1			# Enable Adaptive Quantization (1: enable, 0: d
 
 #============================== LONG TERM REFERENCE CONTROL ==============================
 EnableLongTermReference             0              # Enable Long Term Reference (1: enable, 0: disable)
-LongTermReferenceNumber             2			   # long term reference number (1-4):screen content (1-2):camera video
 LtrMarkPeriod                       30             # Long Term Reference Marking Period
 
 #============================== LAYER DEFINITION ==============================

--- a/testbin/welsenc_vd_1d.cfg
+++ b/testbin/welsenc_vd_1d.cfg
@@ -49,7 +49,6 @@ EnableAdaptiveQuantization			0			# Enable Adaptive Quantization (1: enable, 0: d
 
 #============================== LONG TERM REFERENCE CONTROL ==============================
 EnableLongTermReference             1              # Enable Long Term Reference (1: enable, 0: disable)
-LongTermReferenceNumber             2			   # long term reference number (1-4):screen content (1-2):camera video
 LtrMarkPeriod                       30             # Long Term Reference Marking Period
 
 #============================== LAYER DEFINITION ==============================

--- a/testbin/welsenc_vd_rc.cfg
+++ b/testbin/welsenc_vd_rc.cfg
@@ -49,7 +49,6 @@ EnableAdaptiveQuantization			1			# Enable Adaptive Quantization (1: enable, 0: d
 
 #============================== LONG TERM REFERENCE CONTROL ==============================
 EnableLongTermReference             1              # Enable Long Term Reference (1: enable, 0: disable)
-LongTermReferenceNumber             2			   # long term reference number (1-4):screen content (1-2):camera video
 LtrMarkPeriod                       30             # Long Term Reference Marking Period
 
 #============================== LAYER DEFINITION ==============================


### PR DESCRIPTION
setting arbitrary LTR number is actually not fully supported yet according to the codes, so remove the setting in cfg files to avoid misleading. 
