### PR TITLE
parse only add and UT

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -457,6 +457,7 @@ typedef struct TagSVCDecodingParam {
   unsigned char	uiTargetDqLayer;       ///< setting target dq layer id
 
   ERROR_CON_IDC eEcActiveIdc;          ///< whether active error concealment feature in decoder
+  bool bParseOnly;                     ///< decoder for parse only, no reconstruction
 
   SVideoProperty   sVideoProperty;    ///< video stream property
 } SDecodingParam, *PDecodingParam;
@@ -574,7 +575,7 @@ typedef struct TagParserBsInfo {
   unsigned char* pDstBuff;                     ///< outputted dst buffer for parsed bitstream
   int iSpsWidthInPixel;                        ///< required SPS width info
   int iSpsHeightInPixel;                       ///< required SPS height info
-} SParserBsInfo, PParserBsInfo;
+} SParserBsInfo, *PParserBsInfo;
 
 /**
 * @brief Structure for encoder statistics

--- a/codec/decoder/core/inc/au_parser.h
+++ b/codec/decoder/core/inc/au_parser.h
@@ -86,7 +86,7 @@ uint8_t* DetectStartCodePrefix (const uint8_t* kpBuf, int32_t* pOffset, int32_t 
 uint8_t* ParseNalHeader (PWelsDecoderContext pCtx, SNalUnitHeader* pNalUnitHeader, uint8_t* pSrcRbsp,
                          int32_t iSrcRbspLen, uint8_t* pSrcNal, int32_t iSrcNalLen, int32_t* pConsumedBytes);
 
-int32_t ParseNonVclNal (PWelsDecoderContext pCtx, uint8_t* pRbsp, const int32_t kiSrcLen);
+int32_t ParseNonVclNal (PWelsDecoderContext pCtx, uint8_t* pRbsp, const int32_t kiSrcLen, uint8_t* pSrcNal, const int32_t kSrcNalLen);
 
 int32_t ParseRefBasePicMarking (PBitStringAux pBs, PRefBasePicMarking pRefBasePicMarking);
 
@@ -113,7 +113,7 @@ bool CheckNextAuNewSeq (PWelsDecoderContext pCtx, const PNalUnit kpCurNal, const
  * \note	Call it in case eNalUnitType is SPS.
  *************************************************************************************
  */
-int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicWidth, int32_t* pPicHeight);
+int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicWidth, int32_t* pPicHeight, uint8_t* pSrcNal, const int32_t kSrcNalLen);
 
 /*!
  *************************************************************************************
@@ -129,7 +129,7 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
  * \note	Call it in case eNalUnitType is PPS.
  *************************************************************************************
  */
-int32_t ParsePps (PWelsDecoderContext pCtx, PPps pPpsList, PBitStringAux pBsAux);
+int32_t ParsePps (PWelsDecoderContext pCtx, PPps pPpsList, PBitStringAux pBsAux, uint8_t* pSrcNal, const int32_t kSrcNalLen);
 
 /*!
  *************************************************************************************

--- a/codec/decoder/core/inc/bit_stream.h
+++ b/codec/decoder/core/inc/bit_stream.h
@@ -65,7 +65,15 @@ int32_t InitBits (PBitStringAux pBitString, const uint8_t* kpBuf, const int32_t 
 
 int32_t InitReadBits (PBitStringAux pBitString, intX_t iEndOffset);
 
-
+//The following for writing bs in decoder for Parse Only purpose
+void DecInitBitsForEncoding (PBitStringAux pBitString, uint8_t* kpBuf, const int32_t kiSize);
+int32_t DecBsWriteBits (PBitStringAux pBitString, int32_t iLen, const uint32_t kuiValue);
+int32_t DecBsWriteOneBit (PBitStringAux pBitString, const uint32_t kuiValue);
+int32_t DecBsFlush (PBitStringAux pBitString);
+int32_t DecBsWriteUe (PBitStringAux pBitString, const uint32_t kuiValue);
+int32_t DecBsWriteSe (PBitStringAux pBitString, const int32_t kiValue);
+int32_t DecBsRbspTrailingBits (PBitStringAux pBitString);
+void RBSP2EBSP (uint8_t* pDstBuf, uint8_t* pSrcBuf, const int32_t kiSize);
 
 } // namespace WelsDec
 

--- a/codec/decoder/core/inc/decoder.h
+++ b/codec/decoder/core/inc/decoder.h
@@ -68,7 +68,7 @@ int32_t DecoderConfigParam (PWelsDecoderContext pCtx, const SDecodingParam* kpPa
  * \note	N/A
  *************************************************************************************
  */
-int32_t WelsInitDecoder (PWelsDecoderContext pCtx, SLogContext* pLogCtx);
+int32_t WelsInitDecoder (PWelsDecoderContext pCtx, const bool bParseOnly, SLogContext* pLogCtx);
 
 /*!
  *************************************************************************************
@@ -101,7 +101,7 @@ void WelsEndDecoder (PWelsDecoderContext pCtx);
  */
 
 int32_t WelsDecodeBs (PWelsDecoderContext pCtx, const uint8_t* kpBsBuf, const int32_t kiBsLen,
-                      uint8_t** ppDst, SBufferInfo* pDstBufInfo);
+                      uint8_t** ppDst, SBufferInfo* pDstBufInfo, SParserBsInfo* pDstBsInfo);
 
 /*
  *	request memory blocks for decoder avc part

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -102,6 +102,19 @@ uint8_t* pStartPos;
 uint8_t* pCurPos;
 } SDataBuffer;
 
+//limit size for SPS PPS total permitted size for parse_only
+#define SPS_PPS_BS_SIZE 128
+typedef struct TagSpsBsInfo {
+  uint8_t pSpsBsBuf [SPS_PPS_BS_SIZE];
+  int32_t iSpsId;
+  uint16_t uiSpsBsLen;
+} SSpsBsInfo;
+
+typedef struct TagPpsBsInfo {
+  uint8_t pPpsBsBuf [SPS_PPS_BS_SIZE];
+  int32_t iPpsId;
+  uint16_t uiPpsBsLen;
+} SPpsBsInfo;
 //#ifdef __cplusplus
 //extern "C" {
 //#endif//__cplusplus
@@ -210,6 +223,7 @@ SLogContext sLogCtx;
 void*				pArgDec;			// structured arguments for decoder, reserved here for extension in the future
 
 SDataBuffer                     sRawData;
+SDataBuffer                     sSavedData; //for parse only purpose
 
 // Configuration
 SDecodingParam*                 pParam;
@@ -334,6 +348,14 @@ bool       bNewSeqBegin;
 bool       bNextNewSeqBegin;
 int        iOverwriteFlags;
 ERROR_CON_IDC eErrorConMethod; //
+
+//for Parse only
+bool bParseOnly;
+SSpsBsInfo sSpsBsInfo [MAX_SPS_COUNT];
+SSpsBsInfo sSubsetSpsBsInfo [MAX_PPS_COUNT];
+SPpsBsInfo sPpsBsInfo [MAX_PPS_COUNT];
+SParserBsInfo* pParserBsInfo;
+
 PPicture pPreviousDecodedPictureInDpb; //pointer to previously decoded picture in DPB for error concealment
 PGetIntraPredFunc pGetI16x16LumaPredFunc[7];		//h264_predict_copy_16x16;
 PGetIntraPredFunc pGetI4x4LumaPredFunc[14];		// h264_predict_4x4_t

--- a/codec/decoder/core/src/bit_stream.cpp
+++ b/codec/decoder/core/src/bit_stream.cpp
@@ -49,7 +49,7 @@ inline uint32_t GetValue4Bytes (uint8_t* pDstNal) {
 }
 
 int32_t InitReadBits (PBitStringAux pBitString, intX_t iEndOffset) {
-  if(pBitString->pCurBuf>=(pBitString->pEndBuf - iEndOffset)) {
+  if (pBitString->pCurBuf >= (pBitString->pEndBuf - iEndOffset)) {
     return ERR_INFO_INVALID_ACCESS;
   }
   pBitString->uiCurBits  = GetValue4Bytes (pBitString->pCurBuf);
@@ -79,10 +79,140 @@ int32_t InitBits (PBitStringAux pBitString, const uint8_t* kpBuf, const int32_t 
   pBitString->iBits	    = kiSize;				// count bits of overall bitstreaming inputindex;
   pBitString->pCurBuf   = pBitString->pStartBuf;
   int32_t iErr = InitReadBits (pBitString, 0);
-  if(iErr) {
+  if (iErr) {
     return iErr;
   }
   return ERR_NONE;
+}
+
+//Following for write bs in decoder
+void DecInitBitsForEncoding (PBitStringAux pBitString, uint8_t* pBuf, const int32_t kiSize) {
+  uint8_t* pPtr = pBuf;
+  pBitString->pStartBuf = pPtr;
+  pBitString->pCurBuf = pPtr;
+  pBitString->pEndBuf = pPtr + kiSize;
+  pBitString->iLeftBits = 32;
+  pBitString->uiCurBits = 0;
+}
+
+#define WRITE_BE_32(ptr, val) do { \
+    (ptr)[0] = (val) >> 24; \
+    (ptr)[1] = (val) >> 16; \
+    (ptr)[2] = (val) >>  8; \
+    (ptr)[3] = (val) >>  0; \
+  } while (0);
+
+int32_t DecBsWriteBits (PBitStringAux pBitString, int32_t iLen, const uint32_t kuiValue) {
+  if (iLen < pBitString->iLeftBits) {
+    pBitString->uiCurBits = (pBitString->uiCurBits << iLen) | kuiValue;
+    pBitString->iLeftBits -= iLen;
+  } else {
+    iLen -= pBitString->iLeftBits;
+    pBitString->uiCurBits = (pBitString->uiCurBits << pBitString->iLeftBits) | (kuiValue >> iLen);
+    WRITE_BE_32 (pBitString->pCurBuf, pBitString->uiCurBits);
+    pBitString->pCurBuf += 4;
+    pBitString->uiCurBits = kuiValue & ((1 << iLen) - 1);
+    pBitString->iLeftBits = 32 - iLen;
+  }
+  return 0;
+}
+
+int32_t DecBsWriteOneBit (PBitStringAux pBitString, const uint32_t kuiValue) {
+  DecBsWriteBits (pBitString, 1, kuiValue);
+  return 0;
+}
+
+int32_t DecBsFlush (PBitStringAux pBitString) {
+  WRITE_BE_32 (pBitString->pCurBuf, pBitString->uiCurBits << pBitString->iLeftBits);
+  pBitString->pCurBuf += 4 - pBitString->iLeftBits / 8;
+  pBitString->iLeftBits = 32;
+  pBitString->uiCurBits = 0;
+  return 0;
+}
+
+const uint32_t g_kuiDecGolombUELength[256] = {
+  1,  3,  3,  5,  5,  5,  5,  7,  7,  7,  7,  7,  7,  7,  7,     //14
+  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9, //30
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,//46
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,//62
+  13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,//
+  13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+  13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+  13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  17
+};
+
+int32_t DecBsWriteUe (PBitStringAux pBitString, const uint32_t kuiValue) {
+  uint32_t iTmpValue = kuiValue + 1;
+  if (256 > kuiValue) {
+    DecBsWriteBits (pBitString, g_kuiDecGolombUELength[kuiValue], kuiValue + 1);
+  } else {
+    uint32_t n = 0;
+    if (iTmpValue & 0xffff0000) {
+      iTmpValue >>= 16;
+      n += 16;
+    }
+    if (iTmpValue & 0xff) {
+      iTmpValue >>= 8;
+      n += 8;
+    }
+
+    //n += (g_kuiDecGolombUELength[iTmpValue] >> 1);
+
+    n += (g_kuiDecGolombUELength[iTmpValue - 1] >> 1);
+    DecBsWriteBits (pBitString, (n << 1) + 1, kuiValue + 1);
+  }
+  return 0;
+}
+
+int32_t DecBsWriteSe (PBitStringAux pBitString, const int32_t kiValue) {
+  uint32_t iTmpValue;
+  if (0 == kiValue) {
+    DecBsWriteOneBit (pBitString, 1);
+  } else if (0 < kiValue) {
+    iTmpValue = (kiValue << 1) - 1;
+    DecBsWriteUe (pBitString, iTmpValue);
+  } else {
+    iTmpValue = ((-kiValue) << 1);
+    DecBsWriteUe (pBitString, iTmpValue);
+  }
+  return 0;
+}
+
+int32_t DecBsRbspTrailingBits (PBitStringAux pBitString) {
+  DecBsWriteOneBit (pBitString, 1);
+  DecBsFlush (pBitString);
+
+  return 0;
+}
+
+void RBSP2EBSP (uint8_t* pDstBuf, uint8_t* pSrcBuf, const int32_t kiSize) {
+  uint8_t* pSrcPointer = pSrcBuf;
+  uint8_t* pDstPointer = pDstBuf;
+  uint8_t* pSrcEnd = pSrcBuf + kiSize;
+  int32_t iZeroCount = 0;
+
+  while (pSrcPointer < pSrcEnd) {
+    if (iZeroCount == 2 && *pSrcPointer <= 3) {
+      //add the code 0x03
+      *pDstPointer++ = 3;
+      iZeroCount = 0;
+    }
+    if (*pSrcPointer == 0) {
+      ++ iZeroCount;
+    } else {
+      iZeroCount = 0;
+    }
+    *pDstPointer++ = *pSrcPointer++;
+  }
 }
 
 } // namespace WelsDec

--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -256,6 +256,8 @@ int32_t WelsMarkAsRef (PWelsDecoderContext pCtx) {
 
   pCtx->pDec->uiQualityId = pCtx->pCurDqLayer->sLayerInfo.sNalHeaderExt.uiQualityId;
   pCtx->pDec->uiTemporalId = pCtx->pCurDqLayer->sLayerInfo.sNalHeaderExt.uiTemporalId;
+  pCtx->pDec->iSpsId = pCtx->pCurDqLayer->sLayerInfo.sSliceInLayer.sSliceHeaderExt.sSliceHeader.iSpsId;
+  pCtx->pDec->iPpsId = pCtx->pCurDqLayer->sLayerInfo.sSliceInLayer.sSliceHeaderExt.sSliceHeader.iPpsId;
 
   for (j = pCurAU->uiStartPos; j <= pCurAU->uiEndPos; j++) {
     if (pCurAU->pNalUnitsList[j]->sNalHeaderExt.sNalUnitHeader.eNalUnitType == NAL_UNIT_CODED_SLICE_IDR

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -104,7 +104,7 @@ virtual long EXTAPI GetOption (DECODER_OPTION eOptID, void* pOption);
 PWelsDecoderContext 				m_pDecContext;
 welsCodecTrace*			m_pWelsTrace;
 
-int32_t InitDecoder (void);
+int32_t InitDecoder (const bool);
 void UninitDecoder (void);
 
 #ifdef OUTPUT_BIT_STREAM


### PR DESCRIPTION
add ParseOnly for input bitstream without reconstruction.
This modifies API with "bParseOnly", which can not be modified during decoding.
It also enable some re-writing functions of single layer SVC header to AVC (under no inter-layer prediction) to some degree.

see:
https://rbcommons.com/s/OpenH264/r/910/
