### PR TITLE
Make sure the random test bitrate is high enough

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -455,6 +455,8 @@ void GetValidEncParamBase (SEncParamBase* pEncParamBase) {
   pEncParamBase->iPicWidth = VALID_SIZE (pEncParamBase->iPicWidth);
   pEncParamBase->iPicHeight = VALID_SIZE (pEncParamBase->iPicHeight);
   pEncParamBase->iTargetBitrate = rand() + 1; //!=0
+  // Force a bitrate of at least w*h/50, otherwise we will only get skipped frames
+  pEncParamBase->iTargetBitrate = WELS_CLIP3 (pEncParamBase->iTargetBitrate, pEncParamBase->iPicWidth * pEncParamBase->iPicHeight / 50, 100000000);
   int32_t iLevelMaxBitrate = WelsCommon::g_ksLevelLimits[LEVEL_5_0 - 1].uiMaxBR * CpbBrNalFactor;
   if (pEncParamBase->iTargetBitrate > iLevelMaxBitrate)
     pEncParamBase->iTargetBitrate = iLevelMaxBitrate;


### PR DESCRIPTION
The ForceIntraFrame test will fail (giving up after 100 skipped
frames) if the bitrate is not set high enough.

Set the minimum bitrate to w*h/50, which is a very low value,
but which still should allow getting a non-skipped frame within
a few attempts.

Review at https://rbcommons.com/s/OpenH264/r/1002/.
