### PR TITLE
Update the .info file to match the gmpopenh264 version.

### DIFF
--- a/gmpopenh264.info
+++ b/gmpopenh264.info
@@ -1,4 +1,4 @@
 Name: gmpopenh264
 Description: GMP Plugin for OpenH264.
-Version: 1.0
+Version: 1.3
 APIs: encode-video[h264], decode-video[h264]


### PR DESCRIPTION

We need to start putting the correct version number in the gmpopenh264.info file on the branches for Firefox builds.