### PR TITLE
Remove unnecessary double spaces and tabs in ifdef directives

### DIFF
--- a/codec/common/arm/copy_mb_neon.S
+++ b/codec/common/arm/copy_mb_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 .macro LOAD_ALIGNED_DATA_WITH_STRIDE arg0, arg1, arg2, arg3, arg4, arg5

--- a/codec/common/arm/intra_pred_common_neon.S
+++ b/codec/common/arm/intra_pred_common_neon.S
@@ -31,7 +31,7 @@
  */
 
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 WELS_ASM_FUNC_BEGIN WelsI16x16LumaPredV_neon

--- a/codec/common/arm/mc_neon.S
+++ b/codec/common/arm/mc_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 .macro AVERAGE_TWO_8BITS arg0, arg1, arg2

--- a/codec/common/arm64/copy_mb_aarch64_neon.S
+++ b/codec/common/arm64/copy_mb_aarch64_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 #include "arm_arch64_common_macro.S"
 
 .macro LOAD_ALIGNED_DATA_WITH_STRIDE arg0, arg1, arg2, arg3, arg4, arg5

--- a/codec/common/arm64/intra_pred_common_aarch64_neon.S
+++ b/codec/common/arm64/intra_pred_common_aarch64_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 #include "arm_arch64_common_macro.S"
 
 //for Luma 16x16

--- a/codec/common/src/crt_util_safe_x.cpp
+++ b/codec/common/src/crt_util_safe_x.cpp
@@ -56,9 +56,9 @@
 #include "macros.h"
 #include "crt_util_safe_x.h"	// Safe CRT routines like utils for cross platforms
 
-#if  defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(_MSC_VER)
 
-#if  defined(_MSC_VER) && (_MSC_VER>=1500)
+#if defined(_MSC_VER) && (_MSC_VER>=1500)
 
 int32_t WelsSnprintf (char* pBuffer,  int32_t iSizeOfBuffer, const char* kpFormat, ...) {
   va_list  pArgPtr;

--- a/codec/decoder/core/arm/intra_pred_neon.S
+++ b/codec/decoder/core/arm/intra_pred_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 //Global macro
 #include "arm_arch_common_macro.S"
 

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -2005,7 +2005,7 @@ void WelsBlockFuncInit (SBlockFunc*   pFunc,  int32_t iCpu) {
   pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_c;
   pFunc->pWelsBlockZero8x8Func          = WelsBlockZero8x8_c;
 
-#ifdef	HAVE_NEON
+#ifdef HAVE_NEON
   if (iCpu & WELS_CPU_NEON) {
     pFunc->pWelsSetNonZeroCountFunc		= WelsNonZeroCount_neon;
     pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_neon;
@@ -2013,7 +2013,7 @@ void WelsBlockFuncInit (SBlockFunc*   pFunc,  int32_t iCpu) {
   }
 #endif
 
-#ifdef	HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
   if (iCpu & WELS_CPU_NEON) {
     pFunc->pWelsSetNonZeroCountFunc		= WelsNonZeroCount_AArch64_neon;
     pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_AArch64_neon;

--- a/codec/encoder/core/arm/intra_pred_neon.S
+++ b/codec/encoder/core/arm/intra_pred_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 
 #include "arm_arch_common_macro.S"
 

--- a/codec/encoder/core/arm/memory_neon.S
+++ b/codec/encoder/core/arm/memory_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 

--- a/codec/encoder/core/arm/reconstruct_neon.S
+++ b/codec/encoder/core/arm/reconstruct_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 .macro LOAD_4x4_DATA_FOR_DCT arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7

--- a/codec/encoder/core/arm/svc_motion_estimation.S
+++ b/codec/encoder/core/arm/svc_motion_estimation.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 

--- a/codec/encoder/core/arm64/memory_aarch64_neon.S
+++ b/codec/encoder/core/arm64/memory_aarch64_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 #include "arm_arch64_common_macro.S"
 
 

--- a/codec/encoder/core/arm64/reconstruct_aarch64_neon.S
+++ b/codec/encoder/core/arm64/reconstruct_aarch64_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 #include "arm_arch64_common_macro.S"
 
 .macro ZERO_COUNT_IN_2_QUARWORD arg0, arg1, arg2

--- a/codec/encoder/core/arm64/svc_motion_estimation_aarch64_neon.S
+++ b/codec/encoder/core/arm64/svc_motion_estimation_aarch64_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 #include "arm_arch64_common_macro.S"
 
 WELS_ASM_AARCH64_FUNC_BEGIN SumOf8x8SingleBlock_AArch64_neon

--- a/codec/encoder/core/inc/decode_mb_aux.h
+++ b/codec/encoder/core/inc/decode_mb_aux.h
@@ -70,7 +70,7 @@ void WelsIDctRecI16x16Dc_sse2 (uint8_t* pRec, int32_t iStride, uint8_t* pPredict
                                int16_t* pDctDc);
 #endif//X86_ASM
 
-#ifdef	HAVE_NEON
+#ifdef HAVE_NEON
 void WelsDequantFour4x4_neon (int16_t* pDct, const uint16_t* kpMF);
 void WelsDequant4x4_neon (int16_t* pDct, const uint16_t* kpMF);
 void WelsDequantIHadamard4x4_neon (int16_t* pRes, const uint16_t kuiMF);
@@ -81,7 +81,7 @@ void WelsIDctRecI16x16Dc_neon (uint8_t* pRec, int32_t iStride, uint8_t* pPredict
                                int16_t* pDctDc);
 #endif
 
-#ifdef	HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 void WelsDequantFour4x4_AArch64_neon (int16_t* pDct, const uint16_t* kpMF);
 void WelsDequant4x4_AArch64_neon (int16_t* pDct, const uint16_t* kpMF);
 void WelsDequantIHadamard4x4_AArch64_neon (int16_t* pRes, const uint16_t kuiMF);

--- a/codec/encoder/core/inc/encode_mb_aux.h
+++ b/codec/encoder/core/inc/encode_mb_aux.h
@@ -105,7 +105,7 @@ void WelsQuantFour4x4Max_sse2 (int16_t* pDct, const int16_t* pFF, const int16_t*
 
 #endif
 
-#ifdef	HAVE_NEON
+#ifdef HAVE_NEON
 void WelsHadamardT4Dc_neon (int16_t* pLumaDc, int16_t* pDct);
 int32_t WelsHadamardQuant2x2_neon (int16_t* pRes, const int16_t kiFF, int16_t iMF, int16_t* pDct, int16_t* pBlock);
 int32_t WelsHadamardQuant2x2Skip_neon (int16_t* pRes, int16_t iFF,  int16_t iMF);
@@ -122,7 +122,7 @@ void WelsQuantFour4x4_neon (int16_t* pDct, const int16_t* pFF, const int16_t* pM
 void WelsQuantFour4x4Max_neon (int16_t* pDct, const int16_t* pFF, const int16_t* pMF, int16_t* pMax);
 #endif
 
-#ifdef	HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 void WelsHadamardT4Dc_AArch64_neon (int16_t* pLumaDc, int16_t* pDct);
 int32_t WelsHadamardQuant2x2_AArch64_neon (int16_t* pRes, const int16_t kiFF, int16_t iMF, int16_t* pDct, int16_t* pBlock);
 int32_t WelsHadamardQuant2x2Skip_AArch64_neon (int16_t* pRes, int16_t iFF,  int16_t iMF);

--- a/codec/encoder/core/src/deblocking.cpp
+++ b/codec/encoder/core/src/deblocking.cpp
@@ -776,12 +776,12 @@ void PerformDeblockingFilter (sWelsEncCtx* pEnc) {
 
 void WelsBlockFuncInit (PSetNoneZeroCountZeroFunc* pfSetNZCZero,  int32_t iCpu) {
   *pfSetNZCZero = WelsNonZeroCount_c;
-#ifdef	HAVE_NEON
+#ifdef HAVE_NEON
   if (iCpu & WELS_CPU_NEON) {
     *pfSetNZCZero = WelsNonZeroCount_neon;
   }
 #endif
-#ifdef	HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
   if (iCpu & WELS_CPU_NEON) {
     *pfSetNZCZero = WelsNonZeroCount_AArch64_neon;
   }

--- a/codec/encoder/core/src/encode_mb_aux.cpp
+++ b/codec/encoder/core/src/encode_mb_aux.cpp
@@ -449,13 +449,13 @@ int32_t WelsGetNoneZeroCount_c (int16_t* pLevel) {
   return (16 - iCnt);
 }
 
-#ifdef	HAVE_NEON
+#ifdef HAVE_NEON
 int32_t WelsHadamardQuant2x2Skip_neon (int16_t* pRes, int16_t iFF,  int16_t iMF) {
   int16_t iThreshold = ((1 << 16) - 1) / iMF - iFF;
   return WelsHadamardQuant2x2SkipKernel_neon (pRes, iThreshold);
 }
 #endif
-#ifdef	HAVE_NEON_AARCH64
+#ifdef HAVE_NEON_AARCH64
 int32_t WelsHadamardQuant2x2Skip_AArch64_neon (int16_t* pRes, int16_t iFF,  int16_t iMF) {
   int16_t iThreshold = ((1 << 16) - 1) / iMF - iFF;
   return WelsHadamardQuant2x2SkipKernel_AArch64_neon (pRes, iThreshold);

--- a/codec/processing/src/arm/down_sample_neon.S
+++ b/codec/processing/src/arm/down_sample_neon.S
@@ -30,7 +30,7 @@
  *
  */
 
-#ifdef  HAVE_NEON
+#ifdef HAVE_NEON
 #include "arm_arch_common_macro.S"
 
 


### PR DESCRIPTION
Review at https://rbcommons.com/s/OpenH264/r/1194/.