### PR TITLE
fixed no-support issues due to UNICODE macro for WP8

### DIFF
--- a/build/platform-msvc-wp.mk
+++ b/build/platform-msvc-wp.mk
@@ -2,7 +2,7 @@ ARCH = arm
 include $(SRC_PATH)build/msvc-common.mk
 CFLAGS_OPT += -MD
 CFLAGS_DEBUG += -MDd
-CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -DWINDOWS_PHONE
+CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -DWINDOWS_PHONE -DUNICODE
 # Ignore warnings about the main function prototype when building with -ZW
 CXXFLAGS += -ZW -wd4447
 LDFLAGS += -nodefaultlib:kernel32.lib -nodefaultlib:ole32.lib WindowsPhoneCore.lib


### PR DESCRIPTION
fixed no-support issues due to UNICODE macro for WP8
   ----issue error info listed as below:
        This API is not supported for this application type 
        - Api=CreateEventExA. Module=api-ms-win-core-synch-l1-2-0.dll. File=openh264.dll.
   ----and with UNICODE macro for CFLAGS, resolved this issue

review board:
     https://rbcommons.com/s/OpenH264/r/1201/