### PR TITLE
Move DEFAULT REL into the x86_64 cases

### DIFF
--- a/codec/common/x86/asm_inc.asm
+++ b/codec/common/x86/asm_inc.asm
@@ -60,9 +60,9 @@
 ; Macros
 ;***********************************************************************
 
-DEFAULT REL
-
 %ifdef WIN64 ; Windows x64 ;************************************
+
+DEFAULT REL
 
 BITS 64
 
@@ -113,6 +113,8 @@ BITS 64
 %define  retrd          eax
 
 %elifdef UNIX64 ; Unix x64 ;************************************
+
+DEFAULT REL
 
 BITS 64
 


### PR DESCRIPTION
This fixes warnings when building for x86_32 using yasm, which says
the "DEFAULT REL" is ignored for non-64-bit targets.

Review at https://rbcommons.com/s/OpenH264/r/1110/.