### PR TITLE
Clarify who's implementation OpenH264 is based on

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         </div></td>
       <td width="740" rowspan="4" valign="top" align="left"><H4>Home</H4>
         
-        <div class="text">Cisco has taken our H.264 implementation, and open
+        <div class="text">Cisco has taken their H.264 implementation, and open
           sourced it under BSD license terms. Development and maintenance will
           be overseen by a board from industry and the open source community.
           Furthermore, we have provided a binary form suitable for inclusion in


### PR DESCRIPTION
The previous wording was unclear, since Cisco was named explicitly
first, it read as if "our" referred to some other party, when
the reader doesn't know who has written the text.
