### PR TITLE
Cast to the right data type to avoid comparison warnings in gcc

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -745,7 +745,7 @@ TEST_F (EncoderInterfaceTest, GetStatistics) {
   EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
   iResult = pPtrEnc->GetOption (ENCODER_OPTION_GET_STATISTICS, &sEncoderStatistics);
   EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
-  EXPECT_EQ (static_cast<int> (sEncoderStatistics.fAverageFrameRate), sEncoderStatistics.uiInputFrameCount);
+  EXPECT_EQ (static_cast<unsigned int> (sEncoderStatistics.fAverageFrameRate), sEncoderStatistics.uiInputFrameCount);
 
   // 4, change log interval
   int32_t iInterval = 0;


### PR DESCRIPTION
Review at https://rbcommons.com/s/OpenH264/r/920/.
