### PR TITLE
Avoid endian assumptions in FillQpelLocationByFeatureValue_c

### DIFF
--- a/codec/encoder/core/src/svc_motion_estimate.cpp
+++ b/codec/encoder/core/src/svc_motion_estimate.cpp
@@ -821,7 +821,8 @@ void FillQpelLocationByFeatureValue_c (uint16_t* pFeatureOfBlock, const int32_t 
   for (int32_t y = 0; y < kiHeight; y++) {
     for (int32_t x = 0; x < kiWidth; x++) {
       uint16_t uiFeature = pSrcPointer[x];
-      ST32 (&pFeatureValuePointerList[uiFeature][0], ((iQpelY << 16) | (x << 2)));
+      pFeatureValuePointerList[uiFeature][0] = x << 2;
+      pFeatureValuePointerList[uiFeature][1] = iQpelY;
       pFeatureValuePointerList[uiFeature] += 2;
     }
     iQpelY += 4;

--- a/test/encoder/EncUT_SVC_me.cpp
+++ b/test/encoder/EncUT_SVC_me.cpp
@@ -97,7 +97,8 @@ void FillQpelLocationByFeatureValue_ref (uint16_t* pFeatureOfBlock, const int32_
   for (int32_t y = 0; y < kiHeight; y++) {
     for (int32_t x = 0; x < kiWidth; x++) {
       uint16_t uiFeature = pSrcPointer[x];
-      ST32 (&pFeatureValuePointerList[uiFeature][0], ((iQpelY << 16) | (x << 2)));
+      pFeatureValuePointerList[uiFeature][0] = x << 2;
+      pFeatureValuePointerList[uiFeature][1] = iQpelY;
       pFeatureValuePointerList[uiFeature] += 2;
     }
     iQpelY += 4;


### PR DESCRIPTION
These values are read as two separate 16 bit integers from an
array in the FeatureSearchOne function, therefore we should
also store them in a well-defined order.

This fixes encoding of screen content on big endian; now the
full testsuite passes on big endian.

Review at https://rbcommons.com/s/OpenH264/r/1217/.