### PR TITLE
Remove endianness assumptions from DeblockingBsMarginalMBAvcbase

### DIFF
--- a/codec/decoder/core/src/deblocking.cpp
+++ b/codec/decoder/core/src/deblocking.cpp
@@ -279,8 +279,7 @@ void static inline DeblockingBSInsideMBNormal (PDqLayer pCurDqLayer, uint8_t nBS
 
 uint32_t DeblockingBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int32_t iNeighMb, int32_t iMbXy) {
   int32_t i, j;
-  uint32_t uiBSx4;
-  uint8_t* pBS = (uint8_t*) (&uiBSx4);
+  uint8_t pBS[4];
   const uint8_t* pBIdx      = &g_kuiTableBIdx[iEdge][0];
   const uint8_t* pBnIdx     = &g_kuiTableBIdx[iEdge][4];
   const uint8_t* pB8x8Idx   = &g_kuiTableB8x8Idx[iEdge][0];
@@ -349,7 +348,7 @@ uint32_t DeblockingBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int
     }
   }
 
-  return uiBSx4;
+  return pBS[0] | (pBS[1] << 8) | (pBS[2] << 16) | (pBS[3] << 24);
 }
 int32_t DeblockingAvailableNoInterlayer (PDqLayer pCurDqLayer, int32_t iFilterIdc) {
   int32_t iMbY = pCurDqLayer->iMbY;


### PR DESCRIPTION
This fixes a decoder unit test when running on big endian.

Review at https://rbcommons.com/s/OpenH264/r/1210/.