### PR TITLE
Revert broken big-endian fix for DeblockingBsMarginalMBAvcbase

### DIFF
--- a/codec/decoder/core/src/deblocking.cpp
+++ b/codec/decoder/core/src/deblocking.cpp
@@ -279,7 +279,8 @@ void static inline DeblockingBSInsideMBNormal (PDqLayer pCurDqLayer, uint8_t nBS
 
 uint32_t DeblockingBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int32_t iNeighMb, int32_t iMbXy) {
   int32_t i, j;
-  uint8_t pBS[4];
+  uint32_t uiBSx4;
+  uint8_t* pBS = (uint8_t*) (&uiBSx4);
   const uint8_t* pBIdx      = &g_kuiTableBIdx[iEdge][0];
   const uint8_t* pBnIdx     = &g_kuiTableBIdx[iEdge][4];
   const uint8_t* pB8x8Idx   = &g_kuiTableB8x8Idx[iEdge][0];
@@ -348,7 +349,7 @@ uint32_t DeblockingBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int
     }
   }
 
-  return pBS[0] | (pBS[1] << 8) | (pBS[2] << 16) | (pBS[3] << 24);
+  return uiBSx4;
 }
 int32_t DeblockingAvailableNoInterlayer (PDqLayer pCurDqLayer, int32_t iFilterIdc) {
   int32_t iMbY = pCurDqLayer->iMbY;


### PR DESCRIPTION
The function actually was correct for big-endian use already
(and the changes in 239e22d0 actually broke normal decoding tests),
it was only the test function itself that needed fixing for big-endian.

Review at https://rbcommons.com/s/OpenH264/r/1215/.