### PR TITLE
Add a cast when converting from double to float

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -369,7 +369,7 @@ long CWelsDecoder::GetOption (DECODER_OPTION eOptID, void* pOption) {
 
     memcpy (pDecoderStatistics, &m_pDecContext->sDecoderStatistics, sizeof (SDecoderStatistics));
 
-    pDecoderStatistics->fAverageFrameSpeedInMs = (m_pDecContext->dDecTime) /
+    pDecoderStatistics->fAverageFrameSpeedInMs = (float) (m_pDecContext->dDecTime) /
         (m_pDecContext->sDecoderStatistics.uiDecodedFrameCount);
     memset (&m_pDecContext->sDecoderStatistics, 0, sizeof (SDecoderStatistics));
     m_pDecContext->dDecTime = 0;


### PR DESCRIPTION
This fixes warnings with MSVC.

Review at https://rbcommons.com/s/OpenH264/r/909/.
