### PR TITLE
Remove a stray srand

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -3463,7 +3463,6 @@ INSTANTIATE_TEST_CASE_P (EncodeDecodeTestAPIBase, EncodeTestAPI,
                          ::testing::ValuesIn (kOptionParamArray));
 
 TEST_P (EncodeTestAPI, SetEncOptionSize) {
-  srand(1002);
   EncodeOptionParam p = GetParam();
   FILE * pFile = NULL;
   if (p.sFileSave != NULL && strlen(p.sFileSave) > 0) {


### PR DESCRIPTION
The individual tests shouldn't reseed the random number generator
(other than for local debugging).

Hardcoding a specific random seed here leads to this test (and
all subsequent tests) not testing things randomly as intended, but
always testing the same parameters.

Review at https://rbcommons.com/s/OpenH264/r/1133/.