### PR TITLE
Avoid rebuilds if the version header hasn't changed

### DIFF
--- a/codec/common/generate_version.sh
+++ b/codec/common/generate_version.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-rm -f codec/common/inc/version.h
 git rev-list HEAD | sort > config.git-hash
 LOCALVER=`wc -l config.git-hash | awk '{print $1}'`
 if [ $LOCALVER \> 1 ] ; then
@@ -15,6 +14,13 @@ fi
 GIT_VERSION='"'$GIT_VERSION'"'
 rm -f config.git-hash
 
-cat codec/common/inc/version.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version.h
+cat codec/common/inc/version.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version.h.new
+if cmp codec/common/inc/version.h.new codec/common/inc/version.h > /dev/null 2>&1; then
+    # Identical to old version, don't touch it (to avoid unnecessary rebuilds)
+    rm codec/common/inc/version.h.new
+    echo "Keeping existing codec/common/inc/version.h"
+    exit 0
+fi
+mv codec/common/inc/version.h.new codec/common/inc/version.h
 
 echo "Generated codec/common/inc/version.h"


### PR DESCRIPTION
When generating the version header, don't overwrite it if the
new version is identical to the old one.

Review at https://rbcommons.com/s/OpenH264/r/1003/.
