### PR TITLE
Set pfMeCost to NULL when it isn't initialized

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2982,6 +2982,8 @@ void PreprocessSliceCoding (sWelsEncCtx* pCtx) {
       pFuncList->pfCalculateSatd = CalculateSatdCost;
       pFuncList->pfInterFineMd = WelsMdInterFinePartition;
     }
+  } else {
+    pFuncList->sSampleDealingFuncs.pfMeCost = NULL;
   }
 
   //to init at each frame will be needed when dealing with hybrid content (camera+screen)


### PR DESCRIPTION
This avoids using uninitialized data in the check for bSatdInMdFlag.

Review at https://rbcommons.com/s/OpenH264/r/1142/.