### PR TITLE
modify decoder flowchart for non vcl AU check

### DIFF
--- a/codec/decoder/core/inc/decoder_core.h
+++ b/codec/decoder/core/inc/decoder_core.h
@@ -153,6 +153,7 @@ void WelsDqLayerDecodeStart (PWelsDecoderContext pCtx, PNalUnit pCurNal, PSps pS
 
 int32_t WelsDecodeAccessUnitStart (PWelsDecoderContext pCtx);
 void WelsDecodeAccessUnitEnd (PWelsDecoderContext pCtx);
+void DecodeFinishUpdate (PWelsDecoderContext pCtx);
 
 void ForceResetCurrentAccessUnit (PAccessUnit pAu);
 void ForceClearCurrentNal (PAccessUnit pAu);

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -178,6 +178,7 @@ uint8_t* ParseNalHeader (PWelsDecoderContext pCtx, SNalUnitHeader* pNalUnitHeade
 
 
   switch (pNalUnitHeader->eNalUnitType) {
+  case NAL_UNIT_AU_DELIMITER:
   case NAL_UNIT_SEI:
     if (pCtx->pAccessUnitList->uiAvailUnitsNum > 0) {
       pCtx->pAccessUnitList->uiEndPos = pCtx->pAccessUnitList->uiAvailUnitsNum - 1;


### PR DESCRIPTION
1. Abstract a function DecodeFinishUpdate(). This function check sps/pps overwrite operations, and set new sequence flag.
It was originally inside ConstructAccessUnit() at the end part. 
Now it will be done it outside and after this function. With this modification, the check of overwrite info in slice header is redundant and is removed.
2. Do CheckAndFinishLastPic() for any packet in. This function was originally done only when VCL data is received. Actually it should be done for any data.
Inside this function, it makes no changs to VCL data.
For non VCL data, will reconstruct remaining data first, then do EC operations.
3. Enable AU_DELIMITER check in decoder

review see:
https://rbcommons.com/s/OpenH264/r/1098/