### PR TITLE
refactor --for BaseEncoderTest

### DIFF
--- a/test/BaseEncoderTest.h
+++ b/test/BaseEncoderTest.h
@@ -14,10 +14,8 @@ class BaseEncoderTest {
   BaseEncoderTest();
   void SetUp();
   void TearDown();
-  void EncodeFile (const char* fileName, EUsageType usageType, int width, int height, float frameRate,
-                   SliceModeEnum slices, bool denoise, int layers, bool losslessLink, bool enableLtr, bool cabac, Callback* cbk);
-  void EncodeStream (InputStream* in, EUsageType usageType, int width, int height, float frameRate, SliceModeEnum slices,
-                     bool denoise, int layers, bool losslessLink, bool enableLtr, bool cabac, Callback* cbk);
+  void EncodeFile (const char* fileName, SEncParamExt* pEncParamExt, Callback* cbk);
+  void EncodeStream (InputStream* in,  SEncParamExt* pEncParamExt, Callback* cbk);
 
   ISVCEncoder* encoder_;
  private:

--- a/test/api/BaseEncoderTest.cpp
+++ b/test/api/BaseEncoderTest.cpp
@@ -5,16 +5,20 @@
 #include "utils/FileInputStream.h"
 #include "BaseEncoderTest.h"
 
-static int InitWithParam (ISVCEncoder* encoder, EUsageType usageType, int width,
-                          int height, float frameRate, SliceModeEnum sliceMode, bool denoise, int layers, bool losslessLink, bool enableLtr,bool cabac) {
-  if (SM_SINGLE_SLICE == sliceMode && !denoise && layers == 1 && !losslessLink && !enableLtr &&!cabac) {
+static int InitWithParam (ISVCEncoder* encoder, SEncParamExt* pEncParamExt) {
+
+  SliceModeEnum eSliceMode = pEncParamExt->sSpatialLayers[0].sSliceCfg.uiSliceMode;
+  bool bBaseParamFlag      = (SM_SINGLE_SLICE == eSliceMode             && !pEncParamExt->bEnableDenoise
+                              && pEncParamExt->iSpatialLayerNum == 1     && !pEncParamExt->bIsLosslessLink
+                              && !pEncParamExt->bEnableLongTermReference && !pEncParamExt->iEntropyCodingModeFlag) ? true : false;
+  if (bBaseParamFlag) {
     SEncParamBase param;
     memset (&param, 0, sizeof (SEncParamBase));
 
-    param.iUsageType = usageType;
-    param.fMaxFrameRate = frameRate;
-    param.iPicWidth = width;
-    param.iPicHeight = height;
+    param.iUsageType     = pEncParamExt->iUsageType;
+    param.fMaxFrameRate  = pEncParamExt->fMaxFrameRate;
+    param.iPicWidth      = pEncParamExt->iPicWidth;
+    param.iPicHeight     = pEncParamExt->iPicHeight;
     param.iTargetBitrate = 5000000;
 
     return encoder->Initialize (&param);
@@ -22,27 +26,27 @@ static int InitWithParam (ISVCEncoder* encoder, EUsageType usageType, int width,
     SEncParamExt param;
     encoder->GetDefaultParams (&param);
 
-    param.iUsageType = usageType;
-    param.fMaxFrameRate = frameRate;
-    param.iPicWidth = width;
-    param.iPicHeight = height;
-    param.iTargetBitrate = 5000000;
-    param.bEnableDenoise = denoise;
-    param.iSpatialLayerNum = layers;
-    param.bIsLosslessLink = losslessLink;
-    param.bEnableLongTermReference = enableLtr;
-    param.iEntropyCodingModeFlag = cabac?1:0;
-    if (sliceMode != SM_SINGLE_SLICE && sliceMode != SM_DYN_SLICE) //SM_DYN_SLICE don't support multi-thread now
+    param.iUsageType       = pEncParamExt->iUsageType;
+    param.fMaxFrameRate    = pEncParamExt->fMaxFrameRate;
+    param.iPicWidth        = pEncParamExt->iPicWidth;
+    param.iPicHeight       = pEncParamExt->iPicHeight;
+    param.iTargetBitrate   = 5000000;
+    param.bEnableDenoise   = pEncParamExt->bEnableDenoise;
+    param.iSpatialLayerNum = pEncParamExt->iSpatialLayerNum;
+    param.bIsLosslessLink  = pEncParamExt->bIsLosslessLink;
+    param.bEnableLongTermReference = pEncParamExt->bEnableLongTermReference;
+    param.iEntropyCodingModeFlag   = pEncParamExt->iEntropyCodingModeFlag ? 1 : 0;
+    if (eSliceMode != SM_SINGLE_SLICE && eSliceMode != SM_DYN_SLICE) //SM_DYN_SLICE don't support multi-thread now
       param.iMultipleThreadIdc = 2;
 
     for (int i = 0; i < param.iSpatialLayerNum; i++) {
-      param.sSpatialLayers[i].iVideoWidth = width >> (param.iSpatialLayerNum - 1 - i);
-      param.sSpatialLayers[i].iVideoHeight = height >> (param.iSpatialLayerNum - 1 - i);
-      param.sSpatialLayers[i].fFrameRate = frameRate;
+      param.sSpatialLayers[i].iVideoWidth     = pEncParamExt->iPicWidth  >> (param.iSpatialLayerNum - 1 - i);
+      param.sSpatialLayers[i].iVideoHeight    = pEncParamExt->iPicHeight >> (param.iSpatialLayerNum - 1 - i);
+      param.sSpatialLayers[i].fFrameRate      = pEncParamExt->fMaxFrameRate;
       param.sSpatialLayers[i].iSpatialBitrate = param.iTargetBitrate;
 
-      param.sSpatialLayers[i].sSliceCfg.uiSliceMode = sliceMode;
-      if (sliceMode == SM_DYN_SLICE) {
+      param.sSpatialLayers[i].sSliceCfg.uiSliceMode = eSliceMode;
+      if (eSliceMode == SM_DYN_SLICE) {
         param.sSpatialLayers[i].sSliceCfg.sSliceArgument.uiSliceSizeConstraint = 600;
         param.uiMaxNalSize = 1500;
       }
@@ -68,13 +72,15 @@ void BaseEncoderTest::TearDown() {
   }
 }
 
-void BaseEncoderTest::EncodeStream (InputStream* in, EUsageType usageType, int width, int height,
-                                    float frameRate, SliceModeEnum slices, bool denoise, int layers, bool losslessLink, bool enableLtr, bool cabac,Callback* cbk) {
-  int rv = InitWithParam (encoder_, usageType, width, height, frameRate, slices, denoise, layers, losslessLink, enableLtr,cabac);
+void BaseEncoderTest::EncodeStream (InputStream* in, SEncParamExt* pEncParamExt, Callback* cbk) {
+
+  ASSERT_TRUE (NULL != pEncParamExt);
+
+  int rv = InitWithParam (encoder_, pEncParamExt);
   ASSERT_TRUE (rv == cmResultSuccess);
 
   // I420: 1(Y) + 1/4(U) + 1/4(V)
-  int frameSize = width * height * 3 / 2;
+  int frameSize = pEncParamExt->iPicWidth * pEncParamExt->iPicHeight * 3 / 2;
 
   BufferedData buf;
   buf.SetLength (frameSize);
@@ -85,14 +91,14 @@ void BaseEncoderTest::EncodeStream (InputStream* in, EUsageType usageType, int w
 
   SSourcePicture pic;
   memset (&pic, 0, sizeof (SSourcePicture));
-  pic.iPicWidth = width;
-  pic.iPicHeight = height;
+  pic.iPicWidth    = pEncParamExt->iPicWidth;
+  pic.iPicHeight   = pEncParamExt->iPicHeight;
   pic.iColorFormat = videoFormatI420;
-  pic.iStride[0] = pic.iPicWidth;
-  pic.iStride[1] = pic.iStride[2] = pic.iPicWidth >> 1;
-  pic.pData[0] = buf.data();
-  pic.pData[1] = pic.pData[0] + width * height;
-  pic.pData[2] = pic.pData[1] + (width * height >> 2);
+  pic.iStride[0]   = pic.iPicWidth;
+  pic.iStride[1]   = pic.iStride[2] = pic.iPicWidth >> 1;
+  pic.pData[0]     = buf.data();
+  pic.pData[1]     = pic.pData[0] + pEncParamExt->iPicWidth * pEncParamExt->iPicHeight;
+  pic.pData[2]     = pic.pData[1] + (pEncParamExt->iPicWidth * pEncParamExt->iPicHeight >> 2);
   while (in->read (buf.data(), frameSize) == frameSize) {
     rv = encoder_->EncodeFrame (&pic, &info);
     ASSERT_TRUE (rv == cmResultSuccess);
@@ -102,9 +108,9 @@ void BaseEncoderTest::EncodeStream (InputStream* in, EUsageType usageType, int w
   }
 }
 
-void BaseEncoderTest::EncodeFile (const char* fileName, EUsageType usageType, int width, int height,
-                                  float frameRate, SliceModeEnum slices, bool denoise, int layers, bool losslessLink, bool enableLtr, bool cabac,Callback* cbk) {
+void BaseEncoderTest::EncodeFile (const char* fileName, SEncParamExt* pEncParamExt, Callback* cbk) {
   FileInputStream fileStream;
   ASSERT_TRUE (fileStream.Open (fileName));
-  EncodeStream (&fileStream, usageType, width, height, frameRate, slices, denoise, layers, losslessLink, enableLtr, cabac,cbk);
+  ASSERT_TRUE (NULL != pEncParamExt);
+  EncodeStream (&fileStream, pEncParamExt, cbk);
 }

--- a/test/api/decode_encode_test.cpp
+++ b/test/api/decode_encode_test.cpp
@@ -91,15 +91,38 @@ class DecodeEncodeTest : public ::testing::TestWithParam<DecodeEncodeFileParam>,
   BufferedData buf_;
 };
 
+void DecEncFileParamToParamExt (DecodeEncodeFileParam * pDecEncFileParam, SEncParamExt* pEnxParamExt) {
+  ASSERT_TRUE (NULL != pDecEncFileParam && NULL != pEnxParamExt);
+
+  pEnxParamExt->iPicWidth      = pDecEncFileParam->width;
+  pEnxParamExt->iPicHeight     = pDecEncFileParam->height;
+  pEnxParamExt->fMaxFrameRate  = pDecEncFileParam->frameRate;
+
+  //default value
+  pEnxParamExt->iUsageType        = CAMERA_VIDEO_REAL_TIME;
+  pEnxParamExt->iSpatialLayerNum  = 1;
+  pEnxParamExt->bEnableDenoise    = false;
+  pEnxParamExt->bIsLosslessLink   = false;
+  pEnxParamExt->bEnableLongTermReference  = false;
+  pEnxParamExt->iEntropyCodingModeFlag    = 0;
+
+  for (int i = 0; i < pEnxParamExt->iSpatialLayerNum; i++) {
+     pEnxParamExt->sSpatialLayers[i].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
+  }
+
+}
 TEST_P (DecodeEncodeTest, CompareOutput) {
   DecodeEncodeFileParam p = GetParam();
+  SEncParamExt  EnxParamExt;
+  DecEncFileParamToParamExt(&p,&EnxParamExt);
+
 #if defined(ANDROID_NDK)
   std::string filename = std::string ("/sdcard/") + p.fileName;
   ASSERT_TRUE (Open (filename.c_str()));
 #else
   ASSERT_TRUE (Open (p.fileName));
 #endif
-  EncodeStream (this, CAMERA_VIDEO_REAL_TIME, p.width, p.height, p.frameRate, SM_SINGLE_SLICE, false, 1, false, false,false, this);
+  EncodeStream (this, &EnxParamExt, this);
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result (&ctx_, digest);
   if (!HasFatalFailure()) {

--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -231,7 +231,7 @@ void EncodeDecodeTestAPI::RandomParamExtCombination() {
   param_.bEnableFrameCroppingFlag   = (rand() % 2 == 0) ? false : true;
   param_.bEnableSceneChangeDetect   = (rand() % 2 == 0) ? false : true;
 
-//for rc
+  //for rc
   param_.iRCMode            = static_cast<RC_MODES> (rand() % RC_MODE_RANGE - 1);
   param_.iMaxBitrate        = rand() % BIT_RATE_RANGE;
   param_.iTargetBitrate     = rand() % BIT_RATE_RANGE;
@@ -286,7 +286,7 @@ void EncodeDecodeTestAPI::ValidateParamExtCombination() {
     param_.uiIntraPeriod = 0;
   }
 
-//RefNum
+  //RefNum
   int32_t iRefUpperBound    = (param_.iUsageType == CAMERA_VIDEO_REAL_TIME) ?
                               MAX_REFERENCE_PICTURE_COUNT_NUM_CAMERA : MAX_REFERENCE_PICTURE_COUNT_NUM_SCREEN;
   param_.iNumRefFrame       = WELS_CLIP3 (param_.iNumRefFrame, MIN_REF_PIC_COUNT, iRefUpperBound);
@@ -2003,7 +2003,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionEncParamExt) {
   ASSERT_TRUE (rv == cmResultSuccess);
 
   for (int i = 0; i < iEncFrameNum; i++) {
-    //for (int i = 0; i < 9; i++) {
     int iResult;
     int len = 0;
     unsigned char* pData[3] = { NULL };


### PR DESCRIPTION
1)for function  
                 --EncodeFile(...)
                 --EncodeStream(...)
                 --InitWithPara(...)
    -- used SEncParamExt\* pEncParamExt instead of " EUsageType usageType, int width ...."
     it will be more flexible for adding more parameters in test case such as thread num, temp layer num etc.
2) change some code and let it be more google style
