### PR TITLE
Fix the reference frame used for spatial pic analysis after LTR frame loss

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -212,7 +212,7 @@ int32_t CWelsPreProcess::AnalyzeSpatialPic (sWelsEncCtx* pCtx, const int32_t kiD
   int32_t iRefTemporalIdx = (int32_t)g_kuiRefTemporalIdx[pSvcParam->iDecompStages][pCtx->iCodingIndex &
                             (pSvcParam->uiGopSize - 1)];
   if (pCtx->uiTemporalId == 0 && pCtx->pLtr[pCtx->uiDependencyId].bReceivedT0LostFlag)
-    iRefTemporalIdx = m_uiSpatialLayersInTemporal[kiDidx] + pCtx->pVaa->uiValidLongTermPicIdx;
+    iRefTemporalIdx = m_uiSpatialLayersInTemporal[kiDidx];
 
   SPicture* pCurPic = m_pSpatialPic[kiDidx][iCurTemporalIdx];
   bool bCalculateVar = (pSvcParam->iRCMode >= RC_BITRATE_MODE && pCtx->eSliceType == I_SLICE);


### PR DESCRIPTION
In unit tests for LTR frame loss (e.g.
EncodeDecodeTestBase/EncodeDecodeTestAPI.GetOptionLTR_Engine/0 and
a lot of other tests within EncodeDecodeTestBase/EncodeDecodeTestAPI),
the spatial pic analysis used an uninitialized picture as reference
picture, making the whole analysis step completely useless (and
later mode decisions are done on top of this, making the mode decisions
completely random).

When this uses an uninitialized picture, it uses picture index
iRefTemporalIdx = 4 (m_uiSpatialLayersInTemporal[kiDidx] +
pCtx->pVaa->uiValidLongTermPicIdx = 3 + 1), while nothing in
UpdateSpatialPictures ever actually moves any reference picture
into index slot 4 (only into index 3).

This fixes issue #1362 on github, making sure that the
EncodeDecodeTestBase/EncodeDecodeTestAPI tests run without
errors in valgrind.

Review at https://rbcommons.com/s/OpenH264/r/1044/.