### PR TITLE
Clarify the comment about ABI issues with WelsGetCodecVersion

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -532,7 +532,9 @@ long WelsCreateDecoder (ISVCDecoder** ppDecoder);
 void WelsDestroyDecoder (ISVCDecoder* pDecoder);
 
 /** @brief   Get codec version
- *           Note, this function isn't ABI compatible between MSVC and Mingw.
+ *           Note, old versions of Mingw (GCC < 4.7) are buggy and use an
+ *           incorrect/different ABI for calling this function, making it
+ *           incompatible with MSVC builds.
  *  @return  The linked codec version
 */
 OpenH264Version WelsGetCodecVersion (void);


### PR DESCRIPTION
The incompatibility between mingw and msvc is smaller than it seemed
at first; this turned out to only be a bug in older versions.

Review at https://rbcommons.com/s/OpenH264/r/1046/.