### PR TITLE
Force armv7/neon within the arm assembly header file

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -12,9 +12,6 @@ ifeq ($(ARCH), arm)
     LDFLAGS += -march=armv7-a -Wl,--fix-cortex-a8
     APP_ABI = armeabi-v7a
   endif
-  ifeq (Yes, $(USE_ASM))
-    ASMFLAGS += -march=armv7-a -mfpu=neon
-  endif
 else ifeq ($(ARCH), arm64)
   APP_ABI = arm64-v8a
 else ifeq ($(ARCH), x86)

--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -50,6 +50,8 @@ mov pc, lr
 
 .section .note.GNU-stack,"",%progbits // Mark stack as non-executable
 .text
+.arch armv7-a
+.fpu neon
 
 .macro WELS_ASM_FUNC_BEGIN funcName
 .align 2


### PR DESCRIPTION
This avoids having to add extra compiler flags to be able to build
them.

Review at https://rbcommons.com/s/OpenH264/r/1112/.