### PR TITLE
bug fix for parseonly for complete frame judge

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -1801,6 +1801,7 @@ int32_t ConstructAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBufferI
         memcpy (pDstBuf, pNalBs, iNalLen);
         pDstBuf += iNalLen;
       }
+      pCtx->iTotalNumMbRec = 0;
     } else { //error
       pCtx->pParserBsInfo->uiOutBsTimeStamp = 0;
       pCtx->pParserBsInfo->iNalNum = 0;


### PR DESCRIPTION
reset iTotalNumMbRec if correct.
see:
https://rbcommons.com/s/OpenH264/r/1045/