### PR TITLE
Avoid declaring a new variable shadowing an existing one in the same function

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -3175,7 +3175,7 @@ TEST_F (EncodeDecodeTestAPI, SimulcastAVC) {
   int iIdx = 0;
 
   //create decoder
-  for (int iIdx = 0; iIdx < iSpatialLayerNum; iIdx++) {
+  for (iIdx = 0; iIdx < iSpatialLayerNum; iIdx++) {
     pBsBuf[iIdx] = static_cast<unsigned char*> (malloc (iWidth * iHeight * 3 * sizeof (unsigned char) / 2));
     aLen[iIdx] = 0;
 


### PR DESCRIPTION
All the following loops below assume that int iIdx already is declared.

Review at https://rbcommons.com/s/OpenH264/r/1122/.