### PR TITLE
add this log for codec

### DIFF
--- a/codec/common/inc/utils.h
+++ b/codec/common/inc/utils.h
@@ -54,6 +54,7 @@ typedef void (*PWelsLogCallbackFunc) (void* pCtx, const int32_t iLevel, const ch
 typedef struct TagLogContext {
   PWelsLogCallbackFunc pfLog;
   void* pLogCtx;
+  void* pCodecInstance;
 } SLogContext;
 
 

--- a/codec/common/inc/welsCodecTrace.h
+++ b/codec/common/inc/welsCodecTrace.h
@@ -44,6 +44,7 @@ class welsCodecTrace {
   welsCodecTrace();
   ~welsCodecTrace();
 
+  void SetCodecInstance (void* pCodecInstance);
   void SetTraceLevel (const int32_t kiLevel);
   void SetTraceCallback (WelsTraceCallback func);
   void SetTraceCallbackContext (void* pCtx);

--- a/codec/common/src/utils.cpp
+++ b/codec/common/src/utils.cpp
@@ -53,19 +53,19 @@ void WelsLog (SLogContext* logCtx, int32_t iLevel, const char* kpFmt, ...) {
   char pTraceTag[MAX_LOG_SIZE];
   switch (iLevel) {
   case WELS_LOG_ERROR:
-    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] Error:");
+    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] this = 0x%p, Error:", logCtx->pCodecInstance);
     break;
   case WELS_LOG_WARNING:
-    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] Warning:");
+    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] this = 0x%p, Warning:", logCtx->pCodecInstance);
     break;
   case WELS_LOG_INFO:
-    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] Info:");
+    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] this = 0x%p, Info:", logCtx->pCodecInstance);
     break;
   case WELS_LOG_DEBUG:
-    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] Debug:");
+    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] this = 0x%p, Debug:", logCtx->pCodecInstance);
     break;
   default:
-    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] Detail:");
+    WelsSnprintf (pTraceTag, MAX_LOG_SIZE, "[OpenH264] this = 0x%p, Detail:", logCtx->pCodecInstance);
     break;
   }
   WelsStrcat (pTraceTag, MAX_LOG_SIZE, kpFmt);

--- a/codec/common/src/welsCodecTrace.cpp
+++ b/codec/common/src/welsCodecTrace.cpp
@@ -83,6 +83,10 @@ void welsCodecTrace::CodecTrace (const int32_t iLevel, const char* Str_Format, v
   }
 }
 
+void welsCodecTrace::SetCodecInstance (void* pCodecInstance) {
+  m_sLogCtx.pCodecInstance = pCodecInstance;
+}
+
 void welsCodecTrace::SetTraceLevel (const int32_t iLevel) {
   if (iLevel >= 0)
     m_iTraceLevel	= iLevel;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -104,6 +104,7 @@ CWelsDecoder::CWelsDecoder (void)
 
   m_pWelsTrace	= new welsCodecTrace();
   if (m_pWelsTrace != NULL) {
+    m_pWelsTrace->SetCodecInstance (this);
     m_pWelsTrace->SetTraceLevel (WELS_LOG_ERROR);
 
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, "CWelsDecoder::CWelsDecoder() entry");

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -166,6 +166,7 @@ void CWelsH264SVCEncoder::InitEncoder (void) {
   if (m_pWelsTrace == NULL) {
     return;
   }
+  m_pWelsTrace->SetCodecInstance (this);
 }
 
 /* Interfaces override from ISVCEncoder */


### PR DESCRIPTION
to differentiate individual codecs in multi-party call.
(the same as pull request #1611, which cannot be auto-merged) 
see:
https://rbcommons.com/s/OpenH264/r/976/
