### PR TITLE
Set m_iPicResSize in PrepareOneSrcFrame

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -88,6 +88,10 @@ void EncoderInterfaceTest::PrepareOneSrcFrame() {
   pSrcPic->iPicWidth = pParamExt->iPicWidth;
   pSrcPic->iPicHeight = pParamExt->iPicHeight;
 
+  m_iWidth = pParamExt->iPicWidth;
+  m_iHeight = pParamExt->iPicHeight;
+  m_iPicResSize =  m_iWidth * m_iHeight * 3 >> 1;
+
   pYUV[0] = rand() % 256;
   for (int i = 1; i < m_iPicResSize; i++) {
     if ((i % 256) == 0)


### PR DESCRIPTION
If the calling test hasn't set m_iPicResSize, it is set to the
maximum frame size, which takes much longer to initialize than the
current actual frame size.

This reduces the runtime of EncoderInterfaceTest.SkipFrameCheck
in valgrind from 229 seconds to 8 seconds, and the total runtime
of all the test cases in EncoderInterfaceTest from 405 seconds
to 89 seconds.

Review at https://rbcommons.com/s/OpenH264/r/1109/.