### PR TITLE
Don't downsample to anything smaller than 4x4 pixels

### DIFF
--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -429,11 +429,11 @@ bool JudgeNeedOfScaling (SWelsSvcCodingParam* pParam, Scaled_Picture* pScaledPic
     int32_t iInputHeightXDstWidth	= kiInputPicHeight * iCurDstWidth;
 
     if (iInputWidthXDstHeight > iInputHeightXDstWidth) {
-      pScaledPicture->iScaledWidth[iSpatialIdx] = iCurDstWidth;
+      pScaledPicture->iScaledWidth[iSpatialIdx] = WELS_MAX (iCurDstWidth, 4);
       pScaledPicture->iScaledHeight[iSpatialIdx] = WELS_MAX (iInputHeightXDstWidth / kiInputPicWidth, 4);
     } else {
       pScaledPicture->iScaledWidth[iSpatialIdx] = WELS_MAX (iInputWidthXDstHeight / kiInputPicHeight, 4);
-      pScaledPicture->iScaledHeight[iSpatialIdx] = iCurDstHeight;
+      pScaledPicture->iScaledHeight[iSpatialIdx] = WELS_MAX (iCurDstHeight, 4);
     }
   }
 


### PR DESCRIPTION
This makes for a chroma plane of 2x2. The SIMD versionf of generic
downscalers assume that the width and height is at least 2, since
it does an unconditional loop for the body of the image, and a
separate step for the last pixel and last row. The SIMD versions
assume that (width-1) and (height-1) are larger than zero.

This is the same fix as in e8cdbd2ea7, but making sure it applies
to both dimensions, that commit only fixed it for one of the
dimensions.

This fixes spurious crashes in EncodeDecodeTestAPI.SimulcastSVC.

Review at https://rbcommons.com/s/OpenH264/r/1168/.