### PR TITLE
Use the right data type for a variable

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -787,7 +787,7 @@ TEST_F (EncoderInterfaceTest, FrameSizeCheck) {
   PrepareOneSrcFrame();
   iResult = pPtrEnc->EncodeFrame (pSrcPic, &sFbi);
 
-  uint32_t length = 0;
+  int length = 0;
   for (int i = 0; i < sFbi.iLayerNum; ++i) {
     for (int j = 0; j < sFbi.sLayerInfo[i].iNalCount; ++j) {
       length += sFbi.sLayerInfo[i].pNalLengthInByte[j];


### PR DESCRIPTION
Both pNalLengthInByte[] that are accumulated, and sFbi.iFrameSizeInBytes
that it is compared to, are plain 'int', not 'uint32_t'.

This fixes warnings about comparison between signed and unsigned.

Review at https://rbcommons.com/s/OpenH264/r/922/.
