### PR TITLE
Build using -Werror in travis unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifeq ($(BUILDTYPE), Release)
 CFLAGS += $(CFLAGS_OPT)
 USE_ASM = Yes
 else
-CFLAGS = $(CFLAGS_DEBUG)
+CFLAGS += $(CFLAGS_DEBUG)
 USE_ASM = No
 endif
 

--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -62,7 +62,10 @@
 #endif
 
 // This is for supporting older versions which do not have support for nullptr.
-#if defined(__clang__)
+#if defined(nullptr)
+# define GMP_HAVE_NULLPTR
+
+#elif defined(__clang__)
 # ifndef __has_extension
 # define __has_extension __has_feature
 # endif

--- a/run_Test.sh
+++ b/run_Test.sh
@@ -35,10 +35,10 @@ runInputParamCheck()
 #usage: runUnitTest
 runUnitTest()
 {
-  make -B ENABLE64BIT=Yes BUILDTYPE=Release all plugin test
-  make -B ENABLE64BIT=Yes BUILDTYPE=Debug   all plugin test
-  make -B ENABLE64BIT=No  BUILDTYPE=Release all plugin test
-  make -B ENABLE64BIT=No  BUILDTYPE=Debug   all plugin test
+  CFLAGS=-Werror make -B ENABLE64BIT=Yes BUILDTYPE=Release all plugin test
+  CFLAGS=-Werror make -B ENABLE64BIT=Yes BUILDTYPE=Debug   all plugin test
+  CFLAGS=-Werror make -B ENABLE64BIT=No  BUILDTYPE=Release all plugin test
+  CFLAGS=-Werror make -B ENABLE64BIT=No  BUILDTYPE=Debug   all plugin test
   return $?
 }
 #usage: runPrepareAndBinaryTest $TestBitStream

--- a/test/encoder/EncUT_MemoryZero.cpp
+++ b/test/encoder/EncUT_MemoryZero.cpp
@@ -30,6 +30,8 @@ TEST (SetMemZeroFunTest, WelsSetMemZero) {
   if (uiCpuFlag & WELS_CPU_SSE2) {
     sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZeroAligned64_sse2;	// confirmed_safe_unsafe_usage
   }
+#else
+  (void) uiCpuFlag; // Avoid warnings if no assembly is enabled
 #endif//X86_ASM
 
 #if defined(HAVE_NEON)

--- a/test/encoder/EncUT_ParameterSetStrategy.cpp
+++ b/test/encoder/EncUT_ParameterSetStrategy.cpp
@@ -117,6 +117,7 @@ TEST_F (ParameterSetStrategyTest, FindExistingSps) {
   iFoundId = FindExistingSps (&sParam2, bUseSubsetSps, iDlayerIndex, iDlayerCount, iCurSpsInUse,
                               m_pSpsArray, m_pSubsetArray);
   EXPECT_EQ (iFoundId, INVALID_ID);
+  (void) iRet; // Not using iRet at the moment
 }
 
 


### PR DESCRIPTION
This allows catching warnings that are introduced, that may only be
visible with some compilers.

Review at https://rbcommons.com/s/OpenH264/r/1069/.