### PR TITLE
Add detection of AVX2

### DIFF
--- a/codec/common/inc/cpu_core.h
+++ b/codec/common/inc/cpu_core.h
@@ -67,6 +67,7 @@
 #define WELS_CPU_MOVBE		0x00008000	/* MOVBE instruction */
 #define WELS_CPU_AES		0x00010000	/* AES instruction extensions */
 #define WELS_CPU_FMA		0x00020000	/* AVX VEX FMA instruction sets */
+#define WELS_CPU_AVX2		0x00040000	/* AVX2 */
 
 #define WELS_CPU_CACHELINE_16    0x10000000    /* CacheLine Size 16 */
 #define WELS_CPU_CACHELINE_32    0x20000000    /* CacheLine Size 32 */

--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -136,6 +136,15 @@ uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
     uiCPU |= WELS_CPU_MOVBE;
   }
 
+  if (uiMaxCpuidLevel >= 7) {
+    uiFeatureC = 0;
+    WelsCPUId (7, &uiFeatureA, &uiFeatureB, &uiFeatureC, &uiFeatureD);
+    if ((uiCPU & WELS_CPU_AVX) && (uiFeatureB & 0x00000020)) {
+      /* AVX2 supported */
+      uiCPU |= WELS_CPU_AVX2;
+    }
+  }
+
   if (pNumberOfLogicProcessors != NULL) {
     if (uiCPU & WELS_CPU_HTT) {
       *pNumberOfLogicProcessors = (uiFeatureB & 0x00ff0000) >> 16; // feature bits: 23-16 on returned EBX


### PR DESCRIPTION
change list
1. add `define WELS_CPU_AVX2`  at `codec/common/cpu_core.h`
2. add detection of AVX2 by `WelsCPUId` at `codec/common/src/cpu.cpp:WelsCPUFeatureDetect(X86_ASM)`