### PR TITLE
Remove more generated files in "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ clean:
 ifeq (android,$(OS))
 clean: clean_Android
 endif
-	$(QUIET)rm -f $(OBJS) $(OBJS:.$(OBJ)=.d) $(OBJS:.$(OBJ)=.obj) $(LIBRARIES) $(BINARIES) *.lib *.a *.dylib *.dll *.so
+	$(QUIET)rm -f $(OBJS) $(OBJS:.$(OBJ)=.d) $(OBJS:.$(OBJ)=.obj) $(LIBRARIES) $(BINARIES) *.lib *.a *.dylib *.dll *.so *.exe *.pdb *.exp *.pc
 
 gmp-bootstrap:
 	if [ ! -d gmp-api ] ; then git clone https://github.com/mozilla/gmp-api gmp-api ; fi


### PR DESCRIPTION
Make sure to remove *.exe also, if cross-building from unix to
windows (and running "make clean" without specifying mingw as
target OS).

Review at https://rbcommons.com/s/OpenH264/r/1095/.