### PR TITLE
Avoid shadowing variables within functions

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -3398,7 +3398,7 @@ TEST_F (EncodeDecodeTestAPI, SimulcastAVC_SPS_PPS_LISTING) {
   int iIdx = 0;
 
   //create decoder
-  for (int iIdx = 0; iIdx < iSpatialLayerNum; iIdx++) {
+  for (iIdx = 0; iIdx < iSpatialLayerNum; iIdx++) {
     pBsBuf[iIdx] = static_cast<unsigned char*> (malloc (iWidth * iHeight * 3 * sizeof (unsigned char) / 2));
     EXPECT_TRUE (pBsBuf[iIdx] != NULL);
 


### PR DESCRIPTION
There is already a variable int iIdx declared just a few lines
above.

Review at https://rbcommons.com/s/OpenH264/r/1159/.