### PR TITLE
allow slice-level data come in for parse only

### DIFF
--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -366,11 +366,14 @@ typedef struct TagWelsDecoderContext {
 
 //for Parse only
   bool bParseOnly;
+  bool bFramePending;
+  int32_t iNalNum;
+  int32_t iNalLenInByte[MAX_NAL_UNITS_IN_LAYER];
   SSpsBsInfo sSpsBsInfo [MAX_SPS_COUNT];
   SSpsBsInfo sSubsetSpsBsInfo [MAX_PPS_COUNT];
   SPpsBsInfo sPpsBsInfo [MAX_PPS_COUNT];
   SParserBsInfo* pParserBsInfo;
-
+ 
   PPicture pPreviousDecodedPictureInDpb; //pointer to previously decoded picture in DPB for error concealment
   PGetIntraPredFunc pGetI16x16LumaPredFunc[7];		//h264_predict_copy_16x16;
   PGetIntraPredFunc pGetI4x4LumaPredFunc[14];		// h264_predict_4x4_t

--- a/codec/decoder/core/src/pic_queue.cpp
+++ b/codec/decoder/core/src/pic_queue.cpp
@@ -82,19 +82,25 @@ PPicture AllocPicture (PWelsDecoderContext pCtx, const int32_t kiPicWidth, const
   iLumaSize	= iPicWidth * iPicHeight;
   iChromaSize	= iPicChromaWidth * iPicChromaHeight;
 
-  pPic->pBuffer[0]	= static_cast<uint8_t*> (WelsMallocz (iLumaSize /* luma */
-                      + (iChromaSize << 1) /* Cb,Cr */, "_pic->buffer[0]"));
-  memset (pPic->pBuffer[0], 128, (iLumaSize + (iChromaSize << 1)));
+  if (pCtx->bParseOnly) {
+    pPic->pBuffer[0] = pPic->pBuffer[1] = pPic->pBuffer[2] = NULL;
+    pPic->pData[0] = pPic->pData[1] = pPic->pData[2] = NULL;
+    pPic->iLinesize[0] = iPicWidth;
+    pPic->iLinesize[1] = pPic->iLinesize[2] = iPicChromaWidth;
+  } else {
+    pPic->pBuffer[0]	= static_cast<uint8_t*> (WelsMallocz (iLumaSize /* luma */
+                        + (iChromaSize << 1) /* Cb,Cr */, "_pic->buffer[0]"));
+    memset (pPic->pBuffer[0], 128, (iLumaSize + (iChromaSize << 1)));
 
-  WELS_VERIFY_RETURN_PROC_IF (NULL, NULL == pPic->pBuffer[0], FreePicture (pPic));
-  pPic->iLinesize[0] = iPicWidth;
-  pPic->iLinesize[1] = pPic->iLinesize[2] = iPicChromaWidth;
-  pPic->pBuffer[1]	= pPic->pBuffer[0] + iLumaSize;
-  pPic->pBuffer[2]	= pPic->pBuffer[1] + iChromaSize;
-  pPic->pData[0]	= pPic->pBuffer[0] + (1 + pPic->iLinesize[0]) * PADDING_LENGTH;
-  pPic->pData[1]	= pPic->pBuffer[1] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[1]) * PADDING_LENGTH) >> 1);
-  pPic->pData[2]	= pPic->pBuffer[2] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[2]) * PADDING_LENGTH) >> 1);
-
+    WELS_VERIFY_RETURN_PROC_IF (NULL, NULL == pPic->pBuffer[0], FreePicture (pPic));
+    pPic->iLinesize[0] = iPicWidth;
+    pPic->iLinesize[1] = pPic->iLinesize[2] = iPicChromaWidth;
+    pPic->pBuffer[1]	= pPic->pBuffer[0] + iLumaSize;
+    pPic->pBuffer[2]	= pPic->pBuffer[1] + iChromaSize;
+    pPic->pData[0]	= pPic->pBuffer[0] + (1 + pPic->iLinesize[0]) * PADDING_LENGTH;
+    pPic->pData[1]	= pPic->pBuffer[1] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[1]) * PADDING_LENGTH) >> 1);
+    pPic->pData[2]	= pPic->pBuffer[2] + /*WELS_ALIGN*/ (((1 + pPic->iLinesize[2]) * PADDING_LENGTH) >> 1);
+  }
   pPic->iPlanes		= 3;	// yv12 in default
   pPic->iWidthInPixel	= kiPicWidth;
   pPic->iHeightInPixel = kiPicHeight;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -574,7 +574,10 @@ DECODING_STATE CWelsDecoder::DecodeParser (const unsigned char* kpSrc,
 
   m_pDecContext->iErrorCode = dsErrorFree; //initialize at the starting of AU decoding.
   m_pDecContext->eErrorConMethod = ERROR_CON_DISABLE; //add protection to disable EC here.
-  m_pDecContext->pParserBsInfo = pDstInfo;
+  if (!m_pDecContext->bFramePending) { //frame complete
+    m_pDecContext->pParserBsInfo->iNalNum = 0;
+    memset (m_pDecContext->pParserBsInfo->iNalLenInByte, 0, MAX_NAL_UNITS_IN_LAYER);
+  }
   pDstInfo->iNalNum = 0;
   pDstInfo->iSpsWidthInPixel = pDstInfo->iSpsHeightInPixel = 0;
   if (pDstInfo) {
@@ -584,6 +587,10 @@ DECODING_STATE CWelsDecoder::DecodeParser (const unsigned char* kpSrc,
     m_pDecContext->uiTimeStamp = 0;
   }
   WelsDecodeBs (m_pDecContext, kpSrc, kiSrcLen, NULL, NULL, pDstInfo);
+  if (!m_pDecContext->bFramePending && m_pDecContext->pParserBsInfo->iNalNum) {
+    memcpy (pDstInfo, m_pDecContext->pParserBsInfo, sizeof (SParserBsInfo));
+  }
+
   m_pDecContext->bInstantDecFlag = false; //reset no-delay flag
 
   return (DECODING_STATE) m_pDecContext->iErrorCode;

--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -2487,9 +2487,6 @@ class DecodeParseAPI : public ::testing::TestWithParam<EncodeDecodeFileParamBase
     int rv = decoder_->Initialize (&decParam);
     ASSERT_EQ (0, rv);
     memset (&BsInfo_, 0, sizeof (SParserBsInfo));
-    BsInfo_.pDstBuff = NULL;
-    BsInfo_.pDstBuff = new unsigned char [kiMaxBsSize];
-    ASSERT_TRUE (BsInfo_.pDstBuff != NULL);
     fYuv_ = fopen ("./res/CiscoVT2people_160x96_6fps.yuv", "rb");
     ASSERT_TRUE (fYuv_ != NULL);
     iWidth_ = kiWidth;
@@ -2497,10 +2494,6 @@ class DecodeParseAPI : public ::testing::TestWithParam<EncodeDecodeFileParamBase
   }
   void TearDown() {
     EncodeDecodeTestBase::TearDown();
-    if (BsInfo_.pDstBuff) {
-      delete[] BsInfo_.pDstBuff;
-      BsInfo_.pDstBuff = NULL;
-    }
     fclose (fYuv_);
   }
 
@@ -3449,7 +3442,7 @@ class EncodeTestAPI : public ::testing::TestWithParam<EncodeOptionParam>, public
     uint8_t* ptr = buf_.data();
     uint8_t uiVal = rand() % 256;
     for (int i = 0; i < frameSize; i++) {
-      ptr[i] = bAllRandom? (rand() % 256) :uiVal;
+      ptr[i] = bAllRandom ? (rand() % 256) : uiVal;
     }
     int rv = encoder_->EncodeFrame (&EncPic, &info);
     if (0 == iCheckTypeIndex)
@@ -3464,9 +3457,9 @@ INSTANTIATE_TEST_CASE_P (EncodeDecodeTestAPIBase, EncodeTestAPI,
 
 TEST_P (EncodeTestAPI, SetEncOptionSize) {
   EncodeOptionParam p = GetParam();
-  FILE * pFile = NULL;
-  if (p.sFileSave != NULL && strlen(p.sFileSave) > 0) {
-    pFile = fopen(p.sFileSave, "wb");
+  FILE* pFile = NULL;
+  if (p.sFileSave != NULL && strlen (p.sFileSave) > 0) {
+    pFile = fopen (p.sFileSave, "wb");
   }
   memset (&param_, 0, sizeof (SEncParamExt));
   encoder_->GetDefaultParams (&param_);
@@ -3502,16 +3495,16 @@ TEST_P (EncodeTestAPI, SetEncOptionSize) {
   unsigned char* pData[3] = { NULL };
   while (iIdx <= p.iNumframes) {
     EncodeOneFrameRandom (0, p.bAllRandom);
-    encToDecData(info, iLen);
-    if( pFile ) {
+    encToDecData (info, iLen);
+    if (pFile) {
       fwrite (info.sLayerInfo[0].pBsBuf, iLen, 1, pFile);
       fflush (pFile);
     }
-    memset(&dstBufInfo_, 0, sizeof(SBufferInfo));
-    if(iLen && p.bTestDecoder) {
-      rv = decoder_->DecodeFrameNoDelay(info.sLayerInfo[0].pBsBuf, iLen, pData, &dstBufInfo_);
-      ASSERT_EQ(rv, 0);
-      ASSERT_EQ(dstBufInfo_.iBufferStatus, 1);
+    memset (&dstBufInfo_, 0, sizeof (SBufferInfo));
+    if (iLen && p.bTestDecoder) {
+      rv = decoder_->DecodeFrameNoDelay (info.sLayerInfo[0].pBsBuf, iLen, pData, &dstBufInfo_);
+      ASSERT_EQ (rv, 0);
+      ASSERT_EQ (dstBufInfo_.iBufferStatus, 1);
     }
     int iLayer = 0;
     while (iLayer < info.iLayerNum) {
@@ -3529,7 +3522,7 @@ TEST_P (EncodeTestAPI, SetEncOptionSize) {
     }
     iIdx++;
   }
-  if( pFile ) {
+  if (pFile) {
     fclose (pFile);
   }
 }


### PR DESCRIPTION
allow slice-level inpout of one AU into parseonly decoder.
see:
https://rbcommons.com/s/OpenH264/r/1136/