### PR TITLE
Skip binary comparison of LS_SVA_D.264 in the travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_script:
 env:
   - TASK=UnitTest;      TestParameter=""
   - TASK=BinaryCompare; TestParameter=BA_MW_D.264
-  - TASK=BinaryCompare; TestParameter=LS_SVA_D.264
   - TASK=BinaryCompare; TestParameter=CVPCMNL1_SVA_C.264
 
 matrix:


### PR DESCRIPTION
Currently, the binary comparison run of LS_SVA_D.264 many times exceed
the runtime limit of 50 minutes on travis, leading to lots of stray
errors in the tests, requiring a lot of reruns of tests.

Review at https://rbcommons.com/s/OpenH264/r/1212/.