### PR TITLE
Log the encoder version later in the initialization

### DIFF
--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -166,8 +166,6 @@ void CWelsH264SVCEncoder::InitEncoder (void) {
   if (m_pWelsTrace == NULL) {
     return;
   }
-  WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "CWelsH264SVCEncoder::InitEncoder(), openh264 codec version = %s",
-           VERSION_NUMBER);
 }
 
 /* Interfaces override from ISVCEncoder */
@@ -184,6 +182,9 @@ int CWelsH264SVCEncoder::Initialize (const SEncParamBase* argv) {
   if (m_pWelsTrace == NULL) {
     return cmMallocMemeError;
   }
+
+  WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "CWelsH264SVCEncoder::InitEncoder(), openh264 codec version = %s",
+           VERSION_NUMBER);
 
   if (NULL == argv) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "CWelsH264SVCEncoder::Initialize(), invalid argv= 0x%p",
@@ -208,6 +209,9 @@ int CWelsH264SVCEncoder::InitializeExt (const SEncParamExt* argv) {
   if (m_pWelsTrace == NULL) {
     return cmMallocMemeError;
   }
+
+  WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "CWelsH264SVCEncoder::InitEncoder(), openh264 codec version = %s",
+           VERSION_NUMBER);
 
   if (NULL == argv) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "CWelsH264SVCEncoder::InitializeExt(), invalid argv= 0x%p",


### PR DESCRIPTION
Previously, the encoder logging was done in InitEncoder(),
which is called from the constructor. Therefore, it was impossible
to override the log level, to silence this message.

Review at https://rbcommons.com/s/OpenH264/r/978/.
