### PR TITLE
Remove a redundant check of this!=NULL

### DIFF
--- a/test/encoder/EncUT_InterfaceTest.cpp
+++ b/test/encoder/EncUT_InterfaceTest.cpp
@@ -95,7 +95,7 @@ TEST_F (EncInterfaceCallTest, SetOptionLTR) {
     while (fileStream.read (buf.data(), frameSize) == frameSize) {
       ret = encoder_->EncodeFrame (&pic, &info);
       ASSERT_TRUE (ret == cmResultSuccess);
-      if (info.eFrameType != videoFrameTypeSkip && this != NULL) {
+      if (info.eFrameType != videoFrameTypeSkip) {
         this->onEncodeFrame (info);
         iFrameNum++;
       }


### PR DESCRIPTION
'this' can't be NULL in well-defined C++ code. This fixes a warning
with clang 3.6 from Xcode 6.3.

Review at https://rbcommons.com/s/OpenH264/r/1224/.