### PR TITLE
Reset AU start pos to 0 after construct AU

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -1290,7 +1290,7 @@ void UninitialDqLayersContext (PWelsDecoderContext pCtx) {
 
 void ResetCurrentAccessUnit (PWelsDecoderContext pCtx) {
   PAccessUnit pCurAu = pCtx->pAccessUnitList;
-
+  pCurAu->uiStartPos            = 0;
   pCurAu->uiEndPos		= 0;
   pCurAu->bCompletedAuFlag	= false;
   if (pCurAu->uiActualUnitsNum > 0) {
@@ -1335,6 +1335,7 @@ void ForceResetCurrentAccessUnit (PAccessUnit pAu) {
   else
     pAu->uiAvailUnitsNum	= 0;
   pAu->uiActualUnitsNum	= 0;
+  pAu->uiStartPos       = 0;
   pAu->uiEndPos		= 0;
   pAu->bCompletedAuFlag	= false;
 }

--- a/codec/decoder/core/src/memmgr_nal_unit.cpp
+++ b/codec/decoder/core/src/memmgr_nal_unit.cpp
@@ -75,7 +75,8 @@ int32_t MemInitNalList (PAccessUnit* ppAu, const uint32_t kuiSize) {
   (*ppAu)->uiCountUnitsNum	= kuiSize;
   (*ppAu)->uiAvailUnitsNum	= 0;
   (*ppAu)->uiActualUnitsNum	= 0;
-  (*ppAu)->uiEndPos		    = 0;
+  (*ppAu)->uiStartPos           = 0;
+  (*ppAu)->uiEndPos		= 0;
   (*ppAu)->bCompletedAuFlag	= false;
 
   return 0;


### PR DESCRIPTION
Reset AU uiStartPos to 0 in ResetCurrentAccessUnit for svc
 Reset uiStartPos to 0 when init and forceReset
 review see:
 https://rbcommons.com/s/OpenH264/r/1030/
see also:
https://github.com/cisco/openh264/pull/1679
