### PR TITLE
Mention the "all" target before the extra dependencies for openh264.dll in msvc.mk

### DIFF
--- a/build/platform-msvc.mk
+++ b/build/platform-msvc.mk
@@ -3,4 +3,7 @@ LDFLAGS += user32.lib
 CFLAGS_OPT += -MT
 CFLAGS_DEBUG += -MTd -Gm
 
+# Make sure a plain "make" without a target still builds "all"
+all:
+
 $(LIBPREFIX)$(PROJECT_NAME).$(SHAREDLIBSUFFIXVER): openh264.res


### PR DESCRIPTION
This makes sure that all components get built, not only the DLL,
if doing a plain "make OS=msvc" after 2b33c749939.

Review at https://rbcommons.com/s/OpenH264/r/1185/.