### PR TITLE
Don't overwrite the git-tracked version.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ SHAREDLIBVERSION=0
 include $(SRC_PATH)build/platform-$(OS).mk
 
 
-CFLAGS +=
+CFLAGS += -DGENERATED_VERSION_HEADER
 LDFLAGS +=
 
 ifeq (Yes, $(GCOV))

--- a/codec/common/generate_version.sh
+++ b/codec/common/generate_version.sh
@@ -14,13 +14,13 @@ fi
 GIT_VERSION='"'$GIT_VERSION'"'
 rm -f config.git-hash
 
-cat codec/common/inc/version.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version.h.new
-if cmp codec/common/inc/version.h.new codec/common/inc/version.h > /dev/null 2>&1; then
+cat codec/common/inc/version_gen.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version_gen.h.new
+if cmp codec/common/inc/version_gen.h.new codec/common/inc/version_gen.h > /dev/null 2>&1; then
     # Identical to old version, don't touch it (to avoid unnecessary rebuilds)
-    rm codec/common/inc/version.h.new
-    echo "Keeping existing codec/common/inc/version.h"
+    rm codec/common/inc/version_gen.h.new
+    echo "Keeping existing codec/common/inc/version_gen.h"
     exit 0
 fi
-mv codec/common/inc/version.h.new codec/common/inc/version.h
+mv codec/common/inc/version_gen.h.new codec/common/inc/version_gen.h
 
-echo "Generated codec/common/inc/version.h"
+echo "Generated codec/common/inc/version_gen.h"

--- a/codec/common/inc/.gitignore
+++ b/codec/common/inc/.gitignore
@@ -1,0 +1,1 @@
+version_gen.h

--- a/codec/common/inc/version.h
+++ b/codec/common/inc/version.h
@@ -1,6 +1,10 @@
 #ifndef VERSION_H
 #define VERSION_H
 
+#ifdef GENERATED_VERSION_HEADER
+#include "version_gen.h"
+#else
 #define VERSION_NUMBER "openh264 default: 1.4"
+#endif
 
 #endif // VERSION_H

--- a/codec/common/inc/version.h.template
+++ b/codec/common/inc/version.h.template
@@ -1,6 +1,0 @@
-#ifndef VERSION_H
-#define VERSION_H
-
-#define VERSION_NUMBER $FULL_VERSION
-
-#endif // VERSION_H

--- a/codec/common/inc/version_gen.h.template
+++ b/codec/common/inc/version_gen.h.template
@@ -1,0 +1,6 @@
+#ifndef VERSION_GEN_H
+#define VERSION_GEN_H
+
+#define VERSION_NUMBER $FULL_VERSION
+
+#endif // VERSION_GEN_H


### PR DESCRIPTION
When generating a new version of the header, that includes the
actual git hash, don't overwrite the file that is tracked by git.
Instead create a new file, and include this only if the build system
indicates that it exists (by setting a define). This allows the
untouched source tree to be built from within an IDE even if make
has not been run.

This reduces the hassle with a file that needs to be ignored in the
git configuration.

The downside is that the generated file isn't used if building
from within an IDE, if the header has been updated by calling make
before (since the IDE configuration doesn't know whether the user
actually has run make). Since users of the IDE might not build via
make in the command line at all (in the same source checkout at least),
this should not be an issue in practice. The previous way things worked,
the version hash (generated by make) when used in an IDE could actually
be outdated and misleading.

Review at https://rbcommons.com/s/OpenH264/r/1107/.