### PR TITLE
should not set WELS_LOG_ERROR level in encoder initilization.

### DIFF
--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -166,8 +166,6 @@ void CWelsH264SVCEncoder::InitEncoder (void) {
   if (m_pWelsTrace == NULL) {
     return;
   }
-
-  m_pWelsTrace->SetTraceLevel (WELS_LOG_ERROR);
   WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "CWelsH264SVCEncoder::InitEncoder(), openh264 codec version = %s",
            VERSION_NUMBER);
 }


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/965/
