### PR TITLE
Various fixes for the GeckoMediaPlugin wrapper

### DIFF
--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -603,6 +603,7 @@ class OpenH264VideoDecoder : public GMPVideoDecoder {
     param.eOutputColorFormat = videoFormatI420;
     param.uiTargetDqLayer = UCHAR_MAX;  // Default value
     param.eEcActiveIdc = ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE; // Error concealment on.
+    param.sVideoProperty.size = sizeof(param.sVideoProperty);
     param.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;
 
     if (decoder_->Initialize (&param)) {

--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -653,9 +653,15 @@ class OpenH264VideoDecoder : public GMPVideoDecoder {
   }
 
   virtual void Reset() {
+    if (callback_) {
+      callback_->ResetComplete ();
+    }
   }
 
   virtual void Drain() {
+    if (callback_) {
+      callback_->DrainComplete ();
+    }
   }
 
   virtual void DecodingComplete() {
@@ -713,11 +719,14 @@ class OpenH264VideoDecoder : public GMPVideoDecoder {
 
     // If we don't actually have data, just abort.
     if (!valid) {
+      GMPLOG (GL_ERROR, "No valid data decoded");
       Error (GMPDecodeErr);
       return;
     }
 
     if (decoded->iBufferStatus != 1) {
+      GMPLOG (GL_ERROR, "iBufferStatus=" << decoded->iBufferStatus);
+      callback_->InputDataExhausted();
       return;
     }
 


### PR DESCRIPTION
These fixes (except for the SVideoProperty inititalization, which doesn't seem to be used anywhere) are required to use the OpenH264 GMP plugin in Firefox as a decoder for the video playback engine.  The Firefox patches to implement this are here: https://bugzilla.mozilla.org/show_bug.cgi?id=1121258