### PR TITLE
Remove tabs fom copyright headers, def files, public header code examples and SIMD function pointer assignments

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -77,40 +77,40 @@ typedef unsigned char bool;
   *  //decoder declaration
   *  ISVCDecoder *pSvcDecoder;
   *  //input: encoded bitstream start position; should include start code prefix
-  *	 unsigned char *pBuf =...;
+  *  unsigned char *pBuf =...;
   *  //input: encoded bit stream length; should include the size of start code prefix
-  *	 int iSize =...;
+  *  int iSize =...;
   *  //output: [0~2] for Y,U,V buffer for Decoding only
-  *	 unsigned char *pData[3] =...;
+  *  unsigned char *pData[3] =...;
   *  //in-out: for Decoding only: declare and initialize the output buffer info, this should never co-exist with Parsing only
   *  SBufferInfo sDstBufInfo;
-  *	 memset(&sDstBufInfo, 0, sizeof(SBufferInfo));
+  *  memset(&sDstBufInfo, 0, sizeof(SBufferInfo));
   *  //in-out: for Parsing only: declare and initialize the output bitstream buffer info for parse only, this should never co-exist with Decoding only
   *  SParserBsInfo sDstParseInfo;
-  *      memset(&sDstParseInfo, 0, sizeof(SParserBsInfo));
-  *      sDstParseInfo.pDstBuff = new unsigned char[PARSE_SIZE]; //In Parsing only, allocate enough buffer to save transcoded bitstream for a frame
+  *  memset(&sDstParseInfo, 0, sizeof(SParserBsInfo));
+  *  sDstParseInfo.pDstBuff = new unsigned char[PARSE_SIZE]; //In Parsing only, allocate enough buffer to save transcoded bitstream for a frame
   *
   * @endcode
   *
-  *	Step 2:decoder creation
+  * Step 2:decoder creation
   * @code
   *  CreateDecoder(pSvcDecoder);
   * @endcode
   *
-  *	Step 3:declare required parameter, used to differentiate Decoding only and Parsing only
+  * Step 3:declare required parameter, used to differentiate Decoding only and Parsing only
   * @code
   *  SDecodingParam sDecParam = {0};
-  *	 sDecParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_AVC;
+  *  sDecParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_AVC;
   *  //for Parsing only, the assignment is mandatory
   *  sDecParam.bParseOnly = true;
   * @endcode
   *
-  *	Step 4:initialize the parameter and decoder context, allocate memory
+  * Step 4:initialize the parameter and decoder context, allocate memory
   * @code
   *  Initialize(&sDecParam);
   * @endcode
   *
-  *	Step 5:do actual decoding process in slice level;
+  * Step 5:do actual decoding process in slice level;
   *        this can be done in a loop until data ends
   * @code
   *  //for Decoding only
@@ -120,8 +120,8 @@ typedef unsigned char bool;
   *  //for Parsing only
   *  iRet = DecodeParser(pBuf, iSize, &sDstParseInfo);
   *  //decode failed
-  *	 If (iRet != 0){
-  *	     RequestIDR or something like that.
+  *  If (iRet != 0){
+  *      RequestIDR or something like that.
   *  }
   *  //for Decoding only, pData can be used for render.
   *  if (sDstBufInfo.iBufferStatus==1){
@@ -137,12 +137,12 @@ typedef unsigned char bool;
   *  judge iRet, sDstBufInfo.iBufferStatus ...
   * @endcode
   *
-  *	Step 6:uninitialize the decoder and memory free
+  * Step 6:uninitialize the decoder and memory free
   * @code
   *  Uninitialize();
   * @endcode
   *
-  *	Step 7:destroy the decoder
+  * Step 7:destroy the decoder
   * @code
   *  DestroyDecoder();
   * @endcode

--- a/codec/common/inc/WelsThreadLib.h
+++ b/codec/common/inc/WelsThreadLib.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	WelsThreadLib.h
+ * \file    WelsThreadLib.h
  *
- * \brief	Interfaces introduced in thread programming
+ * \brief   Interfaces introduced in thread programming
  *
- * \date	11/17/2009 Created
+ * \date    11/17/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/cpu.h
+++ b/codec/common/inc/cpu.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	cpu.h
+ * \file    cpu.h
  *
- * \brief	CPU feature compatibility detection
+ * \brief   CPU feature compatibility detection
  *
- * \date	04/29/2009 Created
+ * \date    04/29/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/cpu_core.h
+++ b/codec/common/inc/cpu_core.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	cpu_core.h
+ * \file    cpu_core.h
  *
- * \brief	cpu core feature detection
+ * \brief   cpu core feature detection
  *
- * \date	4/24/2009 Created
+ * \date    4/24/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/crt_util_safe_x.h
+++ b/codec/common/inc/crt_util_safe_x.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	crt_util_safe_x.h
+ * \file    crt_util_safe_x.h
  *
- * \brief	Safe CRT like util for cross platfroms support
+ * \brief   Safe CRT like util for cross platfroms support
  *
- * \date	06/04/2010 Created
+ * \date    06/04/2010 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/expand_pic.h
+++ b/codec/common/inc/expand_pic.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file		expand_pic.h
+ * \file    expand_pic.h
  *
- * \brief		Interface for expanding reconstructed picture to be used for reference
+ * \brief   Interface for expanding reconstructed picture to be used for reference
  *
- * \date		06/08/2009
+ * \date    06/08/2009
  *************************************************************************************
  */
 

--- a/codec/common/inc/golomb_common.h
+++ b/codec/common/inc/golomb_common.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	golomb_common.h
+ * \file    golomb_common.h
  *
- * \brief	Exponential Golomb entropy coding/decoding routine
+ * \brief   Exponential Golomb entropy coding/decoding routine
  *
- * \date	03/12/2015 Created
+ * \date    03/12/2015 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/intra_pred_common.h
+++ b/codec/common/inc/intra_pred_common.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	intra_pred_common.h
+ * \file    intra_pred_common.h
  *
- * \brief	interfaces for intra predictor about 16x16.
+ * \brief   interfaces for intra predictor about 16x16.
  *
- * \date	4/2/2014 Created
+ * \date    4/2/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/macros.h
+++ b/codec/common/inc/macros.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	macros.h
+ * \file    macros.h
  *
- * \brief	MACRO based tool utilization
+ * \brief   MACRO based tool utilization
  *
- * \date	3/13/2009 Created
+ * \date    3/13/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/measure_time.h
+++ b/codec/common/inc/measure_time.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	measure_time.h
+ * \file    measure_time.h
  *
- * \brief	time cost measure utilization
+ * \brief   time cost measure utilization
  *
- * \date	04/28/2009 Created
+ * \date    04/28/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/inc/utils.h
+++ b/codec/common/inc/utils.h
@@ -29,10 +29,10 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \brief	Tool kits for decoder
- *		( malloc, realloc, free, log output and PSNR calculation and so on )
+ * \brief   Tool kits for decoder
+ *          ( malloc, realloc, free, log output and PSNR calculation and so on )
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	WelsThreadLib.c
+ * \file    WelsThreadLib.c
  *
- * \brief	Interfaces introduced in thread programming
+ * \brief   Interfaces introduced in thread programming
  *
- * \date	11/17/2009 Created
+ * \date    11/17/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/copy_mb.cpp
+++ b/codec/common/src/copy_mb.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	copy_mb.cpp
+ * \file    copy_mb.cpp
  *
- * \brief	copy MB YUV data
+ * \brief   copy MB YUV data
  *
- * \date	2014.04.14 Created
+ * \date    2014.04.14 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	cpu.cpp
+ * \file    cpu.cpp
  *
- * \brief	CPU compatibility detection
+ * \brief   CPU compatibility detection
  *
- * \date	04/29/2009 Created
+ * \date    04/29/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/crt_util_safe_x.cpp
+++ b/codec/common/src/crt_util_safe_x.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	crt_utils_safe_x.cpp
+ * \file    crt_utils_safe_x.cpp
  *
- * \brief	common tool/function utilization
+ * \brief   common tool/function utilization
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/expand_pic.cpp
+++ b/codec/common/src/expand_pic.cpp
@@ -115,27 +115,27 @@ static inline void ExpandPictureChroma_c (uint8_t* pDst, const int32_t kiStride,
 }
 
 void InitExpandPictureFunc (SExpandPicFunc* pExpandPicFunc, const uint32_t kuiCPUFlag) {
-  pExpandPicFunc->pfExpandLumaPicture		= ExpandPictureLuma_c;
-  pExpandPicFunc->pfExpandChromaPicture[0]	= ExpandPictureChroma_c;
-  pExpandPicFunc->pfExpandChromaPicture[1]	= ExpandPictureChroma_c;
+  pExpandPicFunc->pfExpandLumaPicture        = ExpandPictureLuma_c;
+  pExpandPicFunc->pfExpandChromaPicture[0]   = ExpandPictureChroma_c;
+  pExpandPicFunc->pfExpandChromaPicture[1]   = ExpandPictureChroma_c;
 
 #if defined(X86_ASM)
   if ((kuiCPUFlag & WELS_CPU_SSE2) == WELS_CPU_SSE2) {
-    pExpandPicFunc->pfExpandLumaPicture	= ExpandPictureLuma_sse2;
+    pExpandPicFunc->pfExpandLumaPicture      = ExpandPictureLuma_sse2;
     pExpandPicFunc->pfExpandChromaPicture[0] = ExpandPictureChromaUnalign_sse2;
     pExpandPicFunc->pfExpandChromaPicture[1] = ExpandPictureChromaAlign_sse2;
   }
 #endif//X86_ASM
 #if defined(HAVE_NEON)
   if (kuiCPUFlag & WELS_CPU_NEON) {
-    pExpandPicFunc->pfExpandLumaPicture	= ExpandPictureLuma_neon;
+    pExpandPicFunc->pfExpandLumaPicture      = ExpandPictureLuma_neon;
     pExpandPicFunc->pfExpandChromaPicture[0] = ExpandPictureChroma_neon;
     pExpandPicFunc->pfExpandChromaPicture[1] = ExpandPictureChroma_neon;
   }
 #endif//HAVE_NEON
 #if defined(HAVE_NEON_AARCH64)
   if (kuiCPUFlag & WELS_CPU_NEON) {
-    pExpandPicFunc->pfExpandLumaPicture	= ExpandPictureLuma_AArch64_neon;
+    pExpandPicFunc->pfExpandLumaPicture      = ExpandPictureLuma_AArch64_neon;
     pExpandPicFunc->pfExpandChromaPicture[0] = ExpandPictureChroma_AArch64_neon;
     pExpandPicFunc->pfExpandChromaPicture[1] = ExpandPictureChroma_AArch64_neon;
   }

--- a/codec/common/src/intra_pred_common.cpp
+++ b/codec/common/src/intra_pred_common.cpp
@@ -29,13 +29,13 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	get_intra_predictor.c
+ * \file    get_intra_predictor.c
  *
- * \brief	implementation for get intra predictor about 16x16, 4x4, chroma.
+ * \brief   implementation for get intra predictor about 16x16, 4x4, chroma.
  *
- * \date	4/2/2009 Created
- *			9/14/2009 C level based optimization with high performance gained.
- *				[const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
+ * \date    4/2/2009 Created
+ *          9/14/2009 C level based optimization with high performance gained.
+ *              [const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
  *
  *************************************************************************************
  */

--- a/codec/common/src/mc.cpp
+++ b/codec/common/src/mc.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mc.c
+ * \file    mc.c
  *
- * \brief	Interfaces implementation for motion compensation
+ * \brief   Interfaces implementation for motion compensation
  *
- * \date	03/17/2009 Created
+ * \date    03/17/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/sad_common.cpp
+++ b/codec/common/src/sad_common.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	sample.c
+ * \file    sample.c
  *
- * \brief	compute SAD and SATD
+ * \brief   compute SAD and SATD
  *
- * \date	2009.06.02 Created
+ * \date    2009.06.02 Created
  *
  *************************************************************************************
  */

--- a/codec/common/src/utils.cpp
+++ b/codec/common/src/utils.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	utils.c
+ * \file    utils.c
  *
- * \brief	common tool/function utilization
+ * \brief   common tool/function utilization
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/console/dec/inc/d3d9_utils.h
+++ b/codec/console/dec/inc/d3d9_utils.h
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	d3d9_utils.h
+ * \file    d3d9_utils.h
  *
- * \brief	interface of d3d9 render module
+ * \brief   interface of d3d9 render module
  *
- * \date	Created 12/14/2010
+ * \date    Created 12/14/2010
  *
  * \description : 1. Rendering in Vista and upper : D3D9Ex method, support host memory / shared surface input
  *                2. Rendering in XP : D3D9 method w/o device lost handling, support host memory input

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -28,7 +28,7 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * h264dec.cpp:		Wels Decoder Console Implementation file
+ * h264dec.cpp:         Wels Decoder Console Implementation file
  */
 
 #if defined (_WIN32)

--- a/codec/decoder/core/inc/au_parser.h
+++ b/codec/decoder/core/inc/au_parser.h
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	au_parser.h
+ * \file    au_parser.h
  *
- * \brief	Interfaces introduced in Access Unit level based parser
+ * \brief   Interfaces introduced in Access Unit level based parser
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/cabac_decoder.h
+++ b/codec/decoder/core/inc/cabac_decoder.h
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	cabac_decoder.h
+ * \file    cabac_decoder.h
  *
- * \brief	Interfaces introduced for cabac decoder
+ * \brief   Interfaces introduced for cabac decoder
  *
- * \date	10/10/2014 Created
+ * \date    10/10/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/deblocking.h
+++ b/codec/decoder/core/inc/deblocking.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	deblocking.h
+ * \file    deblocking.h
  *
- * \brief	Interfaces introduced in frame deblocking filtering
+ * \brief   Interfaces introduced in frame deblocking filtering
  *
- * \date	05/14/2009 Created
+ * \date    05/14/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/dec_golomb.h
+++ b/codec/decoder/core/inc/dec_golomb.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	golomb.h
+ * \file    golomb.h
  *
- * \brief	Exponential Golomb entropy coding/decoding routine
+ * \brief   Exponential Golomb entropy coding/decoding routine
  *
- * \date	03/13/2009 Created
+ * \date    03/13/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/decoder.h
+++ b/codec/decoder/core/inc/decoder.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	decoder.h
+ * \file    decoder.h
  *
- * \brief	Interfaces introduced in decoder system architecture
+ * \brief   Interfaces introduced in decoder system architecture
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	decoder_context.h
+ * \file    decoder_context.h
  *
- * \brief	mainly interface introduced in Wels decoder side
+ * \brief   mainly interface introduced in Wels decoder side
  *
- * \date	3/4/2009 Created
+ * \date    3/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/error_code.h
+++ b/codec/decoder/core/inc/error_code.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	error_code.h
+ * \file    error_code.h
  *
- * \brief	Error codes used in Wels decoder side
+ * \brief   Error codes used in Wels decoder side
  *
- * \date	3/4/2009 Created
+ * \date    3/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/error_concealment.h
+++ b/codec/decoder/core/inc/error_concealment.h
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	error_concealment.h
+ * \file    error_concealment.h
  *
- * \brief	Interfaces introduced for error concealment
+ * \brief   Interfaces introduced for error concealment
  *
- * \date	04/14/2014 Created
+ * \date    04/14/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/fmo.h
+++ b/codec/decoder/core/inc/fmo.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	fmo.h
+ * \file    fmo.h
  *
- * \brief	Flexible Macroblock Ordering implementation
+ * \brief   Flexible Macroblock Ordering implementation
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/get_intra_predictor.h
+++ b/codec/decoder/core/inc/get_intra_predictor.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	get_intra_predictor.h
+ * \file    get_intra_predictor.h
  *
- * \brief	interfaces for get intra predictor about 16x16, 4x4, chroma.
+ * \brief   interfaces for get intra predictor about 16x16, 4x4, chroma.
  *
- * \date	4/2/2009 Created
+ * \date    4/2/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/manage_dec_ref.h
+++ b/codec/decoder/core/inc/manage_dec_ref.h
@@ -29,7 +29,7 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- *  \file	manage_dec_ref.h
+ *  \file   manage_dec_ref.h
  *
  *  Abstract
  *      Interface for managing reference picture

--- a/codec/decoder/core/inc/mv_pred.h
+++ b/codec/decoder/core/inc/mv_pred.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mv_pred.h
+ * \file    mv_pred.h
  *
- * \brief	Get MV predictor and update motion vector of mb cache
+ * \brief   Get MV predictor and update motion vector of mb cache
  *
- * \date	05/22/2009 Created
+ * \date    05/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/parse_mb_syn_cabac.h
+++ b/codec/decoder/core/inc/parse_mb_syn_cabac.h
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	parse_mb_syn_cabac.h
+ * \file    parse_mb_syn_cabac.h
  *
- * \brief	cabac parse for syntax elements
+ * \brief   cabac parse for syntax elements
  *
- * \date	10/10/2014 Created
+ * \date    10/10/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/parse_mb_syn_cavlc.h
+++ b/codec/decoder/core/inc/parse_mb_syn_cavlc.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	parse_mb_syn_cavlc.h
+ * \file    parse_mb_syn_cavlc.h
  *
- * \brief	Parsing all syntax elements of mb and decoding residual with cavlc
+ * \brief   Parsing all syntax elements of mb and decoding residual with cavlc
  *
- * \date	03/17/2009 Created
+ * \date    03/17/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/inc/rec_mb.h
+++ b/codec/decoder/core/inc/rec_mb.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	rec_mb.h
+ * \file    rec_mb.h
  *
- * \brief	interfaces for all macroblock decoding process after mb syntax parsing and residual decoding with cavlc.
+ * \brief   interfaces for all macroblock decoding process after mb syntax parsing and residual decoding with cavlc.
  *
- * \date	3/4/2009 Created
+ * \date    3/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	au_parser.c
+ * \file    au_parser.c
  *
- * \brief	Interfaces introduced in Access Unit level based parser
+ * \brief   Interfaces introduced in Access Unit level based parser
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/bit_stream.cpp
+++ b/codec/decoder/core/src/bit_stream.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	bit_stream.cpp
+ * \file    bit_stream.cpp
  *
- * \brief	Reading / writing bit-stream
+ * \brief   Reading / writing bit-stream
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/cabac_decoder.cpp
+++ b/codec/decoder/core/src/cabac_decoder.cpp
@@ -28,7 +28,7 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- *	cabac_decoder.cpp:	deals with cabac state transition and related functions
+ *      cabac_decoder.cpp:      deals with cabac state transition and related functions
  */
 #include "cabac_decoder.h"
 namespace WelsDec {

--- a/codec/decoder/core/src/deblocking.cpp
+++ b/codec/decoder/core/src/deblocking.cpp
@@ -941,59 +941,59 @@ void WelsDeblockingFilterSlice (PWelsDecoderContext pCtx, PDeblockingFilterMbFun
  */
 
 void  DeblockingInit (SDeblockingFunc*  pFunc,  int32_t iCpu) {
-  pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_c;
-  pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_c;
-  pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_c;
-  pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_c;
+  pFunc->pfLumaDeblockingLT4Ver     = DeblockLumaLt4V_c;
+  pFunc->pfLumaDeblockingEQ4Ver     = DeblockLumaEq4V_c;
+  pFunc->pfLumaDeblockingLT4Hor     = DeblockLumaLt4H_c;
+  pFunc->pfLumaDeblockingEQ4Hor     = DeblockLumaEq4H_c;
 
-  pFunc->pfChromaDeblockingLT4Ver	    = DeblockChromaLt4V_c;
-  pFunc->pfChromaDeblockingEQ4Ver	    = DeblockChromaEq4V_c;
-  pFunc->pfChromaDeblockingLT4Hor	    = DeblockChromaLt4H_c;
-  pFunc->pfChromaDeblockingEQ4Hor	    = DeblockChromaEq4H_c;
+  pFunc->pfChromaDeblockingLT4Ver   = DeblockChromaLt4V_c;
+  pFunc->pfChromaDeblockingEQ4Ver   = DeblockChromaEq4V_c;
+  pFunc->pfChromaDeblockingLT4Hor   = DeblockChromaLt4H_c;
+  pFunc->pfChromaDeblockingEQ4Hor   = DeblockChromaEq4H_c;
 
-  pFunc->pfChromaDeblockingLT4Ver2	    = DeblockChromaLt4V2_c;
-  pFunc->pfChromaDeblockingEQ4Ver2	    = DeblockChromaEq4V2_c;
-  pFunc->pfChromaDeblockingLT4Hor2	    = DeblockChromaLt4H2_c;
-  pFunc->pfChromaDeblockingEQ4Hor2	    = DeblockChromaEq4H2_c;
+  pFunc->pfChromaDeblockingLT4Ver2  = DeblockChromaLt4V2_c;
+  pFunc->pfChromaDeblockingEQ4Ver2  = DeblockChromaEq4V2_c;
+  pFunc->pfChromaDeblockingLT4Hor2  = DeblockChromaLt4H2_c;
+  pFunc->pfChromaDeblockingEQ4Hor2  = DeblockChromaEq4H2_c;
 
 #ifdef X86_ASM
   if (iCpu & WELS_CPU_SSSE3) {
-    pFunc->pfLumaDeblockingLT4Ver	= DeblockLumaLt4V_ssse3;
-    pFunc->pfLumaDeblockingEQ4Ver	= DeblockLumaEq4V_ssse3;
-    pFunc->pfLumaDeblockingLT4Hor       = DeblockLumaLt4H_ssse3;
-    pFunc->pfLumaDeblockingEQ4Hor       = DeblockLumaEq4H_ssse3;
-    pFunc->pfChromaDeblockingLT4Ver	= DeblockChromaLt4V_ssse3;
-    pFunc->pfChromaDeblockingEQ4Ver	= DeblockChromaEq4V_ssse3;
-    pFunc->pfChromaDeblockingLT4Hor	= DeblockChromaLt4H_ssse3;
-    pFunc->pfChromaDeblockingEQ4Hor	= DeblockChromaEq4H_ssse3;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_ssse3;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_ssse3;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_ssse3;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_ssse3;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_ssse3;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_ssse3;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_ssse3;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_ssse3;
   }
 #endif
 
 #if defined(HAVE_NEON)
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_neon;
-    pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_neon;
-    pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_neon;
-    pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_neon;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_neon;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_neon;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_neon;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_neon;
 
-    pFunc->pfChromaDeblockingLT4Ver     = DeblockChromaLt4V_neon;
-    pFunc->pfChromaDeblockingEQ4Ver     = DeblockChromaEq4V_neon;
-    pFunc->pfChromaDeblockingLT4Hor     = DeblockChromaLt4H_neon;
-    pFunc->pfChromaDeblockingEQ4Hor      = DeblockChromaEq4H_neon;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_neon;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_neon;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_neon;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_neon;
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_AArch64_neon;
-    pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_AArch64_neon;
-    pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_AArch64_neon;
-    pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_AArch64_neon;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_AArch64_neon;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_AArch64_neon;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_AArch64_neon;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_AArch64_neon;
 
-    pFunc->pfChromaDeblockingLT4Ver     = DeblockChromaLt4V_AArch64_neon;
-    pFunc->pfChromaDeblockingEQ4Ver     = DeblockChromaEq4V_AArch64_neon;
-    pFunc->pfChromaDeblockingLT4Hor     = DeblockChromaLt4H_AArch64_neon;
-    pFunc->pfChromaDeblockingEQ4Hor      = DeblockChromaEq4H_AArch64_neon;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_AArch64_neon;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_AArch64_neon;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_AArch64_neon;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_AArch64_neon;
   }
 #endif
 }

--- a/codec/decoder/core/src/deblocking.cpp
+++ b/codec/decoder/core/src/deblocking.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	deblocking.c
+ * \file    deblocking.c
  *
- * \brief	Interfaces introduced in frame deblocking filtering
+ * \brief   Interfaces introduced in frame deblocking filtering
  *
- * \date	08/02/2010
+ * \date    08/02/2010
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -2001,31 +2001,31 @@ int32_t WelsDecodeMbCavlcPSlice (PWelsDecoderContext pCtx, PNalUnit pNalCur, uin
 }
 
 void WelsBlockFuncInit (SBlockFunc*   pFunc,  int32_t iCpu) {
-  pFunc->pWelsSetNonZeroCountFunc	    = WelsNonZeroCount_c;
-  pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_c;
-  pFunc->pWelsBlockZero8x8Func          = WelsBlockZero8x8_c;
+  pFunc->pWelsSetNonZeroCountFunc   = WelsNonZeroCount_c;
+  pFunc->pWelsBlockZero16x16Func    = WelsBlockZero16x16_c;
+  pFunc->pWelsBlockZero8x8Func      = WelsBlockZero8x8_c;
 
 #ifdef HAVE_NEON
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pWelsSetNonZeroCountFunc		= WelsNonZeroCount_neon;
-    pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_neon;
-    pFunc->pWelsBlockZero8x8Func	    = WelsBlockZero8x8_neon;
+    pFunc->pWelsSetNonZeroCountFunc = WelsNonZeroCount_neon;
+    pFunc->pWelsBlockZero16x16Func  = WelsBlockZero16x16_neon;
+    pFunc->pWelsBlockZero8x8Func    = WelsBlockZero8x8_neon;
   }
 #endif
 
 #ifdef HAVE_NEON_AARCH64
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pWelsSetNonZeroCountFunc		= WelsNonZeroCount_AArch64_neon;
-    pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_AArch64_neon;
-    pFunc->pWelsBlockZero8x8Func	    = WelsBlockZero8x8_AArch64_neon;
+    pFunc->pWelsSetNonZeroCountFunc = WelsNonZeroCount_AArch64_neon;
+    pFunc->pWelsBlockZero16x16Func  = WelsBlockZero16x16_AArch64_neon;
+    pFunc->pWelsBlockZero8x8Func    = WelsBlockZero8x8_AArch64_neon;
   }
 #endif
 
 #if defined(X86_ASM)
   if (iCpu & WELS_CPU_SSE2) {
-    pFunc->pWelsSetNonZeroCountFunc		= WelsNonZeroCount_sse2;
-    pFunc->pWelsBlockZero16x16Func	    = WelsBlockZero16x16_sse2;
-    pFunc->pWelsBlockZero8x8Func	    = WelsBlockZero8x8_sse2;
+    pFunc->pWelsSetNonZeroCountFunc = WelsNonZeroCount_sse2;
+    pFunc->pWelsBlockZero16x16Func  = WelsBlockZero16x16_sse2;
+    pFunc->pWelsBlockZero8x8Func    = WelsBlockZero8x8_sse2;
   }
 #endif
 

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -885,13 +885,13 @@ void AssignFuncPointerForRec (PWelsDecoderContext pCtx) {
   pCtx->pGetIChromaPredFunc[C_PRED_DC_T  ] = WelsIChromaPredDcTop_c;
   pCtx->pGetIChromaPredFunc[C_PRED_DC_128] = WelsIChromaPredDcNA_c;
 
-  pCtx->pIdctResAddPredFunc	= IdctResAddPred_c;
+  pCtx->pIdctResAddPredFunc     = IdctResAddPred_c;
 
-  pCtx->pIdctResAddPredFunc8x8 = IdctResAddPred8x8_c;
+  pCtx->pIdctResAddPredFunc8x8  = IdctResAddPred8x8_c;
 
 #if defined(HAVE_NEON)
   if (pCtx->uiCpuFlag & WELS_CPU_NEON) {
-    pCtx->pIdctResAddPredFunc	= IdctResAddPred_neon;
+    pCtx->pIdctResAddPredFunc   = IdctResAddPred_neon;
 
     pCtx->pGetI16x16LumaPredFunc[I16_PRED_DC] = WelsDecoderI16x16LumaPredDc_neon;
     pCtx->pGetI16x16LumaPredFunc[I16_PRED_P]  = WelsDecoderI16x16LumaPredPlane_neon;
@@ -916,7 +916,7 @@ void AssignFuncPointerForRec (PWelsDecoderContext pCtx) {
 
 #if defined(HAVE_NEON_AARCH64)
   if (pCtx->uiCpuFlag & WELS_CPU_NEON) {
-    pCtx->pIdctResAddPredFunc	= IdctResAddPred_AArch64_neon;
+    pCtx->pIdctResAddPredFunc   = IdctResAddPred_AArch64_neon;
 
     pCtx->pGetI16x16LumaPredFunc[I16_PRED_DC] = WelsDecoderI16x16LumaPredDc_AArch64_neon;
     pCtx->pGetI16x16LumaPredFunc[I16_PRED_P]  = WelsDecoderI16x16LumaPredPlane_AArch64_neon;
@@ -946,7 +946,7 @@ void AssignFuncPointerForRec (PWelsDecoderContext pCtx) {
 
 #if defined(X86_ASM)
   if (pCtx->uiCpuFlag & WELS_CPU_MMXEXT) {
-    pCtx->pIdctResAddPredFunc	= IdctResAddPred_mmx;
+    pCtx->pIdctResAddPredFunc   = IdctResAddPred_mmx;
 
     ///////mmx code opt---
     pCtx->pGetIChromaPredFunc[C_PRED_H]      = WelsDecoderIChromaPredH_mmx;

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	decoder.c
+ * \file    decoder.c
  *
- * \brief	Interfaces implementation introduced in decoder system architecture
+ * \brief   Interfaces implementation introduced in decoder system architecture
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -28,7 +28,7 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- *	decoder_core.c:	Wels decoder framework core implementation
+ *      decoder_core.c: Wels decoder framework core implementation
  */
 
 #include "decoder_core.h"

--- a/codec/decoder/core/src/error_concealment.cpp
+++ b/codec/decoder/core/src/error_concealment.cpp
@@ -64,15 +64,15 @@ void InitErrorCon (PWelsDecoderContext pCtx) {
 
 #if defined(HAVE_NEON)
     if (pCtx->uiCpuFlag & WELS_CPU_NEON) {
-      pCtx->sCopyFunc.pCopyLumaFunc		= WelsCopy16x16_neon; //aligned
-      pCtx->sCopyFunc.pCopyChromaFunc		= WelsCopy8x8_neon; //aligned
+      pCtx->sCopyFunc.pCopyLumaFunc     = WelsCopy16x16_neon; //aligned
+      pCtx->sCopyFunc.pCopyChromaFunc   = WelsCopy8x8_neon; //aligned
     }
 #endif //HAVE_NEON
 
 #if defined(HAVE_NEON_AARCH64)
     if (pCtx->uiCpuFlag & WELS_CPU_NEON) {
-      pCtx->sCopyFunc.pCopyLumaFunc		= WelsCopy16x16_AArch64_neon; //aligned
-      pCtx->sCopyFunc.pCopyChromaFunc		= WelsCopy8x8_AArch64_neon; //aligned
+      pCtx->sCopyFunc.pCopyLumaFunc     = WelsCopy16x16_AArch64_neon; //aligned
+      pCtx->sCopyFunc.pCopyChromaFunc   = WelsCopy8x8_AArch64_neon; //aligned
     }
 #endif //HAVE_NEON_AARCH64
   } //TODO add more methods here

--- a/codec/decoder/core/src/error_concealment.cpp
+++ b/codec/decoder/core/src/error_concealment.cpp
@@ -28,7 +28,7 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- *	error_concealment.cpp:	Wels decoder error concealment implementation
+ *      error_concealment.cpp:  Wels decoder error concealment implementation
  */
 
 #include "error_code.h"

--- a/codec/decoder/core/src/fmo.cpp
+++ b/codec/decoder/core/src/fmo.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	fmo.c
+ * \file    fmo.c
  *
- * \brief	Flexible Macroblock Ordering implementation
+ * \brief   Flexible Macroblock Ordering implementation
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/get_intra_predictor.cpp
+++ b/codec/decoder/core/src/get_intra_predictor.cpp
@@ -29,13 +29,13 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	get_intra_predictor.c
+ * \file    get_intra_predictor.c
  *
- * \brief	implementation for get intra predictor about 16x16, 4x4, chroma.
+ * \brief   implementation for get intra predictor about 16x16, 4x4, chroma.
  *
- * \date	4/2/2009 Created
- *			9/14/2009 C level based optimization with high performance gained.
- *				[const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
+ * \date    4/2/2009 Created
+ *          9/14/2009 C level based optimization with high performance gained.
+ *              [const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/mv_pred.cpp
+++ b/codec/decoder/core/src/mv_pred.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mv_pred.c
+ * \file    mv_pred.c
  *
- * \brief	Get MV predictor and update motion vector of mb cache
+ * \brief   Get MV predictor and update motion vector of mb cache
  *
- * \date	05/22/2009 Created
+ * \date    05/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/parse_mb_syn_cabac.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cabac.cpp
@@ -28,7 +28,7 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- *	parse_mb_syn_cabac.cpp:	cabac parse for syntax elements
+ *      parse_mb_syn_cabac.cpp: cabac parse for syntax elements
  */
 #include "parse_mb_syn_cabac.h"
 #include "mv_pred.h"

--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	parse_mb_syn_cavlc.c
+ * \file    parse_mb_syn_cavlc.c
  *
- * \brief	Interfaces implementation for parsing the syntax of MB
+ * \brief   Interfaces implementation for parsing the syntax of MB
  *
- * \date	03/17/2009 Created
+ * \date    03/17/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/pic_queue.cpp
+++ b/codec/decoder/core/src/pic_queue.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	pic_queue.c
+ * \file    pic_queue.c
  *
- * \brief	Recycled piture queue implementation
+ * \brief   Recycled piture queue implementation
  *
- * \date	03/13/2009 Created
+ * \date    03/13/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/decoder/core/src/rec_mb.cpp
+++ b/codec/decoder/core/src/rec_mb.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	rec_mb.c
+ * \file    rec_mb.c
  *
- * \brief	implementation for all macroblock decoding process after mb syntax parsing and residual decoding with cavlc.
+ * \brief   implementation for all macroblock decoding process after mb syntax parsing and residual decoding with cavlc.
  *
- * \date	3/18/2009 Created
+ * \date    3/18/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/as264_common.h
+++ b/codec/encoder/core/inc/as264_common.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	common.h
+ * \file    common.h
  *
- * \brief	common flag definitions
+ * \brief   common flag definitions
  *
- * \date	7/6/2009 Created
+ * \date    7/6/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/au_set.h
+++ b/codec/encoder/core/inc/au_set.h
@@ -29,12 +29,12 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	au_set.h
+ * \file    au_set.h
  *
- * \brief	Interfaces introduced in Access Unit level based writer
+ * \brief   Interfaces introduced in Access Unit level based writer
  *
- * \date	05/18/2009 Created
- *			05/21/2009 Added init_sps and init_pps
+ * \date    05/18/2009 Created
+ *          05/21/2009 Added init_sps and init_pps
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/deblocking.h
+++ b/codec/encoder/core/inc/deblocking.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	deblocking.h
+ * \file    deblocking.h
  *
- * \brief	Interfaces introduced in frame deblocking filtering
+ * \brief   Interfaces introduced in frame deblocking filtering
  *
- * \date	08/03/2009 Created
+ * \date    08/03/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/dq_map.h
+++ b/codec/encoder/core/inc/dq_map.h
@@ -29,13 +29,13 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	dq_map.h
+ * \file    dq_map.h
  *
- * \brief	Dependency Quality layer IDC mapping for cross layer selection and jumpping.
- *			DQ layer idc map for svc encoding, might be a better scheme than that of design before,
- *			can aware idc of referencing layer and that idc of successive layer to be coded
+ * \brief   Dependency Quality layer IDC mapping for cross layer selection and jumpping.
+ *          DQ layer idc map for svc encoding, might be a better scheme than that of design before,
+ *          can aware idc of referencing layer and that idc of successive layer to be coded
  *
- * \date	4/22/2009 Created
+ * \date    4/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/encoder.h
+++ b/codec/encoder/core/inc/encoder.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	encoder.h
+ * \file    encoder.h
  *
- * \brief	core encoder
+ * \brief   core encoder
  *
- * \date	5/14/2009
+ * \date    5/14/2009
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/encoder_context.h
+++ b/codec/encoder/core/inc/encoder_context.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	encoder_context.h
+ * \file    encoder_context.h
  *
- * \brief	Main pData to be operated over Wels encoder all modules
+ * \brief   Main pData to be operated over Wels encoder all modules
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	extern.h
+ * \file    extern.h
  *
- * \brief	extern interfaces between core and plus of wels encoder
+ * \brief   extern interfaces between core and plus of wels encoder
  *
- * \date	4/21/2009 Created
+ * \date    4/21/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/get_intra_predictor.h
+++ b/codec/encoder/core/inc/get_intra_predictor.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	get_intra_predictor.h
+ * \file    get_intra_predictor.h
  *
- * \brief	interfaces for get intra predictor about 16x16, 4x4, chroma.
+ * \brief   interfaces for get intra predictor about 16x16, 4x4, chroma.
  *
- * \date	4/2/2009 Created
+ * \date    4/2/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/md.h
+++ b/codec/encoder/core/inc/md.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	md.h
+ * \file    md.h
  *
- * \brief	mode decision
+ * \brief   mode decision
  *
- * \date	2009.5.14 Created
+ * \date    2009.5.14 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/mt_defs.h
+++ b/codec/encoder/core/inc/mt_defs.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mt_defs.h
+ * \file    mt_defs.h
  *
- * \brief	Main macros for multiple threading implementation
+ * \brief   Main macros for multiple threading implementation
  *
- * \date	2/26/2010 Created
+ * \date    2/26/2010 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/mv_pred.h
+++ b/codec/encoder/core/inc/mv_pred.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mv_pred.h
+ * \file    mv_pred.h
  *
- * \brief	Get MV predictor and update motion vector of mb cache
+ * \brief   Get MV predictor and update motion vector of mb cache
  *
- * \date	05/22/2009 Created
+ * \date    05/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/nal_encap.h
+++ b/codec/encoder/core/inc/nal_encap.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	nal_encap.h
+ * \file    nal_encap.h
  *
- * \brief	NAL pRawNal pData encapsulation
+ * \brief   NAL pRawNal pData encapsulation
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	param_svc.h
+ * \file    param_svc.h
  *
- * \brief	Configurable parameters in H.264/SVC Encoder
+ * \brief   Configurable parameters in H.264/SVC Encoder
  *
- * \date	4/20/2009 Created
+ * \date    4/20/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/picture_handle.h
+++ b/codec/encoder/core/inc/picture_handle.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	picture_handle.h
+ * \file    picture_handle.h
  *
- * \brief	picture pData handling
+ * \brief   picture pData handling
  *
- * \date	5/20/2009 Created
+ * \date    5/20/2009 Created
  *
  *************************************************************************************/
 #if !defined(WELS_ENCODER_PICTURE_HANDLE_H__)

--- a/codec/encoder/core/inc/property.h
+++ b/codec/encoder/core/inc/property.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	property.h
+ * \file    property.h
  *
- * \brief	CODE name, library module and corresponding version are included
+ * \brief   CODE name, library module and corresponding version are included
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/ref_list_mgr_svc.h
+++ b/codec/encoder/core/inc/ref_list_mgr_svc.h
@@ -35,8 +35,8 @@
  *      Interface for managing reference picture in svc encoder side
  *
  *  History
- *		09/01/2008 Created
- *		08/07/2009 Ported
+ *      09/01/2008 Created
+ *      08/07/2009 Ported
  *
  *****************************************************************************/
 #if !defined(REFERENCE_PICTURE_LIST_MANAGEMENT_SVC_H__)

--- a/codec/encoder/core/inc/set_mb_syn_cabac.h
+++ b/codec/encoder/core/inc/set_mb_syn_cabac.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	set_mb_syn_cabac.h
+ * \file    set_mb_syn_cabac.h
  *
- * \brief	Seting all syntax elements of mb and encoding residual with cabac
+ * \brief   Seting all syntax elements of mb and encoding residual with cabac
  *
- * \date	09/27/2014 Created
+ * \date    09/27/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/set_mb_syn_cavlc.h
+++ b/codec/encoder/core/inc/set_mb_syn_cavlc.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	set_mb_syn_cavlc.h
+ * \file    set_mb_syn_cavlc.h
  *
- * \brief	Seting all syntax elements of mb and decoding residual with cavlc
+ * \brief   Seting all syntax elements of mb and decoding residual with cavlc
  *
- * \date	05/19/2009 Created
+ * \date    05/19/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/slice_multi_threading.h
+++ b/codec/encoder/core/inc/slice_multi_threading.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	slice_multi_threading.c
+ * \file    slice_multi_threading.c
  *
- * \brief	slice based multiple threading
+ * \brief   slice based multiple threading
  *
- * \date	04/16/2010 Created
+ * \date    04/16/2010 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/stat.h
+++ b/codec/encoder/core/inc/stat.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	stat.h
+ * \file    stat.h
  *
- * \brief	statistical pData information
+ * \brief   statistical pData information
  *
- * \date	4/22/2009 Created
+ * \date    4/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_base_layer_md.h
+++ b/codec/encoder/core/inc/svc_base_layer_md.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_base_layer_md.h
+ * \file    svc_base_layer_md.h
  *
- * \brief	mode decision
+ * \brief   mode decision
  *
- * \date	2009.08.10 Created
+ * \date    2009.08.10 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_enc_golomb.h
+++ b/codec/encoder/core/inc/svc_enc_golomb.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_enc_golomb.h
+ * \file    svc_enc_golomb.h
  *
- * \brief	Exponential Golomb entropy coding routine
+ * \brief   Exponential Golomb entropy coding routine
  *
- * \date	03/13/2009 Created
+ * \date    03/13/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_enc_slice_segment.h
+++ b/codec/encoder/core/inc/svc_enc_slice_segment.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	slice_segment.h
+ * \file    slice_segment.h
  *
- * \brief	SSlice segment routine (Single slice/multiple slice/fmo arrangement exclusive)
+ * \brief   SSlice segment routine (Single slice/multiple slice/fmo arrangement exclusive)
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_encode_mb.h
+++ b/codec/encoder/core/inc/svc_encode_mb.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	encode_mb.h
+ * \file    encode_mb.h
  *
- * \brief	interface for mb encoding
+ * \brief   interface for mb encoding
  *
- * \date	5/21/2009 Created
+ * \date    5/21/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_encode_slice.h
+++ b/codec/encoder/core/inc/svc_encode_slice.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_encode_slice.h
+ * \file    svc_encode_slice.h
  *
- * \brief	svc encoding slice
+ * \brief   svc encoding slice
  *
- * \date	2009.07.27 Created
+ * \date    2009.07.27 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_mode_decision.h
+++ b/codec/encoder/core/inc/svc_mode_decision.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_mode_decision.h
+ * \file    svc_mode_decision.h
  *
- * \brief	SVC Spatial Enhancement Layer MD
+ * \brief   SVC Spatial Enhancement Layer MD
  *
- * \date	2009.7.29 Created
+ * \date    2009.7.29 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_set_mb_syn.h
+++ b/codec/encoder/core/inc/svc_set_mb_syn.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_set_mb_syn.h
+ * \file    svc_set_mb_syn.h
  *
- * \brief	Seting all syntax elements of mb and encoding residual with cavlc and cabac
+ * \brief   Seting all syntax elements of mb and encoding residual with cavlc and cabac
  *
- * \date	2009.8.12 Created
+ * \date    2009.8.12 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/svc_set_mb_syn_cavlc.h
+++ b/codec/encoder/core/inc/svc_set_mb_syn_cavlc.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_set_mb_syn_cavlc.h
+ * \file    svc_set_mb_syn_cavlc.h
  *
- * \brief	Seting all syntax elements of mb and decoding residual with cavlc
+ * \brief   Seting all syntax elements of mb and decoding residual with cavlc
  *
- * \date	2009.8.12 Created
+ * \date    2009.8.12 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	wels_preprocess.h
+ * \file    wels_preprocess.h
  *
- * \brief	interface of video pre-process plugins
+ * \brief   interface of video pre-process plugins
  *
- * \date	03/15/2011
+ * \date    03/15/2011
  *
  * \description : this class is designed as an interface to unify video pre-processing
  *                class implement sets such as denoise,colorspace conversion etc...

--- a/codec/encoder/core/src/au_set.cpp
+++ b/codec/encoder/core/src/au_set.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	au_set.c
+ * \file    au_set.c
  *
- * \brief	Interfaces introduced in Access Unit level based writer
+ * \brief   Interfaces introduced in Access Unit level based writer
  *
- * \date	05/18/2009 Created
+ * \date    05/18/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/deblocking.cpp
+++ b/codec/encoder/core/src/deblocking.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	deblocking.c
+ * \file    deblocking.c
  *
- * \brief	Interfaces introduced in frame deblocking filtering
+ * \brief   Interfaces introduced in frame deblocking filtering
  *
- * \date	08/03/2009 Created
+ * \date    08/03/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/deblocking.cpp
+++ b/codec/encoder/core/src/deblocking.cpp
@@ -794,64 +794,64 @@ void WelsBlockFuncInit (PSetNoneZeroCountZeroFunc* pfSetNZCZero,  int32_t iCpu) 
 }
 
 void  DeblockingInit (DeblockingFunc*   pFunc,  int32_t iCpu) {
-  pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_c;
-  pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_c;
-  pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_c;
-  pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_c;
+  pFunc->pfLumaDeblockingLT4Ver     = DeblockLumaLt4V_c;
+  pFunc->pfLumaDeblockingEQ4Ver     = DeblockLumaEq4V_c;
+  pFunc->pfLumaDeblockingLT4Hor     = DeblockLumaLt4H_c;
+  pFunc->pfLumaDeblockingEQ4Hor     = DeblockLumaEq4H_c;
 
-  pFunc->pfChromaDeblockingLT4Ver	= DeblockChromaLt4V_c;
-  pFunc->pfChromaDeblockingEQ4Ver	= DeblockChromaEq4V_c;
-  pFunc->pfChromaDeblockingLT4Hor	= DeblockChromaLt4H_c;
-  pFunc->pfChromaDeblockingEQ4Hor	= DeblockChromaEq4H_c;
+  pFunc->pfChromaDeblockingLT4Ver   = DeblockChromaLt4V_c;
+  pFunc->pfChromaDeblockingEQ4Ver   = DeblockChromaEq4V_c;
+  pFunc->pfChromaDeblockingLT4Hor   = DeblockChromaLt4H_c;
+  pFunc->pfChromaDeblockingEQ4Hor   = DeblockChromaEq4H_c;
 
-  pFunc->pfDeblockingBSCalc             = DeblockingBSCalc_c;
+  pFunc->pfDeblockingBSCalc         = DeblockingBSCalc_c;
 
 
 #ifdef X86_ASM
   if (iCpu & WELS_CPU_SSSE3) {
-    pFunc->pfLumaDeblockingLT4Ver	= DeblockLumaLt4V_ssse3;
-    pFunc->pfLumaDeblockingEQ4Ver	= DeblockLumaEq4V_ssse3;
-    pFunc->pfLumaDeblockingLT4Hor       = DeblockLumaLt4H_ssse3;
-    pFunc->pfLumaDeblockingEQ4Hor       = DeblockLumaEq4H_ssse3;
-    pFunc->pfChromaDeblockingLT4Ver	= DeblockChromaLt4V_ssse3;
-    pFunc->pfChromaDeblockingEQ4Ver	= DeblockChromaEq4V_ssse3;
-    pFunc->pfChromaDeblockingLT4Hor	= DeblockChromaLt4H_ssse3;
-    pFunc->pfChromaDeblockingEQ4Hor	= DeblockChromaEq4H_ssse3;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_ssse3;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_ssse3;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_ssse3;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_ssse3;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_ssse3;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_ssse3;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_ssse3;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_ssse3;
   }
 #endif
 
 #if defined(HAVE_NEON)
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_neon;
-    pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_neon;
-    pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_neon;
-    pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_neon;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_neon;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_neon;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_neon;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_neon;
 
-    pFunc->pfChromaDeblockingLT4Ver     = DeblockChromaLt4V_neon;
-    pFunc->pfChromaDeblockingEQ4Ver     = DeblockChromaEq4V_neon;
-    pFunc->pfChromaDeblockingLT4Hor     = DeblockChromaLt4H_neon;
-    pFunc->pfChromaDeblockingEQ4Hor     = DeblockChromaEq4H_neon;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_neon;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_neon;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_neon;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_neon;
 
 #if defined(SINGLE_REF_FRAME)
-    pFunc->pfDeblockingBSCalc           = DeblockingBSCalc_neon;
+    pFunc->pfDeblockingBSCalc       = DeblockingBSCalc_neon;
 #endif
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (iCpu & WELS_CPU_NEON) {
-    pFunc->pfLumaDeblockingLT4Ver		= DeblockLumaLt4V_AArch64_neon;
-    pFunc->pfLumaDeblockingEQ4Ver		= DeblockLumaEq4V_AArch64_neon;
-    pFunc->pfLumaDeblockingLT4Hor		= DeblockLumaLt4H_AArch64_neon;
-    pFunc->pfLumaDeblockingEQ4Hor		= DeblockLumaEq4H_AArch64_neon;
+    pFunc->pfLumaDeblockingLT4Ver   = DeblockLumaLt4V_AArch64_neon;
+    pFunc->pfLumaDeblockingEQ4Ver   = DeblockLumaEq4V_AArch64_neon;
+    pFunc->pfLumaDeblockingLT4Hor   = DeblockLumaLt4H_AArch64_neon;
+    pFunc->pfLumaDeblockingEQ4Hor   = DeblockLumaEq4H_AArch64_neon;
 
-    pFunc->pfChromaDeblockingLT4Ver     = DeblockChromaLt4V_AArch64_neon;
-    pFunc->pfChromaDeblockingEQ4Ver     = DeblockChromaEq4V_AArch64_neon;
-    pFunc->pfChromaDeblockingLT4Hor     = DeblockChromaLt4H_AArch64_neon;
-    pFunc->pfChromaDeblockingEQ4Hor     = DeblockChromaEq4H_AArch64_neon;
+    pFunc->pfChromaDeblockingLT4Ver = DeblockChromaLt4V_AArch64_neon;
+    pFunc->pfChromaDeblockingEQ4Ver = DeblockChromaEq4V_AArch64_neon;
+    pFunc->pfChromaDeblockingLT4Hor = DeblockChromaLt4H_AArch64_neon;
+    pFunc->pfChromaDeblockingEQ4Hor = DeblockChromaEq4H_AArch64_neon;
 
 #if defined(SINGLE_REF_FRAME)
-    pFunc->pfDeblockingBSCalc           = DeblockingBSCalc_AArch64_neon;
+    pFunc->pfDeblockingBSCalc       = DeblockingBSCalc_AArch64_neon;
 #endif
   }
 #endif

--- a/codec/encoder/core/src/decode_mb_aux.cpp
+++ b/codec/encoder/core/src/decode_mb_aux.cpp
@@ -249,49 +249,49 @@ void WelsGetEncBlockStrideOffset (int32_t* pBlock, const int32_t kiStrideY, cons
 }
 
 void WelsInitReconstructionFuncs (SWelsFuncPtrList* pFuncList, uint32_t  uiCpuFlag) {
-  pFuncList->pfDequantization4x4			= WelsDequant4x4_c;
-  pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_c;
-  pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_c;
+  pFuncList->pfDequantization4x4            = WelsDequant4x4_c;
+  pFuncList->pfDequantizationFour4x4        = WelsDequantFour4x4_c;
+  pFuncList->pfDequantizationIHadamard4x4   = WelsDequantIHadamard4x4_c;
 
-  pFuncList->pfIDctT4		= WelsIDctT4Rec_c;
-  pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_c;
-  pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_c;
+  pFuncList->pfIDctT4           = WelsIDctT4Rec_c;
+  pFuncList->pfIDctFourT4       = WelsIDctFourT4Rec_c;
+  pFuncList->pfIDctI16x16Dc     = WelsIDctRecI16x16Dc_c;
 
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_MMXEXT) {
-    pFuncList->pfIDctT4		= WelsIDctT4Rec_mmx;
+    pFuncList->pfIDctT4         = WelsIDctT4Rec_mmx;
   }
   if (uiCpuFlag & WELS_CPU_SSE2) {
-    pFuncList->pfDequantization4x4			= WelsDequant4x4_sse2;
-    pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_sse2;
-    pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_sse2;
+    pFuncList->pfDequantization4x4          = WelsDequant4x4_sse2;
+    pFuncList->pfDequantizationFour4x4      = WelsDequantFour4x4_sse2;
+    pFuncList->pfDequantizationIHadamard4x4 = WelsDequantIHadamard4x4_sse2;
 
-    pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_sse2;
-    pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_sse2;
+    pFuncList->pfIDctFourT4     = WelsIDctFourT4Rec_sse2;
+    pFuncList->pfIDctI16x16Dc   = WelsIDctRecI16x16Dc_sse2;
   }
 #endif//X86_ASM
 
 #if defined(HAVE_NEON)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfDequantization4x4			= WelsDequant4x4_neon;
-    pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_neon;
-    pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_neon;
+    pFuncList->pfDequantization4x4          = WelsDequant4x4_neon;
+    pFuncList->pfDequantizationFour4x4      = WelsDequantFour4x4_neon;
+    pFuncList->pfDequantizationIHadamard4x4 = WelsDequantIHadamard4x4_neon;
 
-    pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_neon;
-    pFuncList->pfIDctT4		= WelsIDctT4Rec_neon;
-    pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_neon;
+    pFuncList->pfIDctFourT4     = WelsIDctFourT4Rec_neon;
+    pFuncList->pfIDctT4         = WelsIDctT4Rec_neon;
+    pFuncList->pfIDctI16x16Dc   = WelsIDctRecI16x16Dc_neon;
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfDequantization4x4			= WelsDequant4x4_AArch64_neon;
-    pFuncList->pfDequantizationFour4x4		= WelsDequantFour4x4_AArch64_neon;
-    pFuncList->pfDequantizationIHadamard4x4	= WelsDequantIHadamard4x4_AArch64_neon;
+    pFuncList->pfDequantization4x4          = WelsDequant4x4_AArch64_neon;
+    pFuncList->pfDequantizationFour4x4      = WelsDequantFour4x4_AArch64_neon;
+    pFuncList->pfDequantizationIHadamard4x4 = WelsDequantIHadamard4x4_AArch64_neon;
 
-    pFuncList->pfIDctFourT4		= WelsIDctFourT4Rec_AArch64_neon;
-    pFuncList->pfIDctT4		= WelsIDctT4Rec_AArch64_neon;
-    pFuncList->pfIDctI16x16Dc = WelsIDctRecI16x16Dc_AArch64_neon;
+    pFuncList->pfIDctFourT4     = WelsIDctFourT4Rec_AArch64_neon;
+    pFuncList->pfIDctT4         = WelsIDctT4Rec_AArch64_neon;
+    pFuncList->pfIDctI16x16Dc   = WelsIDctRecI16x16Dc_AArch64_neon;
   }
 #endif
 }

--- a/codec/encoder/core/src/encode_mb_aux.cpp
+++ b/codec/encoder/core/src/encode_mb_aux.cpp
@@ -462,63 +462,63 @@ int32_t WelsHadamardQuant2x2Skip_AArch64_neon (int16_t* pRes, int16_t iFF,  int1
 }
 #endif
 void WelsInitEncodingFuncs (SWelsFuncPtrList* pFuncList, uint32_t  uiCpuFlag) {
-  pFuncList->pfCopy8x8Aligned			= WelsCopy8x8_c;
-  pFuncList->pfCopy16x16Aligned		=
-    pFuncList->pfCopy16x16NotAligned	= WelsCopy16x16_c;
-  pFuncList->pfCopy16x8NotAligned		= WelsCopy16x8_c;
-  pFuncList->pfCopy8x16Aligned		= WelsCopy8x16_c;
+  pFuncList->pfCopy8x8Aligned           = WelsCopy8x8_c;
+  pFuncList->pfCopy16x16Aligned         =
+    pFuncList->pfCopy16x16NotAligned    = WelsCopy16x16_c;
+  pFuncList->pfCopy16x8NotAligned       = WelsCopy16x8_c;
+  pFuncList->pfCopy8x16Aligned          = WelsCopy8x16_c;
 
-  pFuncList->pfQuantizationHadamard2x2		= WelsHadamardQuant2x2_c;
-  pFuncList->pfQuantizationHadamard2x2Skip	= WelsHadamardQuant2x2Skip_c;
-  pFuncList->pfTransformHadamard4x4Dc			= WelsHadamardT4Dc_c;
+  pFuncList->pfQuantizationHadamard2x2          = WelsHadamardQuant2x2_c;
+  pFuncList->pfQuantizationHadamard2x2Skip      = WelsHadamardQuant2x2Skip_c;
+  pFuncList->pfTransformHadamard4x4Dc           = WelsHadamardT4Dc_c;
 
-  pFuncList->pfDctT4					= WelsDctT4_c;
-  pFuncList->pfDctFourT4   			= WelsDctFourT4_c;
+  pFuncList->pfDctT4                    = WelsDctT4_c;
+  pFuncList->pfDctFourT4                = WelsDctFourT4_c;
 
-  pFuncList->pfScan4x4				= WelsScan4x4DcAc_c;
-  pFuncList->pfScan4x4Ac				= WelsScan4x4Ac_c;
-  pFuncList->pfCalculateSingleCtr4x4	= WelsCalculateSingleCtr4x4_c;
+  pFuncList->pfScan4x4                  = WelsScan4x4DcAc_c;
+  pFuncList->pfScan4x4Ac                = WelsScan4x4Ac_c;
+  pFuncList->pfCalculateSingleCtr4x4    = WelsCalculateSingleCtr4x4_c;
 
-  pFuncList->pfGetNoneZeroCount		= WelsGetNoneZeroCount_c;
+  pFuncList->pfGetNoneZeroCount         = WelsGetNoneZeroCount_c;
 
-  pFuncList->pfQuantization4x4		= WelsQuant4x4_c;
-  pFuncList->pfQuantizationDc4x4		= WelsQuant4x4Dc_c;
-  pFuncList->pfQuantizationFour4x4	= WelsQuantFour4x4_c;
-  pFuncList->pfQuantizationFour4x4Max	= WelsQuantFour4x4Max_c;
+  pFuncList->pfQuantization4x4          = WelsQuant4x4_c;
+  pFuncList->pfQuantizationDc4x4        = WelsQuant4x4Dc_c;
+  pFuncList->pfQuantizationFour4x4      = WelsQuantFour4x4_c;
+  pFuncList->pfQuantizationFour4x4Max   = WelsQuantFour4x4Max_c;
 
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_MMXEXT) {
 
-    pFuncList->pfQuantizationHadamard2x2		= WelsHadamardQuant2x2_mmx;
-    pFuncList->pfQuantizationHadamard2x2Skip	= WelsHadamardQuant2x2Skip_mmx;
+    pFuncList->pfQuantizationHadamard2x2        = WelsHadamardQuant2x2_mmx;
+    pFuncList->pfQuantizationHadamard2x2Skip    = WelsHadamardQuant2x2Skip_mmx;
 
-    pFuncList->pfDctT4					= WelsDctT4_mmx;
+    pFuncList->pfDctT4                  = WelsDctT4_mmx;
 
-    pFuncList->pfCopy8x8Aligned			= WelsCopy8x8_mmx;
-    pFuncList->pfCopy8x16Aligned		= WelsCopy8x16_mmx;
+    pFuncList->pfCopy8x8Aligned         = WelsCopy8x8_mmx;
+    pFuncList->pfCopy8x16Aligned        = WelsCopy8x16_mmx;
   }
   if (uiCpuFlag & WELS_CPU_SSE2) {
-    pFuncList->pfGetNoneZeroCount		= WelsGetNoneZeroCount_sse2;
-    pFuncList->pfTransformHadamard4x4Dc	= WelsHadamardT4Dc_sse2;
+    pFuncList->pfGetNoneZeroCount       = WelsGetNoneZeroCount_sse2;
+    pFuncList->pfTransformHadamard4x4Dc = WelsHadamardT4Dc_sse2;
 
-    pFuncList->pfQuantization4x4		= WelsQuant4x4_sse2;
-    pFuncList->pfQuantizationDc4x4		= WelsQuant4x4Dc_sse2;
-    pFuncList->pfQuantizationFour4x4	= WelsQuantFour4x4_sse2;
-    pFuncList->pfQuantizationFour4x4Max	= WelsQuantFour4x4Max_sse2;
+    pFuncList->pfQuantization4x4        = WelsQuant4x4_sse2;
+    pFuncList->pfQuantizationDc4x4      = WelsQuant4x4Dc_sse2;
+    pFuncList->pfQuantizationFour4x4    = WelsQuantFour4x4_sse2;
+    pFuncList->pfQuantizationFour4x4Max = WelsQuantFour4x4Max_sse2;
 
-    pFuncList->pfCopy16x16Aligned		= WelsCopy16x16_sse2;
-    pFuncList->pfCopy16x16NotAligned	= WelsCopy16x16NotAligned_sse2;
-    pFuncList->pfCopy16x8NotAligned		= WelsCopy16x8NotAligned_sse2;
+    pFuncList->pfCopy16x16Aligned       = WelsCopy16x16_sse2;
+    pFuncList->pfCopy16x16NotAligned    = WelsCopy16x16NotAligned_sse2;
+    pFuncList->pfCopy16x8NotAligned     = WelsCopy16x8NotAligned_sse2;
 
-    pFuncList->pfScan4x4				= WelsScan4x4DcAc_sse2;
-    pFuncList->pfScan4x4Ac				= WelsScan4x4Ac_sse2;
-    pFuncList->pfCalculateSingleCtr4x4	= WelsCalculateSingleCtr4x4_sse2;
+    pFuncList->pfScan4x4                = WelsScan4x4DcAc_sse2;
+    pFuncList->pfScan4x4Ac              = WelsScan4x4Ac_sse2;
+    pFuncList->pfCalculateSingleCtr4x4  = WelsCalculateSingleCtr4x4_sse2;
 
-    pFuncList->pfDctFourT4				= WelsDctFourT4_sse2;
+    pFuncList->pfDctFourT4              = WelsDctFourT4_sse2;
   }
 //#ifndef MACOS
   if (uiCpuFlag & WELS_CPU_SSSE3) {
-    pFuncList->pfScan4x4				= WelsScan4x4DcAc_ssse3;
+    pFuncList->pfScan4x4                = WelsScan4x4DcAc_ssse3;
   }
 
 //#endif//MACOS
@@ -527,47 +527,47 @@ void WelsInitEncodingFuncs (SWelsFuncPtrList* pFuncList, uint32_t  uiCpuFlag) {
 
 #if defined(HAVE_NEON)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfQuantizationHadamard2x2		= WelsHadamardQuant2x2_neon;
-    pFuncList->pfQuantizationHadamard2x2Skip	= WelsHadamardQuant2x2Skip_neon;
-    pFuncList->pfDctT4					= WelsDctT4_neon;
-    pFuncList->pfCopy8x8Aligned			= WelsCopy8x8_neon;
-    pFuncList->pfCopy8x16Aligned		= WelsCopy8x16_neon;
+    pFuncList->pfQuantizationHadamard2x2        = WelsHadamardQuant2x2_neon;
+    pFuncList->pfQuantizationHadamard2x2Skip    = WelsHadamardQuant2x2Skip_neon;
+    pFuncList->pfDctT4                          = WelsDctT4_neon;
+    pFuncList->pfCopy8x8Aligned                 = WelsCopy8x8_neon;
+    pFuncList->pfCopy8x16Aligned                = WelsCopy8x16_neon;
 
-    pFuncList->pfGetNoneZeroCount		= WelsGetNoneZeroCount_neon;
-    pFuncList->pfTransformHadamard4x4Dc	= WelsHadamardT4Dc_neon;
+    pFuncList->pfGetNoneZeroCount       = WelsGetNoneZeroCount_neon;
+    pFuncList->pfTransformHadamard4x4Dc = WelsHadamardT4Dc_neon;
 
-    pFuncList->pfQuantization4x4		= WelsQuant4x4_neon;
-    pFuncList->pfQuantizationDc4x4		= WelsQuant4x4Dc_neon;
-    pFuncList->pfQuantizationFour4x4	= WelsQuantFour4x4_neon;
-    pFuncList->pfQuantizationFour4x4Max	= WelsQuantFour4x4Max_neon;
+    pFuncList->pfQuantization4x4        = WelsQuant4x4_neon;
+    pFuncList->pfQuantizationDc4x4      = WelsQuant4x4Dc_neon;
+    pFuncList->pfQuantizationFour4x4    = WelsQuantFour4x4_neon;
+    pFuncList->pfQuantizationFour4x4Max = WelsQuantFour4x4Max_neon;
 
-    pFuncList->pfCopy16x16Aligned		= WelsCopy16x16_neon;
-    pFuncList->pfCopy16x16NotAligned	= WelsCopy16x16NotAligned_neon;
-    pFuncList->pfCopy16x8NotAligned		= WelsCopy16x8NotAligned_neon;
-    pFuncList->pfDctFourT4				= WelsDctFourT4_neon;
+    pFuncList->pfCopy16x16Aligned       = WelsCopy16x16_neon;
+    pFuncList->pfCopy16x16NotAligned    = WelsCopy16x16NotAligned_neon;
+    pFuncList->pfCopy16x8NotAligned     = WelsCopy16x8NotAligned_neon;
+    pFuncList->pfDctFourT4              = WelsDctFourT4_neon;
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfQuantizationHadamard2x2		= WelsHadamardQuant2x2_AArch64_neon;
-    pFuncList->pfQuantizationHadamard2x2Skip	= WelsHadamardQuant2x2Skip_AArch64_neon;
-    pFuncList->pfDctT4					= WelsDctT4_AArch64_neon;
-    pFuncList->pfCopy8x8Aligned			= WelsCopy8x8_AArch64_neon;
-    pFuncList->pfCopy8x16Aligned		= WelsCopy8x16_AArch64_neon;
+    pFuncList->pfQuantizationHadamard2x2        = WelsHadamardQuant2x2_AArch64_neon;
+    pFuncList->pfQuantizationHadamard2x2Skip    = WelsHadamardQuant2x2Skip_AArch64_neon;
+    pFuncList->pfDctT4                          = WelsDctT4_AArch64_neon;
+    pFuncList->pfCopy8x8Aligned                 = WelsCopy8x8_AArch64_neon;
+    pFuncList->pfCopy8x16Aligned                = WelsCopy8x16_AArch64_neon;
 
-    pFuncList->pfGetNoneZeroCount		= WelsGetNoneZeroCount_AArch64_neon;
-    pFuncList->pfTransformHadamard4x4Dc	= WelsHadamardT4Dc_AArch64_neon;
+    pFuncList->pfGetNoneZeroCount       = WelsGetNoneZeroCount_AArch64_neon;
+    pFuncList->pfTransformHadamard4x4Dc = WelsHadamardT4Dc_AArch64_neon;
 
-    pFuncList->pfQuantization4x4		= WelsQuant4x4_AArch64_neon;
-    pFuncList->pfQuantizationDc4x4		= WelsQuant4x4Dc_AArch64_neon;
-    pFuncList->pfQuantizationFour4x4	= WelsQuantFour4x4_AArch64_neon;
-    pFuncList->pfQuantizationFour4x4Max	= WelsQuantFour4x4Max_AArch64_neon;
+    pFuncList->pfQuantization4x4        = WelsQuant4x4_AArch64_neon;
+    pFuncList->pfQuantizationDc4x4      = WelsQuant4x4Dc_AArch64_neon;
+    pFuncList->pfQuantizationFour4x4    = WelsQuantFour4x4_AArch64_neon;
+    pFuncList->pfQuantizationFour4x4Max = WelsQuantFour4x4Max_AArch64_neon;
 
-    pFuncList->pfCopy16x16Aligned		= WelsCopy16x16_AArch64_neon;
-    pFuncList->pfCopy16x16NotAligned	= WelsCopy16x16NotAligned_AArch64_neon;
-    pFuncList->pfCopy16x8NotAligned		= WelsCopy16x8NotAligned_AArch64_neon;
-    pFuncList->pfDctFourT4				= WelsDctFourT4_AArch64_neon;
+    pFuncList->pfCopy16x16Aligned       = WelsCopy16x16_AArch64_neon;
+    pFuncList->pfCopy16x16NotAligned    = WelsCopy16x16NotAligned_AArch64_neon;
+    pFuncList->pfCopy16x8NotAligned     = WelsCopy16x8NotAligned_AArch64_neon;
+    pFuncList->pfDctFourT4              = WelsDctFourT4_AArch64_neon;
   }
 #endif
 }

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	encoder.c
+ * \file    encoder.c
  *
- * \brief	core encoder
+ * \brief   core encoder
  *
- * \date	5/14/2009 Created
+ * \date    5/14/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -159,33 +159,33 @@ int32_t InitFunctionPointers (sWelsEncCtx* pEncCtx, SWelsSvcCodingParam* pParam,
   bool bScreenContent = (SCREEN_CONTENT_REAL_TIME == pParam->iUsageType);
 
   /* Functionality utilization of CPU instructions dependency */
-  pFuncList->pfSetMemZeroSize8	= WelsSetMemZero_c;		// confirmed_safe_unsafe_usage
-  pFuncList->pfSetMemZeroSize64Aligned16	= WelsSetMemZero_c;	// confirmed_safe_unsafe_usage
-  pFuncList->pfSetMemZeroSize64	= WelsSetMemZero_c;	// confirmed_safe_unsafe_usage
+  pFuncList->pfSetMemZeroSize8              = WelsSetMemZero_c;             // confirmed_safe_unsafe_usage
+  pFuncList->pfSetMemZeroSize64Aligned16    = WelsSetMemZero_c;     // confirmed_safe_unsafe_usage
+  pFuncList->pfSetMemZeroSize64             = WelsSetMemZero_c;     // confirmed_safe_unsafe_usage
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_MMXEXT) {
-    pFuncList->pfSetMemZeroSize8	= WelsSetMemZeroSize8_mmx;		// confirmed_safe_unsafe_usage
-    pFuncList->pfSetMemZeroSize64Aligned16	= WelsSetMemZeroSize64_mmx;	// confirmed_safe_unsafe_usage
-    pFuncList->pfSetMemZeroSize64	= WelsSetMemZeroSize64_mmx;	// confirmed_safe_unsafe_usage
+    pFuncList->pfSetMemZeroSize8            = WelsSetMemZeroSize8_mmx;              // confirmed_safe_unsafe_usage
+    pFuncList->pfSetMemZeroSize64Aligned16  = WelsSetMemZeroSize64_mmx;     // confirmed_safe_unsafe_usage
+    pFuncList->pfSetMemZeroSize64           = WelsSetMemZeroSize64_mmx;     // confirmed_safe_unsafe_usage
   }
   if (uiCpuFlag & WELS_CPU_SSE2) {
-    pFuncList->pfSetMemZeroSize64Aligned16	= WelsSetMemZeroAligned64_sse2;	// confirmed_safe_unsafe_usage
+    pFuncList->pfSetMemZeroSize64Aligned16  = WelsSetMemZeroAligned64_sse2; // confirmed_safe_unsafe_usage
   }
 #endif//X86_ASM
 
 #if defined(HAVE_NEON)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfSetMemZeroSize8	= WelsSetMemZero_neon;
-    pFuncList->pfSetMemZeroSize64Aligned16	= WelsSetMemZero_neon;
-    pFuncList->pfSetMemZeroSize64	= WelsSetMemZero_neon;
+    pFuncList->pfSetMemZeroSize8            = WelsSetMemZero_neon;
+    pFuncList->pfSetMemZeroSize64Aligned16  = WelsSetMemZero_neon;
+    pFuncList->pfSetMemZeroSize64           = WelsSetMemZero_neon;
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    pFuncList->pfSetMemZeroSize8	= WelsSetMemZero_AArch64_neon;
-    pFuncList->pfSetMemZeroSize64Aligned16	= WelsSetMemZero_AArch64_neon;
-    pFuncList->pfSetMemZeroSize64	= WelsSetMemZero_AArch64_neon;
+    pFuncList->pfSetMemZeroSize8            = WelsSetMemZero_AArch64_neon;
+    pFuncList->pfSetMemZeroSize64Aligned16  = WelsSetMemZero_AArch64_neon;
+    pFuncList->pfSetMemZeroSize64           = WelsSetMemZero_AArch64_neon;
   }
 #endif
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	encoder_ext.c
+ * \file    encoder_ext.c
  *
- * \brief	core encoder for SVC
+ * \brief   core encoder for SVC
  *
- * \date	7/24/2009 Created
+ * \date    7/24/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/get_intra_predictor.cpp
+++ b/codec/encoder/core/src/get_intra_predictor.cpp
@@ -29,13 +29,13 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	get_intra_predictor.c
+ * \file    get_intra_predictor.c
  *
- * \brief	implementation for get intra predictor about 16x16, 4x4, chroma.
+ * \brief   implementation for get intra predictor about 16x16, 4x4, chroma.
  *
- * \date	4/2/2009 Created
- *			9/14/2009 C level based optimization with high performance gained.
- *				[const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
+ * \date    4/2/2009 Created
+ *          9/14/2009 C level based optimization with high performance gained.
+ *              [const, using ST32/ST64 to replace memset, memcpy and memmove etc.]
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/md.cpp
+++ b/codec/encoder/core/src/md.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	md.c
+ * \file    md.c
  *
- * \brief	mode decision
+ * \brief   mode decision
  *
- * \date	2009.05.14 Created
+ * \date    2009.05.14 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/md.cpp
+++ b/codec/encoder/core/src/md.cpp
@@ -475,21 +475,21 @@ int32_t AnalysisVaaInfoIntra_c (uint8_t* pDataY, const int32_t kiLineSize) {
 
 // for pfGetVarianceFromIntraVaa function ptr adaptive by CPU features, 6/7/2010
 void InitIntraAnalysisVaaInfo (SWelsFuncPtrList* pFuncList, const uint32_t kuiCpuFlag) {
-  pFuncList->pfGetVarianceFromIntraVaa		= AnalysisVaaInfoIntra_c;
-  pFuncList->pfGetMbSignFromInterVaa	= MdInterAnalysisVaaInfo_c;
-  pFuncList->pfUpdateMbMv					= UpdateMbMv_c;
+  pFuncList->pfGetVarianceFromIntraVaa      = AnalysisVaaInfoIntra_c;
+  pFuncList->pfGetMbSignFromInterVaa        = MdInterAnalysisVaaInfo_c;
+  pFuncList->pfUpdateMbMv                   = UpdateMbMv_c;
 
 #if defined(X86_ASM)
   if ((kuiCpuFlag & WELS_CPU_SSE2) == WELS_CPU_SSE2) {
-    pFuncList->pfGetVarianceFromIntraVaa		= AnalysisVaaInfoIntra_sse2;
-    pFuncList->pfGetMbSignFromInterVaa	= MdInterAnalysisVaaInfo_sse2;
-    pFuncList->pfUpdateMbMv					= UpdateMbMv_sse2;
+    pFuncList->pfGetVarianceFromIntraVaa    = AnalysisVaaInfoIntra_sse2;
+    pFuncList->pfGetMbSignFromInterVaa      = MdInterAnalysisVaaInfo_sse2;
+    pFuncList->pfUpdateMbMv                 = UpdateMbMv_sse2;
   }
   if ((kuiCpuFlag & WELS_CPU_SSSE3) == WELS_CPU_SSSE3) {
-    pFuncList->pfGetVarianceFromIntraVaa	= AnalysisVaaInfoIntra_ssse3;
+    pFuncList->pfGetVarianceFromIntraVaa    = AnalysisVaaInfoIntra_ssse3;
   }
   if ((kuiCpuFlag & WELS_CPU_SSE41) == WELS_CPU_SSE41) {
-    pFuncList->pfGetMbSignFromInterVaa	= MdInterAnalysisVaaInfo_sse41;
+    pFuncList->pfGetMbSignFromInterVaa      = MdInterAnalysisVaaInfo_sse41;
   }
 #endif//X86_ASM
 }

--- a/codec/encoder/core/src/mv_pred.cpp
+++ b/codec/encoder/core/src/mv_pred.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	mv_pred.c
+ * \file    mv_pred.c
  *
- * \brief	Get MV predictor and update motion vector of mb cache
+ * \brief   Get MV predictor and update motion vector of mb cache
  *
- * \date	05/22/2009 Created
+ * \date    05/22/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/nal_encap.cpp
+++ b/codec/encoder/core/src/nal_encap.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	nal_encap.c
+ * \file    nal_encap.c
  *
- * \brief	NAL pRawNal pData encapsulation
+ * \brief   NAL pRawNal pData encapsulation
  *
- * \date	5/25/2009	Created
+ * \date    5/25/2009   Created
  *
  *************************************************************************************/
 #include "nal_encap.h"

--- a/codec/encoder/core/src/picture_handle.cpp
+++ b/codec/encoder/core/src/picture_handle.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	picture_handle.c
+ * \file    picture_handle.c
  *
- * \brief	picture pData handling
+ * \brief   picture pData handling
  *
- * \date	5/20/2009 Created
+ * \date    5/20/2009 Created
  *
  *************************************************************************************/
 #include "picture_handle.h"

--- a/codec/encoder/core/src/property.cpp
+++ b/codec/encoder/core/src/property.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	property.c
+ * \file    property.c
  *
- * \brief	CODE name, library module and corresponding version are included
+ * \brief   CODE name, library module and corresponding version are included
  *
- * \date	03/10/2009 Created
+ * \date    03/10/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/sample.cpp
+++ b/codec/encoder/core/src/sample.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	sample.c
+ * \file    sample.c
  *
- * \brief	compute SAD and SATD
+ * \brief   compute SAD and SATD
  *
- * \date	2009.06.02 Created
+ * \date    2009.06.02 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/set_mb_syn_cabac.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cabac.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	set_mb_syn_cabac.cpp
+ * \file    set_mb_syn_cabac.cpp
  *
- * \brief	cabac coding engine
+ * \brief   cabac coding engine
  *
- * \date	10/11/2014 Created
+ * \date    10/11/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cavlc.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	set_mb_syn_cavlc.h
+ * \file    set_mb_syn_cavlc.h
  *
- * \brief	Seting all syntax elements of mb and decoding residual with cavlc
+ * \brief   Seting all syntax elements of mb and decoding residual with cavlc
  *
- * \date	05/19/2009 Created
+ * \date    05/19/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	slice_multi_threading.h
+ * \file    slice_multi_threading.h
  *
- * \brief	pSlice based multiple threading
+ * \brief   pSlice based multiple threading
  *
- * \date	04/16/2010 Created
+ * \date    04/16/2010 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/svc_base_layer_md.cpp
+++ b/codec/encoder/core/src/svc_base_layer_md.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_base_layer_md.c
+ * \file    svc_base_layer_md.c
  *
- * \brief	mode decision
+ * \brief   mode decision
  *
- * \date	2009.08.10 Created
+ * \date    2009.08.10 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/svc_enc_slice_segment.cpp
+++ b/codec/encoder/core/src/svc_enc_slice_segment.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	slice_segment.c
+ * \file    slice_segment.c
  *
- * \brief	SSlice segment routine (Single slice/multiple slice/fmo arrangement exclusive)
+ * \brief   SSlice segment routine (Single slice/multiple slice/fmo arrangement exclusive)
  *
- * \date	2/4/2009 Created
+ * \date    2/4/2009 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/svc_encode_mb.cpp
+++ b/codec/encoder/core/src/svc_encode_mb.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file		encode_mb.c
+ * \file    encode_mb.c
  *
- * \brief		Implementaion for pCurMb encoding
+ * \brief   Implementaion for pCurMb encoding
  *
- * \date		05/19/2009 Created
+ * \date    05/19/2009 Created
  *************************************************************************************
  */
 

--- a/codec/encoder/core/src/svc_encode_slice.cpp
+++ b/codec/encoder/core/src/svc_encode_slice.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_encode_slice.c
+ * \file    svc_encode_slice.c
  *
- * \brief	svc encoding slice
+ * \brief   svc encoding slice
  *
- * \date	2009.07.27 Created
+ * \date    2009.07.27 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/svc_mode_decision.cpp
+++ b/codec/encoder/core/src/svc_mode_decision.cpp
@@ -29,13 +29,13 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_mode_decision.c
+ * \file    svc_mode_decision.c
  *
  * \brief Algorithmetic MD for:
  * - multi-spatial Enhancement Layer MD;
  * - Scrolling PSkip Decision for screen content
  *
- * \date	2009.7.29
+ * \date    2009.7.29
  *
 
  **************************************************************************************

--- a/codec/encoder/core/src/svc_set_mb_syn_cabac.cpp
+++ b/codec/encoder/core/src/svc_set_mb_syn_cabac.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_set_mb_syn_cabac.cpp
+ * \file    svc_set_mb_syn_cabac.cpp
  *
- * \brief	wrtie cabac syntax
+ * \brief   wrtie cabac syntax
  *
- * \date	9/28/2014 Created
+ * \date    9/28/2014 Created
  *
  *************************************************************************************
  */

--- a/codec/encoder/core/src/svc_set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/svc_set_mb_syn_cavlc.cpp
@@ -29,11 +29,11 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	svc_set_mb_syn_cavlc.h
+ * \file    svc_set_mb_syn_cavlc.h
  *
- * \brief	Seting all syntax elements of mb and decoding residual with cavlc
+ * \brief   Seting all syntax elements of mb and decoding residual with cavlc
  *
- * \date	2009.8.12 Created
+ * \date    2009.8.12 Created
  *
  *************************************************************************************
  */

--- a/codec/processing/interface/IWelsVP.h
+++ b/codec/processing/interface/IWelsVP.h
@@ -29,9 +29,9 @@
  *     POSSIBILITY OF SUCH DAMAGE.
  *
  *
- * \file	    :  IWelsVP.h
+ * \file        :  IWelsVP.h
  *
- * \brief	    :  Interface of wels video processor class
+ * \brief       :  Interface of wels video processor class
  *
  * \date        :  2011/01/04
  *

--- a/codec/processing/src/adaptivequantization/AdaptiveQuantization.h
+++ b/codec/processing/src/adaptivequantization/AdaptiveQuantization.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	        :  AdaptiveQuantization.h
+ * \file         :  AdaptiveQuantization.h
  *
- * \brief	    :  adaptive quantization class of wels video processor class
+ * \brief        :  adaptive quantization class of wels video processor class
  *
  * \date         :  2011/03/21
  *

--- a/codec/processing/src/backgrounddetection/BackgroundDetection.h
+++ b/codec/processing/src/backgrounddetection/BackgroundDetection.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	       :  BackgroundDetection.h
+ * \file        :  BackgroundDetection.h
  *
- * \brief	     :  background detection class of wels video processor class
+ * \brief       :  background detection class of wels video processor class
  *
  * \date        :  2011/03/17
  *

--- a/codec/processing/src/common/WelsFrameWork.h
+++ b/codec/processing/src/common/WelsFrameWork.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  WelsFrameWork.h
+ * \file        :  WelsFrameWork.h
  *
- * \brief	    :  framework of wels video processor class
+ * \brief       :  framework of wels video processor class
  *
  * \date        :  2011/01/04
  *

--- a/codec/processing/src/common/WelsVP.def
+++ b/codec/processing/src/common/WelsVP.def
@@ -30,7 +30,7 @@
 ;*
 ;*
 
-LIBRARY		    welsvp.dll
+LIBRARY         welsvp.dll
 EXPORTS
                 WelsCreateVpInterface
                 WelsDestroyVpInterface

--- a/codec/processing/src/common/common.h
+++ b/codec/processing/src/common/common.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	        :  SceneChangeDetectionCommon.h
+ * \file         :  SceneChangeDetectionCommon.h
  *
- * \brief	    :  scene change detection class of wels video processor class
+ * \brief        :  scene change detection class of wels video processor class
  *
  * \date         :  2011/03/14
  *

--- a/codec/processing/src/common/memory.h
+++ b/codec/processing/src/common/memory.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  memory.h
+ * \file        :  memory.h
  *
- * \brief	    :  memory definition for wels video processor class
+ * \brief       :  memory definition for wels video processor class
  *
  * \date        :  2011/02/22
  *

--- a/codec/processing/src/common/typedef.h
+++ b/codec/processing/src/common/typedef.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  typedef.h
+ * \file        :  typedef.h
  *
- * \brief	    :  basic type definition
+ * \brief       :  basic type definition
  *
  * \date        :  2011/01/04
  *

--- a/codec/processing/src/common/util.h
+++ b/codec/processing/src/common/util.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  util.h
+ * \file        :  util.h
  *
- * \brief	    :  utils for wels video processor class
+ * \brief       :  utils for wels video processor class
  *
  * \date        :  2011/01/04
  *

--- a/codec/processing/src/complexityanalysis/ComplexityAnalysis.h
+++ b/codec/processing/src/complexityanalysis/ComplexityAnalysis.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
-* \file	        :  ComplexityAnalysis.h
+* \file         :  ComplexityAnalysis.h
 *
-* \brief	    :  complexity analysis class of wels video processor class
+* \brief        :  complexity analysis class of wels video processor class
 *
 * \date         :  2011/03/28
 *

--- a/codec/processing/src/denoise/denoise.h
+++ b/codec/processing/src/denoise/denoise.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  denoise.h
+ * \file        :  denoise.h
  *
- * \brief	    :  denoise class of wels video processor class
+ * \brief       :  denoise class of wels video processor class
  *
  * \date        :  2011/03/15
  *

--- a/codec/processing/src/denoise/denoise_filter.cpp
+++ b/codec/processing/src/denoise/denoise_filter.cpp
@@ -28,11 +28,11 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	svc_preprocess.h
+ * \file    svc_preprocess.h
  *
- * \brief	svc denoising
+ * \brief   svc denoising
  *
- * \date	4/1/2010 Created
+ * \date    4/1/2010 Created
  *
  */
 

--- a/codec/processing/src/downsample/downsample.cpp
+++ b/codec/processing/src/downsample/downsample.cpp
@@ -53,25 +53,25 @@ void CDownsampling::InitDownsampleFuncs (SDownsampleFuncs& sDownsampleFunc,  int
   sDownsampleFunc.pfHalfAverage[1] = DyadicBilinearDownsampler_c;
   sDownsampleFunc.pfHalfAverage[2] = DyadicBilinearDownsampler_c;
   sDownsampleFunc.pfHalfAverage[3] = DyadicBilinearDownsampler_c;
-  sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsampler_c;
-  sDownsampleFunc.pfGeneralRatioLuma	 = GeneralBilinearFastDownsampler_c;
+  sDownsampleFunc.pfGeneralRatioChroma  = GeneralBilinearAccurateDownsampler_c;
+  sDownsampleFunc.pfGeneralRatioLuma    = GeneralBilinearFastDownsampler_c;
 #if defined(X86_ASM)
   if (iCpuFlag & WELS_CPU_SSE) {
-    sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse;
-    sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse;
-    sDownsampleFunc.pfHalfAverage[2]	= DyadicBilinearDownsamplerWidthx8_sse;
+    sDownsampleFunc.pfHalfAverage[0]    = DyadicBilinearDownsamplerWidthx32_sse;
+    sDownsampleFunc.pfHalfAverage[1]    = DyadicBilinearDownsamplerWidthx16_sse;
+    sDownsampleFunc.pfHalfAverage[2]    = DyadicBilinearDownsamplerWidthx8_sse;
   }
   if (iCpuFlag & WELS_CPU_SSE2) {
     sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsamplerWrap_sse2;
     sDownsampleFunc.pfGeneralRatioLuma   = GeneralBilinearFastDownsamplerWrap_sse2;
   }
   if (iCpuFlag & WELS_CPU_SSSE3) {
-    sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_ssse3;
-    sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_ssse3;
+    sDownsampleFunc.pfHalfAverage[0]    = DyadicBilinearDownsamplerWidthx32_ssse3;
+    sDownsampleFunc.pfHalfAverage[1]    = DyadicBilinearDownsamplerWidthx16_ssse3;
   }
   if (iCpuFlag & WELS_CPU_SSE41) {
-    sDownsampleFunc.pfHalfAverage[0]	= DyadicBilinearDownsamplerWidthx32_sse4;
-    sDownsampleFunc.pfHalfAverage[1]	= DyadicBilinearDownsamplerWidthx16_sse4;
+    sDownsampleFunc.pfHalfAverage[0]    = DyadicBilinearDownsamplerWidthx32_sse4;
+    sDownsampleFunc.pfHalfAverage[1]    = DyadicBilinearDownsamplerWidthx16_sse4;
   }
 #endif//X86_ASM
 
@@ -82,7 +82,7 @@ void CDownsampling::InitDownsampleFuncs (SDownsampleFuncs& sDownsampleFunc,  int
     sDownsampleFunc.pfHalfAverage[2] = DyadicBilinearDownsampler_neon;
     sDownsampleFunc.pfHalfAverage[3] = DyadicBilinearDownsampler_neon;
     sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsamplerWrap_neon;
-    sDownsampleFunc.pfGeneralRatioLuma	 = GeneralBilinearAccurateDownsamplerWrap_neon;
+    sDownsampleFunc.pfGeneralRatioLuma   = GeneralBilinearAccurateDownsamplerWrap_neon;
   }
 #endif
 
@@ -93,7 +93,7 @@ void CDownsampling::InitDownsampleFuncs (SDownsampleFuncs& sDownsampleFunc,  int
     sDownsampleFunc.pfHalfAverage[2] = DyadicBilinearDownsampler_AArch64_neon;
     sDownsampleFunc.pfHalfAverage[3] = DyadicBilinearDownsampler_AArch64_neon;
     sDownsampleFunc.pfGeneralRatioChroma = GeneralBilinearAccurateDownsamplerWrap_AArch64_neon;
-    sDownsampleFunc.pfGeneralRatioLuma	 = GeneralBilinearAccurateDownsamplerWrap_AArch64_neon;
+    sDownsampleFunc.pfGeneralRatioLuma   = GeneralBilinearAccurateDownsamplerWrap_AArch64_neon;
   }
 #endif
 }

--- a/codec/processing/src/downsample/downsample.h
+++ b/codec/processing/src/downsample/downsample.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  downsample.h
+ * \file        :  downsample.h
  *
- * \brief	    :  downsample class of wels video processor class
+ * \brief       :  downsample class of wels video processor class
  *
  * \date        :  2011/03/33
  *

--- a/codec/processing/src/imagerotate/imagerotate.h
+++ b/codec/processing/src/imagerotate/imagerotate.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  downsample.h
+ * \file        :  downsample.h
  *
- * \brief	    :  image rotate class of wels video processor class
+ * \brief       :  image rotate class of wels video processor class
  *
  * \date        :  2011/04/06
  *

--- a/codec/processing/src/scenechangedetection/SceneChangeDetection.h
+++ b/codec/processing/src/scenechangedetection/SceneChangeDetection.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	        :  SceneChangeDetection.h
+ * \file         :  SceneChangeDetection.h
  *
- * \brief	    :  scene change detection class of wels video processor class
+ * \brief        :  scene change detection class of wels video processor class
  *
  * \date         :  2011/03/14
  *

--- a/codec/processing/src/scrolldetection/ScrollDetection.h
+++ b/codec/processing/src/scrolldetection/ScrollDetection.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	        :  ScrollDectection.h
+ * \file         :  ScrollDectection.h
  *
- * \brief	    :  scroll detection class of wels video processor class
+ * \brief        :  scroll detection class of wels video processor class
  *
  * \date         :  2011/04/26
  *

--- a/codec/processing/src/scrolldetection/ScrollDetectionFuncs.h
+++ b/codec/processing/src/scrolldetection/ScrollDetectionFuncs.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	        :  ScrollDetectionFuncs.h
+ * \file         :  ScrollDetectionFuncs.h
  *
- * \brief	    :  scroll detection class of wels video processor class
+ * \brief        :  scroll detection class of wels video processor class
  *
  * \date         :  2011/04/26
  *

--- a/codec/processing/src/vaacalc/vaacalculation.cpp
+++ b/codec/processing/src/vaacalc/vaacalculation.cpp
@@ -51,37 +51,37 @@ CVAACalculation::~CVAACalculation() {
 }
 
 void CVAACalculation::InitVaaFuncs (SVaaFuncs& sVaaFuncs, int32_t iCpuFlag) {
-  sVaaFuncs.pfVAACalcSad				= VAACalcSad_c;
-  sVaaFuncs.pfVAACalcSadBgd			= VAACalcSadBgd_c;
-  sVaaFuncs.pfVAACalcSadSsd			= VAACalcSadSsd_c;
-  sVaaFuncs.pfVAACalcSadSsdBgd		= VAACalcSadSsdBgd_c;
-  sVaaFuncs.pfVAACalcSadVar			= VAACalcSadVar_c;
+  sVaaFuncs.pfVAACalcSad         = VAACalcSad_c;
+  sVaaFuncs.pfVAACalcSadBgd      = VAACalcSadBgd_c;
+  sVaaFuncs.pfVAACalcSadSsd      = VAACalcSadSsd_c;
+  sVaaFuncs.pfVAACalcSadSsdBgd   = VAACalcSadSsdBgd_c;
+  sVaaFuncs.pfVAACalcSadVar      = VAACalcSadVar_c;
 #ifdef X86_ASM
   if ((iCpuFlag & WELS_CPU_SSE2) == WELS_CPU_SSE2) {
-    sVaaFuncs.pfVAACalcSad			= VAACalcSad_sse2;
-    sVaaFuncs.pfVAACalcSadBgd		= VAACalcSadBgd_sse2;
-    sVaaFuncs.pfVAACalcSadSsd		= VAACalcSadSsd_sse2;
+    sVaaFuncs.pfVAACalcSad       = VAACalcSad_sse2;
+    sVaaFuncs.pfVAACalcSadBgd    = VAACalcSadBgd_sse2;
+    sVaaFuncs.pfVAACalcSadSsd    = VAACalcSadSsd_sse2;
     sVaaFuncs.pfVAACalcSadSsdBgd = VAACalcSadSsdBgd_sse2;
-    sVaaFuncs.pfVAACalcSadVar		= VAACalcSadVar_sse2;
+    sVaaFuncs.pfVAACalcSadVar    = VAACalcSadVar_sse2;
   }
 #endif//X86_ASM
 #ifdef HAVE_NEON
   if ((iCpuFlag & WELS_CPU_NEON) == WELS_CPU_NEON) {
-    sVaaFuncs.pfVAACalcSad			= VAACalcSad_neon;
-    sVaaFuncs.pfVAACalcSadBgd		= VAACalcSadBgd_neon;
-    sVaaFuncs.pfVAACalcSadSsd		= VAACalcSadSsd_neon;
+    sVaaFuncs.pfVAACalcSad       = VAACalcSad_neon;
+    sVaaFuncs.pfVAACalcSadBgd    = VAACalcSadBgd_neon;
+    sVaaFuncs.pfVAACalcSadSsd    = VAACalcSadSsd_neon;
     sVaaFuncs.pfVAACalcSadSsdBgd = VAACalcSadSsdBgd_neon;
-    sVaaFuncs.pfVAACalcSadVar		= VAACalcSadVar_neon;
+    sVaaFuncs.pfVAACalcSadVar    = VAACalcSadVar_neon;
   }
 #endif//HAVE_NEON
 
 #ifdef HAVE_NEON_AARCH64
   if ((iCpuFlag & WELS_CPU_NEON) == WELS_CPU_NEON) {
-    sVaaFuncs.pfVAACalcSad			= VAACalcSad_AArch64_neon;
-    sVaaFuncs.pfVAACalcSadBgd		= VAACalcSadBgd_AArch64_neon;
-    sVaaFuncs.pfVAACalcSadSsd		= VAACalcSadSsd_AArch64_neon;
+    sVaaFuncs.pfVAACalcSad       = VAACalcSad_AArch64_neon;
+    sVaaFuncs.pfVAACalcSadBgd    = VAACalcSadBgd_AArch64_neon;
+    sVaaFuncs.pfVAACalcSadSsd    = VAACalcSadSsd_AArch64_neon;
     sVaaFuncs.pfVAACalcSadSsdBgd = VAACalcSadSsdBgd_AArch64_neon;
-    sVaaFuncs.pfVAACalcSadVar		= VAACalcSadVar_AArch64_neon;
+    sVaaFuncs.pfVAACalcSadVar    = VAACalcSadVar_AArch64_neon;
   }
 #endif//HAVE_NEON_AARCH64
 }

--- a/codec/processing/src/vaacalc/vaacalculation.h
+++ b/codec/processing/src/vaacalc/vaacalculation.h
@@ -28,9 +28,9 @@
  *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *     POSSIBILITY OF SUCH DAMAGE.
  *
- * \file	    :  vaacalculation.h
+ * \file        :  vaacalculation.h
  *
- * \brief	    :  pVaa calculation class of wels video processor class
+ * \brief       :  pVaa calculation class of wels video processor class
  *
  * \date        :  2011/03/18
  *

--- a/openh264.def
+++ b/openh264.def
@@ -1,7 +1,7 @@
 EXPORTS
-	WelsCreateDecoder
-	WelsDestroyDecoder
-	WelsCreateSVCEncoder
-	WelsDestroySVCEncoder
-	WelsGetCodecVersion
-	WelsGetCodecVersionEx
+    WelsCreateDecoder
+    WelsDestroyDecoder
+    WelsCreateSVCEncoder
+    WelsDestroySVCEncoder
+    WelsGetCodecVersion
+    WelsGetCodecVersionEx

--- a/ut.def
+++ b/ut.def
@@ -1,2 +1,2 @@
 EXPORTS
-	CodecUtMain
+    CodecUtMain


### PR DESCRIPTION
The astyle configuration makes sure normal code is indented consistently
with 2 spaces, but astyle doesn't seem to touch the indentation in
these multi-line macros and within lines (such as in tables).

There's plenty more cases of stray tabs in the codebase that ruin the code
readability, but I'm sending the cleanup in small pieces to ease review
and readability of the cleanup.

Review at https://rbcommons.com/s/OpenH264/r/1214/.