### PR TITLE
Declare the g_strCodecVer variable as const

### DIFF
--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -5,7 +5,7 @@
 #include "codec_app_def.h"
 
 static const OpenH264Version g_stCodecVersion  = {1,3,0,0};
-static const char* g_strCodecVer  = "OpenH264 version:1.3.0.0";
+static const char* const g_strCodecVer  = "OpenH264 version:1.3.0.0";
 
 #define OPENH264_MAJOR (1)
 #define OPENH264_MINOR (3)

--- a/codec/build/generate_codec_ver.sh
+++ b/codec/build/generate_codec_ver.sh
@@ -28,11 +28,11 @@ echo "#include \"codec_app_def.h\"" >>codec_ver.h
 echo "" >>codec_ver.h
 
 echo "static const OpenH264Version g_stCodecVersion  = {$1};"|tr '.' ',' >>codec_ver.h
-echo "static const char* g_strCodecVer  = \"OpenH264 version:$1\";" >>codec_ver.h
+echo "static const char* const g_strCodecVer  = \"OpenH264 version:$1\";" >>codec_ver.h
 #if [ "$2"x = ""x ]; then
-#echo "static const char* g_strCodecBuildNum = \"OpenH264 revision:$revision\";" >> codec_ver.h
+#echo "static const char* const g_strCodecBuildNum = \"OpenH264 revision:$revision\";" >> codec_ver.h
 #else
-#echo "static const char* g_strCodecBuildNum = \"OpenH264 build:$2, OpenH264 revision:$revision\";" >> codec_ver.h
+#echo "static const char* const g_strCodecBuildNum = \"OpenH264 build:$2, OpenH264 revision:$revision\";" >> codec_ver.h
 #fi
 echo "" >>codec_ver.h
 

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -1228,7 +1228,6 @@ void WelsDestroySVCEncoder (ISVCEncoder* pEncoder) {
 }
 
 OpenH264Version WelsGetCodecVersion() {
-  (void) g_strCodecVer; // Avoid warnings about unused static variables
   return g_stCodecVersion;
 }
 


### PR DESCRIPTION
Previously, the variable itself wasn't const (which meant that
it could be set to point to another const string instead).

By declaring it as const, gcc doesn't warn about it being unused,
and we can get rid of a workaround.

Review at https://rbcommons.com/s/OpenH264/r/1041/.