### PR TITLE
Only use pthread_setname_np on Android >= 9 (2.3)

### DIFF
--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -58,6 +58,9 @@
 #ifdef ANDROID_NDK
 #include <cpu-features.h>
 #endif
+#ifdef __ANDROID__
+#include <android/api-level.h>
+#endif
 
 #include "WelsThreadLib.h"
 #include <stdio.h>
@@ -252,7 +255,7 @@ WELS_THREAD_ERROR_CODE WelsThreadSetName (const char* thread_name) {
 #ifdef APPLE_IOS
   pthread_setname_np(thread_name);
 #endif
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && __ANDROID_API__ >= 9
   pthread_setname_np(pthread_self(), thread_name);
 #endif
   // do nothing


### PR DESCRIPTION
Older versions of Android don't have this function.

Review at https://rbcommons.com/s/OpenH264/r/869/.
