### PR TITLE
Avoid a spurious valgrind warning in DecoderIntraPredictionTest.WelsDecoderI16x16LumaPredPlane_sse2

### DIFF
--- a/codec/decoder/core/x86/intra_pred.asm
+++ b/codec/decoder/core/x86/intra_pred.asm
@@ -259,6 +259,13 @@ WELS_EXTERN WelsDecoderI16x16LumaPredPlane_sse2
     pmullw  xmm7,   xmm6
     psubw   xmm7,   xmm0
 
+    ; Indicate that xmm2 is fully initialized. Its actual value doesn't
+    ; matter in SUMW_HORIZON below, but after being used in LOAD_COLUMN above,
+    ; valgrind thinks that xmm2 contains uninitalized data (if the columns outside
+    ; of the left are uninitialized, such as in DecUT_IntraPrediction), which taints
+    ; r2d below, even if actually isn't based on the uninitialized data.
+    pxor xmm2, xmm2
+
     SUMW_HORIZON   xmm7,xmm0,xmm2
     movd    r2d,   xmm7         ; V
     movsx   r2, r2w


### PR DESCRIPTION
valgrind thinks xmm2 is uninitialized - in fact it is, but
its value here doesn't really matter. Instead set it to a known value
before using it in SUMW_HORIZON.

Review at https://rbcommons.com/s/OpenH264/r/1055.