### PR TITLE
Enable -Wc++11-compat-reserved-user-defined-literal when building with clang on linux

### DIFF
--- a/build/platform-linux.mk
+++ b/build/platform-linux.mk
@@ -15,3 +15,7 @@ ifeq ($(ASM_ARCH), arm)
 ASMFLAGS += -march=armv7-a -mfpu=neon
 endif
 
+ifeq ($(CXX), clang++)
+CXXFLAGS += -Wc++11-compat-reserved-user-defined-literal
+endif
+


### PR DESCRIPTION
This allows catching issues that causes the build to fail on MSVC 2015 RC,
without having to include such a configuration in travis.

Currently including an extra commit that should trigger a travis failure, to test that things behave as intended, I will remove that commit once the travis build shows that things work.