### PR TITLE
Don't implicitly convert int to bool

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -127,7 +127,7 @@ static inline int32_t DecodeFrameConstruction (PWelsDecoderContext pCtx, uint8_t
       WelsLog (& (pCtx->sLogCtx), WELS_LOG_INFO, "DecodeFrameConstruction():New sequence detected, but freezed.");
     }
   }
-  UpdateDecStat (pCtx, pDstInfo->iBufferStatus);
+  UpdateDecStat (pCtx, pDstInfo->iBufferStatus != 0);
 
   return 0;
 }


### PR DESCRIPTION
This avoids warnings with MSVC.

Review at https://rbcommons.com/s/OpenH264/r/960/.
