### PR TITLE
Public header warning fixes for the 1.3 release branch

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -534,7 +534,7 @@ void WelsDestroyDecoder (ISVCDecoder* pDecoder);
 /** @brief   Get codec version
  *  @return  The linked codec version
 */
-OpenH264Version WelsGetCodecVersion ();
+OpenH264Version WelsGetCodecVersion (void);
 
 #ifdef __cplusplus
 }

--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -5,7 +5,7 @@
 #include "codec_app_def.h"
 
 static const OpenH264Version g_stCodecVersion  = {1,3,0,0};
-static const char* g_strCodecVer  = "OpenH264 version:1.3.0.0";
+static const char* const g_strCodecVer  = "OpenH264 version:1.3.0.0";
 
 #define OPENH264_MAJOR (1)
 #define OPENH264_MINOR (3)

--- a/codec/build/generate_codec_ver.sh
+++ b/codec/build/generate_codec_ver.sh
@@ -28,11 +28,11 @@ echo "#include \"codec_app_def.h\"" >>codec_ver.h
 echo "" >>codec_ver.h
 
 echo "static const OpenH264Version g_stCodecVersion  = {$1};"|tr '.' ',' >>codec_ver.h
-echo "static const char* g_strCodecVer  = \"OpenH264 version:$1\";" >>codec_ver.h
+echo "static const char* const g_strCodecVer  = \"OpenH264 version:$1\";" >>codec_ver.h
 #if [ "$2"x = ""x ]; then
-#echo "static const char* g_strCodecBuildNum = \"OpenH264 revision:$revision\";" >> codec_ver.h
+#echo "static const char* const g_strCodecBuildNum = \"OpenH264 revision:$revision\";" >> codec_ver.h
 #else
-#echo "static const char* g_strCodecBuildNum = \"OpenH264 build:$2, OpenH264 revision:$revision\";" >> codec_ver.h
+#echo "static const char* const g_strCodecBuildNum = \"OpenH264 build:$2, OpenH264 revision:$revision\";" >> codec_ver.h
 #fi
 echo "" >>codec_ver.h
 


### PR DESCRIPTION
These fix warnings in third party code that use OpenH264 - they do not change the ABI. (Technically, the codec_ver.h change is an API change but it shouldn't matter, the way this (very new) symbol is used.)