### PR TITLE
Make sure the width/height is large enough in SetOptionEncParamExt

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -1985,8 +1985,8 @@ TEST_F (EncodeDecodeTestAPI, Engine_SVC_Switch_P) {
 
 
 TEST_F (EncodeDecodeTestAPI, SetOptionEncParamExt) {
-  int iWidth       = WELS_CLIP3 ((((rand() % MAX_WIDTH) >> 1) + 1) << 1,  2, MAX_WIDTH);
-  int iHeight      = WELS_CLIP3 ((((rand() % MAX_HEIGHT) >> 1) + 1) << 1, 2, MAX_HEIGHT);
+  int iWidth       = (((rand() % MAX_WIDTH) >> 1) + 16) << 1;
+  int iHeight      = (((rand() % MAX_HEIGHT) >> 1) + 16) << 1;
   float fFrameRate = rand() + 0.5f;
   int iEncFrameNum = WELS_CLIP3 ((rand() % ENCODE_FRAME_NUM) + 1, 1, ENCODE_FRAME_NUM);
   int iSpatialLayerNum = 4;


### PR DESCRIPTION
When using 4 downsampled layers, make sure the random width/height
is large enough that the downsampled layers don't have a zero size.

Review at https://rbcommons.com/s/OpenH264/r/881/.
