### PR TITLE
Remove a duplicated field in SWelsSvcCodingParam

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -118,9 +118,6 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
   int8_t		iDecompStages;		// GOP size dependency
   int32_t  iMaxNumRefFrame;
 
-//setting this according to link type in use MAY invoke some algorithms targeting higher coding efficiency
-  bool bIsLosslessLink;
-
  public:
   TagWelsSvcCodingParam() {
     FillDefault();


### PR DESCRIPTION
The same field already exists in SEncParamExt. When the
initialization was deduplicated in ac404ce, this lead to
reading the now uninitialized field in SWelsSvcCodingParam,
instead of the properly initialized one in the base class.

Review at https://rbcommons.com/s/OpenH264/r/912/.
