### PR TITLE
Regenerate codec_ver.h using generate_codec_ver.sh

### DIFF
--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -4,7 +4,7 @@
 
 #include "codec_app_def.h"
 
-static const OpenH264Version g_stCodecVersion  = {1,4,1,0};
+static const OpenH264Version g_stCodecVersion  = {1, 4, 1, 0};
 static const char* const g_strCodecVer  = "OpenH264 version:1.4.1.0";
 
 #define OPENH264_MAJOR (1)


### PR DESCRIPTION
This adds some spacing to the version struct, so that astyle won't
need to change the file.

This was changed in 02354832cf8, both in the earlier codec_ver.h
and in the script that generates it, but a recent change manually
overwrote the spacing.