### PR TITLE
Avoid a warning about a variable set but not used

### DIFF
--- a/test/encoder/EncUT_ParameterSetStrategy.cpp
+++ b/test/encoder/EncUT_ParameterSetStrategy.cpp
@@ -117,6 +117,7 @@ TEST_F (ParameterSetStrategyTest, FindExistingSps) {
   iFoundId = FindExistingSps (&sParam2, bUseSubsetSps, iDlayerIndex, iDlayerCount, iCurSpsInUse,
                               m_pSpsArray, m_pSubsetArray);
   EXPECT_EQ (iFoundId, INVALID_ID);
+  (void) iRet; // Not using iRet at the moment
 }
 
 


### PR DESCRIPTION
The return values may be useful later, so instead of removing the
variable, just silence the warning.

This fixes a warning in builds with GCC.

Review at https://rbcommons.com/s/OpenH264/r/1067/.