### PR TITLE
Add a new public function WelsGetCodecVersionEx

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -532,9 +532,15 @@ long WelsCreateDecoder (ISVCDecoder** ppDecoder);
 void WelsDestroyDecoder (ISVCDecoder* pDecoder);
 
 /** @brief   Get codec version
+ *           Note, this function isn't ABI compatible between MSVC and Mingw.
  *  @return  The linked codec version
 */
 OpenH264Version WelsGetCodecVersion ();
+
+/** @brief   Get codec version
+ *  @param   pVersion  struct to fill in with the version
+*/
+void WelsGetCodecVersionEx (OpenH264Version *pVersion);
 
 #ifdef __cplusplus
 }

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -1231,4 +1231,8 @@ OpenH264Version WelsGetCodecVersion() {
   (void) g_strCodecVer; // Avoid warnings about unused static variables
   return g_stCodecVersion;
 }
+
+void WelsGetCodecVersionEx (OpenH264Version* pVersion) {
+  *pVersion = g_stCodecVersion;
+}
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/codec/encoder/plus/src/wels_enc_export.def
+++ b/codec/encoder/plus/src/wels_enc_export.def
@@ -2,3 +2,4 @@ EXPORTS
     WelsCreateSVCEncoder
     WelsDestroySVCEncoder
     WelsGetCodecVersion
+    WelsGetCodecVersionEx

--- a/openh264.def
+++ b/openh264.def
@@ -4,3 +4,4 @@ EXPORTS
 	WelsCreateSVCEncoder
 	WelsDestroySVCEncoder
 	WelsGetCodecVersion
+	WelsGetCodecVersionEx


### PR DESCRIPTION
This function doesn't return a struct, but fills in a struct via
a provided pointer.

The ABI of returning a struct is different between MSVC and mingw.

This allows using the same function from mingw, even though the DLL
has been built with MSVC.

Review at https://rbcommons.com/s/OpenH264/r/1039/.