### PR TITLE
More fixes for out-of-tree build:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ ifneq ($(V),Yes)
 endif
 
 
-INCLUDES += -I$(SRC_PATH)codec/api/svc -I$(SRC_PATH)codec/common/inc
+INCLUDES += -I$(SRC_PATH)codec/api/svc -I$(SRC_PATH)codec/common/inc -Icodec/common/inc
 
 DECODER_INCLUDES += \
     -I$(SRC_PATH)codec/decoder/core/inc \
@@ -144,7 +144,7 @@ COMMON_UNITTEST_CFLAGS += $(CODEC_UNITTEST_CFLAGS)
 .PHONY: test gtest-bootstrap clean $(PROJECT_NAME).pc $(PROJECT_NAME)-static.pc
 
 generate-version:
-	$(QUIET)cd $(SRC_PATH) && sh ./codec/common/generate_version.sh
+	$(QUIET)sh $(SRC_PATH)codec/common/generate_version.sh $(SRC_PATH)
 
 codec/decoder/plus/src/welsDecoderExt.$(OBJ): | generate-version
 codec/encoder/plus/src/welsEncoderExt.$(OBJ): | generate-version

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -46,5 +46,4 @@ STATIC_LDFLAGS=
 CODEC_UNITTEST_CFLAGS=-D_CRT_SECURE_NO_WARNINGS
 
 %.res: %.rc
-	# //fo is required instead of /fo because of msys interpreting it as a path otherwise
-	$(QUIET_RC)rc //fo $@ $<
+	$(QUIET_RC)rc -fo $@ $<

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -41,9 +41,10 @@ SHAREDLIBSUFFIXVER=$(SHAREDLIBSUFFIX)
 SHARED=-LD
 EXTRA_LIBRARY=$(PROJECT_NAME)_dll.lib
 LDFLAGS += -link
-SHLDFLAGS=-pdb:$(PROJECT_NAME).pdb -def:openh264.def -implib:$(EXTRA_LIBRARY)
+SHLDFLAGS=-pdb:$(PROJECT_NAME).pdb -def:$(SRC_PATH)openh264.def -implib:$(EXTRA_LIBRARY)
 STATIC_LDFLAGS=
 CODEC_UNITTEST_CFLAGS=-D_CRT_SECURE_NO_WARNINGS
 
 %.res: %.rc
-	$(QUIET_RC)rc $<
+	# //fo is required instead of /fo because of msys interpreting it as a path otherwise
+	$(QUIET_RC)rc //fo $@ $<

--- a/build/platform-msvc-wp.mk
+++ b/build/platform-msvc-wp.mk
@@ -2,5 +2,5 @@ ARCH = arm
 include $(SRC_PATH)build/msvc-app.mk
 CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -DWINDOWS_PHONE
 LDFLAGS += -nodefaultlib:kernel32.lib -nodefaultlib:ole32.lib WindowsPhoneCore.lib
-UTSHLDFLAGS = -def:ut.def
+UTSHLDFLAGS = -def:$(SRC_PATH)ut.def
 

--- a/codec/common/generate_version.sh
+++ b/codec/common/generate_version.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 git rev-list HEAD | sort > config.git-hash
+SRC_PATH=$1
 LOCALVER=`wc -l config.git-hash | awk '{print $1}'`
 if [ $LOCALVER \> 1 ] ; then
     VER="$(git rev-list HEAD -n 1 | cut -c 1-7)"
@@ -14,7 +15,8 @@ fi
 GIT_VERSION='"'$GIT_VERSION'"'
 rm -f config.git-hash
 
-cat codec/common/inc/version_gen.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version_gen.h.new
+mkdir -p codec/common/inc
+cat $SRC_PATH/codec/common/inc/version_gen.h.template | sed "s/\$FULL_VERSION/$GIT_VERSION/g" > codec/common/inc/version_gen.h.new
 if cmp codec/common/inc/version_gen.h.new codec/common/inc/version_gen.h > /dev/null 2>&1; then
     # Identical to old version, don't touch it (to avoid unnecessary rebuilds)
     rm codec/common/inc/version_gen.h.new


### PR DESCRIPTION
 - Generate version header in the build tree
 - Generate .res file in the build tree on Windows
 - Add the $(SRC_PATH) prefix to the .def files on Windows