### PR TITLE
Use the correct version of delete within a unit test

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -405,7 +405,7 @@ int SimulateNALLoss (const unsigned char* pSrc,  int& iSrcLen, std::vector<SLost
   memset ((void*)pSrc, 0, iSrcLen);
   memcpy ((void*)pSrc, pDst, iDstLen);
   iSrcLen = iDstLen;
-  delete pDst;
+  delete [] pDst;
   return iSkipedBytes;
 }
 


### PR DESCRIPTION
This fixes valgrind warnings when running this test. The mismatched
delete could also potentially have caused memory corruption issues
while running the tests.

Review at https://rbcommons.com/s/OpenH264/r/814/.
