### PR TITLE
Add spaces in the struct in codec_ver.h

### DIFF
--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -4,7 +4,7 @@
 
 #include "codec_app_def.h"
 
-static const OpenH264Version g_stCodecVersion  = {1,4,0,0};
+static const OpenH264Version g_stCodecVersion  = {1, 4, 0, 0};
 static const char* const g_strCodecVer  = "OpenH264 version:1.4.0.0";
 
 #define OPENH264_MAJOR (1)

--- a/codec/build/generate_codec_ver.sh
+++ b/codec/build/generate_codec_ver.sh
@@ -36,7 +36,7 @@ revnr="${tmp%%.*}"
 tmp=${tmp#*.}
 resnr="${tmp%%.*}"
 
-echo "static const OpenH264Version g_stCodecVersion  = {$major,$minor,$revnr,$resnr};" >>codec_ver.h
+echo "static const OpenH264Version g_stCodecVersion  = {$major, $minor, $revnr, $resnr};" >>codec_ver.h
 echo "static const char* const g_strCodecVer  = \"OpenH264 version:$fullver\";" >>codec_ver.h
 #if [ "$2"x = ""x ]; then
 #echo "static const char* const g_strCodecBuildNum = \"OpenH264 revision:$revision\";" >> codec_ver.h


### PR DESCRIPTION
This avoids unnecessary changes if this file is run through astyle.

Review at https://rbcommons.com/s/OpenH264/r/1196/.