### PR TITLE
Hook up the x86_32-only assembly as well

### DIFF
--- a/build/x86-common.mk
+++ b/build/x86-common.mk
@@ -17,6 +17,9 @@ ASMFLAGS_PLATFORM = -DX86_32
 endif
 ifeq ($(USE_ASM),Yes)
 CFLAGS += -DX86_ASM
+ifneq ($(ENABLE64BIT), Yes)
+CFLAGS += -DX86_32_ASM
+endif
 ASM_ARCH = x86
 endif
 ASM = nasm

--- a/codec/encoder/core/src/set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cavlc.cpp
@@ -274,9 +274,9 @@ void WelsWriteSliceEndSyn (SSlice* pSlice, bool bEntropyCodingModeFlag) {
 void InitCoeffFunc (SWelsFuncPtrList* pFuncList, const uint32_t uiCpuFlag, int32_t iEntropyCodingModeFlag) {
   pFuncList->pfCavlcParamCal = CavlcParamCal_c;
 
-#if defined(X86_ASM)
+#if defined(X86_32_ASM)
   if (uiCpuFlag & WELS_CPU_SSE2) {
-    // pFuncList->pfCavlcParamCal = CavlcParamCal_sse2;
+    pFuncList->pfCavlcParamCal = CavlcParamCal_sse2;
   }
 #endif
   if (iEntropyCodingModeFlag) {


### PR DESCRIPTION
This makes sure the code is at least somewhat tested. Ideally those
assembly functions should be upgraded to work in 64 bit mode as well,
but until then it's better to actually use them in the configurations
where they can be built.

Review at https://rbcommons.com/s/OpenH264/r/1177/.