### PR TITLE
[Encoder] Fix a warning and refactor

### DIFF
--- a/codec/encoder/core/inc/picture.h
+++ b/codec/encoder/core/inc/picture.h
@@ -99,6 +99,27 @@ int32_t   iFrameAverageQp;
 
 /*******************************for screen reference frames****************************/
 SScreenBlockFeatureStorage* pScreenBlockFeatureStorage;
+
+  /*
+   *	set picture as unreferenced
+   */
+  void SetUnref () {
+    if (NULL != this)	{
+      iFramePoc		= -1;
+      iFrameNum		= -1;
+      uiTemporalId	=
+        uiSpatialId		=
+        iLongTermPicNum = -1;
+      bIsLongRef	= false;
+      uiRecieveConfirmed = RECIEVE_FAILED;
+      iMarkFrameNum = -1;
+      bUsedAsRef	= false;
+
+      if (NULL != pScreenBlockFeatureStorage)
+        pScreenBlockFeatureStorage->bRefBlockFeatureCalculated	= false;
+    }
+  }
+
 } SPicture;
 
 /*

--- a/codec/encoder/core/inc/picture_handle.h
+++ b/codec/encoder/core/inc/picture_handle.h
@@ -62,12 +62,5 @@ SPicture* AllocPicture (CMemoryAlign* pMa, const int32_t kiWidth, const int32_t 
  */
 void FreePicture (CMemoryAlign* pMa, SPicture** ppPic);
 
-/*!
-* \brief	exchange two picture pData planes
-* \param	ppPic1		picture pointer to picture 1
-* \param	ppPic2		picture pointer to picture 2
-* \return	none
-*/
-void WelsExchangeSpatialPictures (SPicture** ppPic1, SPicture** ppPic2);
 }
 #endif//WELS_ENCODER_PICTURE_HANDLE_H__

--- a/codec/encoder/core/inc/ref_list_mgr_svc.h
+++ b/codec/encoder/core/inc/ref_list_mgr_svc.h
@@ -47,11 +47,6 @@
 #include "codec_app_def.h"
 
 namespace WelsEnc {
-typedef enum {
-RECIEVE_UNKOWN = 0,
-RECIEVE_SUCCESS = 1,
-RECIEVE_FAILED = 2,
-} LTR_MARKING_RECEIVE_STATE;
 
 typedef enum {
 LTR_DIRECT_MARK = 0,

--- a/codec/encoder/core/inc/wels_const.h
+++ b/codec/encoder/core/inc/wels_const.h
@@ -189,6 +189,12 @@ BLOCK_4x4   = 4,
 BLOCK_SIZE_ALL = 5
 };
 
+typedef enum {
+RECIEVE_UNKOWN = 0,
+RECIEVE_SUCCESS = 1,
+RECIEVE_FAILED = 2,
+} LTR_MARKING_RECEIVE_STATE;
+
 enum {
   CUR_AU_IDX	= 0,			// index symbol for current access unit
   SUC_AU_IDX	= 1				// index symbol for successive access unit

--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -132,6 +132,14 @@ class CWelsPreProcess {
                                     const int32_t kiDependencyId, const bool kbCalculateBGD);
   int32_t UpdateBlockIdcForScreen (uint8_t*  pCurBlockStaticPointer, const SPicture* kpRefPic, const SPicture* kpSrcPic);
 
+  SPicture* GetCurrentFrameFromOrigList (int32_t iDIdx) {
+    return m_pSpatialPic[iDIdx][0];
+  };
+  void UpdateSrcList (SPicture*	pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
+                      const uint32_t kuiShortRefCount);
+  void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture*	pCurPicture, const int32_t kiCurDid,
+      const int32_t kuiMarkLongTermPicIdx, SPicture** pLongRefList);
+
  private:
   int32_t WelsPreprocessCreate();
   int32_t WelsPreprocessDestroy();
@@ -160,8 +168,9 @@ class CWelsPreProcess {
 
   ESceneChangeIdc DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPicture* pCurPicture);
   void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
-  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
-                            SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
+  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,
+      const int32_t iClosestLtrFrameNum,
+      SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
   void GetAvailableRefList (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
                             SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
   void InitRefJudgement (SRefJudgement* pRefJudgement);
@@ -171,6 +180,14 @@ class CWelsPreProcess {
   void SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSceneChangeResult& sSceneChangeResult,
                            SRefInfoParam* pRefSaved);
   void SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef);
+
+  /*!
+  * \brief	exchange two picture pData planes
+  * \param	ppPic1		picture pointer to picture 1
+  * \param	ppPic2		picture pointer to picture 2
+  * \return	none
+  */
+  void WelsExchangeSpatialPictures (SPicture** ppPic1, SPicture** ppPic2);
 
  private:
   Scaled_Picture   m_sScaledPicture;
@@ -182,8 +199,9 @@ class CWelsPreProcess {
   uint8_t          m_uiSpatialPicNum[MAX_DEPENDENCY_LAYER];
  public:
   /* For Downsampling & VAA I420 based source pictures */
-  SPicture*        m_pSpatialPic[MAX_DEPENDENCY_LAYER][MAX_TEMPORAL_LEVEL + 1 +
-      LONG_TERM_REF_NUM];	// need memory requirement with total number of (log2(uiGopSize)+1+1+long_term_ref_num)
+  SPicture*        m_pSpatialPic[MAX_DEPENDENCY_LAYER][MAX_REF_PIC_COUNT + 1];
+  // need memory requirement with total number of num_of_ref + 1, "+1" is for current frame
+  int32_t           m_iAvaliableRefInSpatialPicList;
 
 };
 

--- a/codec/encoder/core/src/picture_handle.cpp
+++ b/codec/encoder/core/src/picture_handle.cpp
@@ -179,20 +179,6 @@ void FreePicture (CMemoryAlign* pMa, SPicture** ppPic) {
     *ppPic = NULL;
   }
 }
-/*!
-* \brief	exchange two picture pData planes
-* \param	ppPic1		picture pointer to picture 1
-* \param	ppPic2		picture pointer to picture 2
-* \return	none
-*/
-void WelsExchangeSpatialPictures (SPicture** ppPic1, SPicture** ppPic2) {
-  SPicture* tmp	= *ppPic1;
-
-  assert (*ppPic1 != *ppPic2);
-
-  *ppPic1 = *ppPic2;
-  *ppPic2 = tmp;
-}
 
 } // namespace WelsEnc
 


### PR DESCRIPTION
```
1, fix a value in preprocess to avoid warning in UT
2, refactor to wrap the operation to m_pSpatialPic into WelsPreprocess
```

being reviewed at: https://rbcommons.com/s/OpenH264/r/834/
