### PR TITLE
Add void to the parameter list of WelsGetCodecVersion

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -534,7 +534,7 @@ void WelsDestroyDecoder (ISVCDecoder* pDecoder);
 /** @brief   Get codec version
  *  @return  The linked codec version
 */
-OpenH264Version WelsGetCodecVersion ();
+OpenH264Version WelsGetCodecVersion (void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When the header is used from C instead of C++, an empty parameter
list means that it can take any number of parameters, and can cause
warnings like "function declaration isn’t a prototype" with some
C compilers. Clarify this by explicitly adding void to this function.

Review at https://rbcommons.com/s/OpenH264/r/1037/.