### PR TITLE
Remove tabs from table-like code, SIMD function pointer assignments and accidental tabs

### DIFF
--- a/codec/common/src/copy_mb.cpp
+++ b/codec/common/src/copy_mb.cpp
@@ -51,8 +51,8 @@ void WelsCopy4x4_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStr
   const int32_t kiDstStride2 = iStrideD << 1;
   const int32_t kiDstStride3 = iStrideD + kiDstStride2;
 
-  ST32 (pDst,				LD32 (pSrc));
-  ST32 (pDst + iStrideD,	LD32 (pSrc + iStrideS));
+  ST32 (pDst,                LD32 (pSrc));
+  ST32 (pDst + iStrideD,     LD32 (pSrc + iStrideS));
   ST32 (pDst + kiDstStride2, LD32 (pSrc + kiSrcStride2));
   ST32 (pDst + kiDstStride3, LD32 (pSrc + kiSrcStride3));
 }
@@ -67,10 +67,10 @@ void WelsCopy4x8_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStr
 void WelsCopy8x8_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStrideS) {
   int32_t i;
   for (i = 0; i < 4; i++) {
-    ST32 (pDst,				LD32 (pSrc));
-    ST32 (pDst + 4 ,			LD32 (pSrc + 4));
-    ST32 (pDst + iStrideD,	LD32 (pSrc + iStrideS));
-    ST32 (pDst + iStrideD + 4 ,	LD32 (pSrc + iStrideS + 4));
+    ST32 (pDst,                 LD32 (pSrc));
+    ST32 (pDst + 4 ,            LD32 (pSrc + 4));
+    ST32 (pDst + iStrideD,      LD32 (pSrc + iStrideS));
+    ST32 (pDst + iStrideD + 4 , LD32 (pSrc + iStrideS + 4));
     pDst += iStrideD << 1;
     pSrc += iStrideS << 1;
   }
@@ -78,10 +78,10 @@ void WelsCopy8x8_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStr
 void WelsCopy8x16_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStrideS) {
   int32_t i;
   for (i = 0; i < 8; ++i) {
-    ST32 (pDst,				LD32 (pSrc));
-    ST32 (pDst + 4 ,			LD32 (pSrc + 4));
-    ST32 (pDst + iStrideD,	LD32 (pSrc + iStrideS));
-    ST32 (pDst + iStrideD + 4 ,	LD32 (pSrc + iStrideS + 4));
+    ST32 (pDst,                 LD32 (pSrc));
+    ST32 (pDst + 4 ,            LD32 (pSrc + 4));
+    ST32 (pDst + iStrideD,      LD32 (pSrc + iStrideS));
+    ST32 (pDst + iStrideD + 4 , LD32 (pSrc + iStrideS + 4));
     pDst += iStrideD << 1;
     pSrc += iStrideS << 1;
   }
@@ -89,10 +89,10 @@ void WelsCopy8x16_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iSt
 void WelsCopy16x8_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStrideS) {
   int32_t i;
   for (i = 0; i < 8; i++) {
-    ST32 (pDst,		LD32 (pSrc));
-    ST32 (pDst + 4 ,	LD32 (pSrc + 4));
-    ST32 (pDst + 8 , LD32 (pSrc + 8));
-    ST32 (pDst + 12 ,	LD32 (pSrc + 12));
+    ST32 (pDst,         LD32 (pSrc));
+    ST32 (pDst + 4 ,    LD32 (pSrc + 4));
+    ST32 (pDst + 8 ,    LD32 (pSrc + 8));
+    ST32 (pDst + 12 ,   LD32 (pSrc + 12));
     pDst += iStrideD ;
     pSrc += iStrideS;
   }
@@ -100,10 +100,10 @@ void WelsCopy16x8_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iSt
 void WelsCopy16x16_c (uint8_t* pDst, int32_t iStrideD, uint8_t* pSrc, int32_t iStrideS) {
   int32_t i;
   for (i = 0; i < 16; i++) {
-    ST32 (pDst,		LD32 (pSrc));
-    ST32 (pDst + 4 ,	LD32 (pSrc + 4));
-    ST32 (pDst + 8 , LD32 (pSrc + 8));
-    ST32 (pDst + 12 ,	LD32 (pSrc + 12));
+    ST32 (pDst,         LD32 (pSrc));
+    ST32 (pDst + 4 ,    LD32 (pSrc + 4));
+    ST32 (pDst + 8 ,    LD32 (pSrc + 8));
+    ST32 (pDst + 12 ,   LD32 (pSrc + 12));
     pDst += iStrideD ;
     pSrc += iStrideS;
   }

--- a/codec/common/src/deblocking_common.cpp
+++ b/codec/common/src/deblocking_common.cpp
@@ -106,7 +106,7 @@ void DeblockChromaLt4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
       bDetaP0Q0 =  WELS_ABS (p0 - q0) < iAlpha;
       bDetaP1P0 =  WELS_ABS (p1 - p0) < iBeta;
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
-      if (bDetaP0Q0 && bDetaP1P0 &&	bDetaQ1Q0) {
+      if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
         iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCb[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCb[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
@@ -122,7 +122,7 @@ void DeblockChromaLt4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
       bDetaP1P0 =  WELS_ABS (p1 - p0) < iBeta;
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
 
-      if (bDetaP0Q0 && bDetaP1P0 &&	bDetaQ1Q0) {
+      if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
         iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCr[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCr[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
@@ -197,7 +197,7 @@ void DeblockChromaLt42_c (uint8_t* pPixCbCr, int32_t iStrideX, int32_t iStrideY,
       bDetaP0Q0 =  WELS_ABS (p0 - q0) < iAlpha;
       bDetaP1P0 =  WELS_ABS (p1 - p0) < iBeta;
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
-      if (bDetaP0Q0 && bDetaP1P0 &&	bDetaQ1Q0) {
+      if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
         iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCbCr[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCbCr[0]  = WelsClip1 (q0 - iDeta);     /* q0' */

--- a/codec/common/src/memory_align.cpp
+++ b/codec/common/src/memory_align.cpp
@@ -45,7 +45,7 @@ static uint32_t nCountRequestNum;
 
 CMemoryAlign::CMemoryAlign (const uint32_t kuiCacheLineSize)
 #ifdef MEMORY_MONITOR
-  :	m_nMemoryUsageInBytes (0)
+  : m_nMemoryUsageInBytes (0)
 #endif//MEMORY_MONITOR
 {
   if ((kuiCacheLineSize == 0) || (kuiCacheLineSize & 0x0f))

--- a/codec/common/src/utils.cpp
+++ b/codec/common/src/utils.cpp
@@ -104,7 +104,7 @@ float WelsCalcPsnr (const void* kpTarPic,
                     const int32_t kiRefStride,
                     const int32_t kiWidth,
                     const int32_t kiHeight) {
-  int64_t	iSqe = 0;
+  int64_t iSqe = 0;
   int32_t x, y;
   uint8_t* pTar = (uint8_t*)kpTarPic;
   uint8_t* pRef = (uint8_t*)kpRefPic;

--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -706,7 +706,7 @@ int ProcessEncoding (ISVCEncoder* pPtrEnc, int argc, char** argv, bool bConfigFi
   FILE* pFileYUV = NULL;
   int32_t iActualFrameEncodedCount = 0;
   int32_t iFrameIdx = 0;
-  int32_t	iTotalFrameMax = -1;
+  int32_t iTotalFrameMax = -1;
   uint8_t* pYUV = NULL;
   SSourcePicture* pSrcPic = NULL;
   uint32_t iSourceWidth, iSourceHeight, kiPicResSize;

--- a/codec/decoder/core/inc/fmo.h
+++ b/codec/decoder/core/inc/fmo.h
@@ -73,7 +73,7 @@ uint8_t		uiReserved[3];		// reserved padding bytes
  *
  * \return  0 - successful; none 0 - failed;
  */
-int32_t	InitFmo (PFmo pFmo, PPps pPps, const int32_t kiMbWidth, const int32_t kiMbHeight);
+int32_t InitFmo (PFmo pFmo, PPps pPps, const int32_t kiMbWidth, const int32_t kiMbHeight);
 
 /*!
  * \brief   Uninitialize Wels Flexible Macroblock Ordering (FMO) list

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -908,8 +908,8 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
   PSps pSps				= NULL;
   PSubsetSps pSubsetSps	= NULL;
   SNalUnitHeader* pNalHead = &pCtx->sCurNalHead;
-  ProfileIdc	uiProfileIdc;
-  uint8_t	uiLevelIdc;
+  ProfileIdc uiProfileIdc;
+  uint8_t uiLevelIdc;
   int32_t iSpsId;
   uint32_t uiCode;
   int32_t iCode;

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -833,7 +833,7 @@ int32_t WelsDecodeMbCabacPSliceBaseMode0 (PWelsDecoderContext pCtx, PWelsNeighAv
   if (uiMbType < 4) { //Inter mode
     int16_t pMotionVector[LIST_A][30][MV_A];
     int16_t pMvdCache[LIST_A][30][MV_A];
-    int8_t	pRefIndex[LIST_A][30];
+    int8_t  pRefIndex[LIST_A][30];
     pCurLayer->pMbType[iMbXy] = g_ksInterMbTypeInfo[uiMbType].iType;
     WelsFillCacheInterCabac (pNeighAvail, pNonZeroCount, pMotionVector, pMvdCache, pRefIndex, pCurLayer);
     WELS_READ_VERIFY (ParseInterMotionInfoCabac (pCtx, pNeighAvail, pNonZeroCount, pMotionVector, pMvdCache, pRefIndex));
@@ -1605,7 +1605,7 @@ int32_t WelsActualDecodeMbCavlcPSlice (PWelsDecoderContext pCtx) {
   uiMbType = uiCode;
   if (uiMbType < 5) { //inter MB type
     int16_t iMotionVector[LIST_A][30][MV_A];
-    int8_t	iRefIndex[LIST_A][30];
+    int8_t  iRefIndex[LIST_A][30];
     pCurLayer->pMbType[iMbXy] = g_ksInterMbTypeInfo[uiMbType].iType;
     WelsFillCacheInter (&sNeighAvail, pNonZeroCount, iMotionVector, iRefIndex, pCurLayer);
 

--- a/codec/decoder/core/src/fmo.cpp
+++ b/codec/decoder/core/src/fmo.cpp
@@ -186,7 +186,7 @@ static inline int32_t FmoGenerateSliceGroup (PFmo pFmo, const PPps kpPps, const 
  *
  * \return  0 - successful; none 0 - failed;
  */
-int32_t	InitFmo (PFmo pFmo, PPps pPps, const int32_t kiMbWidth, const int32_t kiMbHeight) {
+int32_t InitFmo (PFmo pFmo, PPps pPps, const int32_t kiMbWidth, const int32_t kiMbHeight) {
   return FmoGenerateSliceGroup (pFmo, pPps, kiMbWidth, kiMbHeight);
 }
 

--- a/codec/decoder/core/src/get_intra_predictor.cpp
+++ b/codec/decoder/core/src/get_intra_predictor.cpp
@@ -54,10 +54,10 @@ namespace WelsDec {
 void WelsI4x4LumaPredV_c (uint8_t* pPred, const int32_t kiStride) {
   const uint32_t kuiVal = LD32A4 (pPred - kiStride);
 
-  ST32A4 (pPred						    , kuiVal);
-  ST32A4 (pPred + kiStride				, kuiVal);
-  ST32A4 (pPred + (kiStride << 1)			, kuiVal);
-  ST32A4 (pPred + (kiStride << 1) + kiStride	, kuiVal);
+  ST32A4 (pPred                                 , kuiVal);
+  ST32A4 (pPred + kiStride                      , kuiVal);
+  ST32A4 (pPred + (kiStride << 1)               , kuiVal);
+  ST32A4 (pPred + (kiStride << 1) + kiStride    , kuiVal);
 }
 
 void WelsI4x4LumaPredH_c (uint8_t* pPred, const int32_t kiStride) {
@@ -68,7 +68,7 @@ void WelsI4x4LumaPredH_c (uint8_t* pPred, const int32_t kiStride) {
   const uint32_t kuiL2 = 0x01010101U * pPred[-1 + kiStride2];
   const uint32_t kuiL3 = 0x01010101U * pPred[-1 + kiStride3];
 
-  ST32A4 (pPred          , kuiL0);
+  ST32A4 (pPred            , kuiL0);
   ST32A4 (pPred + kiStride , kuiL1);
   ST32A4 (pPred + kiStride2, kuiL2);
   ST32A4 (pPred + kiStride3, kuiL3);
@@ -81,7 +81,7 @@ void WelsI4x4LumaPredDc_c (uint8_t* pPred, const int32_t kiStride) {
                            pPred[-kiStride] + pPred[-kiStride + 1] + pPred[-kiStride + 2] + pPred[-kiStride + 3] + 4) >> 3;
   const uint32_t kuiMean32 = 0x01010101U * kuiMean;
 
-  ST32A4 (pPred          , kuiMean32);
+  ST32A4 (pPred            , kuiMean32);
   ST32A4 (pPred + kiStride , kuiMean32);
   ST32A4 (pPred + kiStride2, kuiMean32);
   ST32A4 (pPred + kiStride3, kuiMean32);
@@ -93,7 +93,7 @@ void WelsI4x4LumaPredDcLeft_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiMean	= (pPred[-1] + pPred[-1 + kiStride] + pPred[-1 + kiStride2] + pPred[-1 + kiStride3] + 2) >> 2;
   const uint32_t kuiMean32 = 0x01010101U * kuiMean;
 
-  ST32A4 (pPred          , kuiMean32);
+  ST32A4 (pPred            , kuiMean32);
   ST32A4 (pPred + kiStride , kuiMean32);
   ST32A4 (pPred + kiStride2, kuiMean32);
   ST32A4 (pPred + kiStride3, kuiMean32);
@@ -106,7 +106,7 @@ void WelsI4x4LumaPredDcTop_c (uint8_t* pPred, const int32_t kiStride) {
                           2;
   const uint32_t kuiMean32 = 0x01010101U * kuiMean;
 
-  ST32A4 (pPred          , kuiMean32);
+  ST32A4 (pPred            , kuiMean32);
   ST32A4 (pPred + kiStride , kuiMean32);
   ST32A4 (pPred + kiStride2, kuiMean32);
   ST32A4 (pPred + kiStride3, kuiMean32);
@@ -115,9 +115,9 @@ void WelsI4x4LumaPredDcTop_c (uint8_t* pPred, const int32_t kiStride) {
 void WelsI4x4LumaPredDcNA_c (uint8_t* pPred, const int32_t kiStride) {
   const uint32_t kuiDC32		= 0x80808080U;
 
-  ST32A4 (pPred                       , kuiDC32);
-  ST32A4 (pPred + kiStride              , kuiDC32);
-  ST32A4 (pPred + (kiStride << 1)         , kuiDC32);
+  ST32A4 (pPred                             , kuiDC32);
+  ST32A4 (pPred + kiStride                  , kuiDC32);
+  ST32A4 (pPred + (kiStride << 1)           , kuiDC32);
   ST32A4 (pPred + (kiStride << 1) + kiStride, kuiDC32);
 }
 
@@ -144,7 +144,7 @@ void WelsI4x4LumaPredDDL_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDDL6	= (2 + kuiT6 + kuiT7 + (kuiT7 << 1)) >> 2;	// kDDL6
   const uint8_t kuiList[8] = { kuiDDL0, kuiDDL1, kuiDDL2, kuiDDL3, kuiDDL4, kuiDDL5, kuiDDL6, 0 };
 
-  ST32A4 (pPred          , LD32 (kuiList));
+  ST32A4 (pPred            , LD32 (kuiList));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 3));
@@ -170,7 +170,7 @@ void WelsI4x4LumaPredDDLTop_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDLT3	= kuiT33 >> 1;			// kDLT3
   const uint8_t kuiList[8] = { kuiDLT0, kuiDLT1, kuiDLT2, kuiDLT3, kuiDLT3, kuiDLT3, kuiDLT3 , kuiDLT3 };
 
-  ST32A4 (pPred,           LD32 (kuiList));
+  ST32A4 (pPred,             LD32 (kuiList));
   ST32A4 (pPred + kiStride,  LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 3));
@@ -210,7 +210,7 @@ void WelsI4x4LumaPredDDR_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDDR6	= (kuiL12 + kuiL23) >> 2;	// kuiDDR6
   const uint8_t kuiList[8] = { kuiDDR6, kuiDDR5, kuiDDR4, kuiDDR0, kuiDDR1, kuiDDR2, kuiDDR3, 0	};
 
-  ST32A4 (pPred          , LD32 (kuiList + 3));
+  ST32A4 (pPred            , LD32 (kuiList + 3));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 2));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride3, LD32 (kuiList));
@@ -248,7 +248,7 @@ void WelsI4x4LumaPredVL_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVL9		= (kuiT45 + kuiT56) >> 2;	// kuiVL9
   const uint8_t kuiList[10]	= { kuiVL0, kuiVL1, kuiVL2, kuiVL3, kuiVL4, kuiVL5, kuiVL6, kuiVL7, kuiVL8, kuiVL9 };
 
-  ST32A4 (pPred,           LD32 (kuiList));
+  ST32A4 (pPred,             LD32 (kuiList));
   ST32A4 (pPred + kiStride,  LD32 (kuiList + 5));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -278,7 +278,7 @@ void WelsI4x4LumaPredVLTop_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVL7		= kuiVL3;
   const uint8_t kuiList[10]	= { kuiVL0, kuiVL1, kuiVL2, kuiVL3, kuiVL3, kuiVL4, kuiVL5, kuiVL6, kuiVL7, kuiVL7 };
 
-  ST32A4 (pPred          , LD32 (kuiList));
+  ST32A4 (pPred            , LD32 (kuiList));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 5));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -310,7 +310,7 @@ void WelsI4x4LumaPredVR_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVR9		= (2 + kuiL0 + (kuiL1 << 1) + kuiL2) >> 2;	// kuiVR9
   const uint8_t kuiList[10]	= { kuiVR8, kuiVR0, kuiVR1, kuiVR2, kuiVR3, kuiVR9, kuiVR4, kuiVR5, kuiVR6, kuiVR7 };
 
-  ST32A4 (pPred          , LD32 (kuiList + 1));
+  ST32A4 (pPred            , LD32 (kuiList + 1));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 6));
   ST32A4 (pPred + kiStride2, LD32 (kuiList));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 5));
@@ -336,7 +336,7 @@ void WelsI4x4LumaPredHU_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiHU5		= (1 + kuiL23 + (kuiL3 << 1)) >> 2;
   const uint8_t kuiList[10]	= { kuiHU0, kuiHU1, kuiHU2, kuiHU3, kuiHU4, kuiHU5, kuiL3, kuiL3, kuiL3, kuiL3 };
 
-  ST32A4 (pPred          , LD32 (kuiList));
+  ST32A4 (pPred            , LD32 (kuiList));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 2));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 4));
   ST32A4 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -374,7 +374,7 @@ void WelsI4x4LumaPredHD_c (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiHD9	    = (kuiL12 + kuiL23) >> 2;
   const uint8_t kuiList[10]	= { kuiHD8, kuiHD9, kuiHD6, kuiHD7, kuiHD4, kuiHD5, kuiHD0, kuiHD1, kuiHD2, kuiHD3 };
 
-  ST32A4 (pPred          , LD32 (kuiList + 6));
+  ST32A4 (pPred            , LD32 (kuiList + 6));
   ST32A4 (pPred + kiStride , LD32 (kuiList + 4));
   ST32A4 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32A4 (pPred + kiStride3, LD32 (kuiList));

--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -267,7 +267,7 @@ int32_t WelsMarkAsRef (PWelsDecoderContext pCtx) {
 
   for (j = pCurAU->uiStartPos; j <= pCurAU->uiEndPos; j++) {
     if (pCurAU->pNalUnitsList[j]->sNalHeaderExt.sNalUnitHeader.eNalUnitType == NAL_UNIT_CODED_SLICE_IDR
-        ||	pCurAU->pNalUnitsList[j]->sNalHeaderExt.bIdrFlag) {
+        || pCurAU->pNalUnitsList[j]->sNalHeaderExt.bIdrFlag) {
       bIsIDRAU = true;
       break;
     }

--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -682,7 +682,7 @@ static int32_t CavlcGetLevelVal (int32_t iLevel[16], SReadBitsCache* pBitsCache,
   iSuffixLength = (uiTotalCoeff > 10 && uiTrailingOnes < 3);
 
   for (; i < uiTotalCoeff; i++) {
-    if (pBitsCache->uiRemainBits <= 16)		SHIFT_BUFFER (pBitsCache);
+    if (pBitsCache->uiRemainBits <= 16) SHIFT_BUFFER (pBitsCache);
     WELS_GET_PREFIX_BITS (pBitsCache->uiCache32Bit, iPrefixBits);
     if (iPrefixBits > MAX_LEVEL_PREFIX + 1) //iPrefixBits includes leading "0"s and first "1", should +1
       return -1;
@@ -753,8 +753,8 @@ static int32_t CavlcGetTotalZeros (int32_t& iZerosLeft, SReadBitsCache* pBitsCac
 
   return iUsedBits;
 }
-static int32_t	CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, uint8_t uiTotalCoeff,
-                                   SVlcTable* pVlcTable, int32_t iZerosLeft) {
+static int32_t CavlcGetRunBefore (int32_t iRun[16], SReadBitsCache* pBitsCache, uint8_t uiTotalCoeff,
+                                  SVlcTable* pVlcTable, int32_t iZerosLeft) {
   int32_t i, iUsedBits = 0;
   uint32_t uiCount, uiValue, iPrefixBits;
 

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -87,7 +87,7 @@ namespace WelsDec {
 *   return: none
 ***************************************************************************/
 CWelsDecoder::CWelsDecoder (void)
-  :	m_pDecContext (NULL),
+  : m_pDecContext (NULL),
     m_pWelsTrace (NULL) {
 #ifdef OUTPUT_BIT_STREAM
   char chFileName[1024] = { 0 };  //for .264

--- a/codec/encoder/core/inc/mb_cache.h
+++ b/codec/encoder/core/inc/mb_cache.h
@@ -59,7 +59,7 @@ namespace WelsEnc {
 extern const uint8_t g_kuiSmb4AddrIn256[16];
 extern const uint8_t g_kuiCache12_8x8RefIdx[4];
 
-typedef	struct TagDCTCoeff {
+typedef struct TagDCTCoeff {
 //ALIGNED_DECLARE( int16_t, residual_ac[16], 16 ); //I_16x16
 int16_t iLumaBlock[16][16]; //based on block4x4 luma DC/AC
 //ALIGNED_DECLARE( int16_t, iLumaI16x16Dc[16], 16 ); //I_16x16 DC

--- a/codec/encoder/core/inc/svc_enc_frame.h
+++ b/codec/encoder/core/inc/svc_enc_frame.h
@@ -120,6 +120,6 @@ SDqLayer*				pRefLayer;		// pointer to referencing dq_layer of current layer to 
 ///////////////////////////////////////////////////////////////////////
 
 // frame structure for svc
-typedef SDqLayer	SWelsSvcFrame;
+typedef SDqLayer SWelsSvcFrame;
 }
 #endif//WELS_SVC_EXTENSION_LAYER_H__

--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -136,9 +136,9 @@ class CWelsPreProcess {
   SPicture* GetCurrentFrameFromOrigList (int32_t iDIdx) {
     return m_pSpatialPic[iDIdx][0];
   }
-  void UpdateSrcList (SPicture*	pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
+  void UpdateSrcList (SPicture* pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
                       const uint32_t kuiShortRefCount);
-  void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture*	pCurPicture, const int32_t kiCurDid,
+  void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* pCurPicture, const int32_t kiCurDid,
       const int32_t kuiMarkLongTermPicIdx, SPicture** pLongRefList);
 
  private:

--- a/codec/encoder/core/src/decode_mb_aux.cpp
+++ b/codec/encoder/core/src/decode_mb_aux.cpp
@@ -189,8 +189,8 @@ void WelsIDctT4Rec_c (uint8_t* pRec, int32_t iStride, uint8_t* pPred, int32_t iP
     const int32_t kiVerDelR   = (iTemp[4 + i] >> 1) - iTemp[12 + i];
     const int32_t kiVerSumR = iTemp[4 + i]             + (iTemp[12 + i] >> 1);
 
-    pRec[i				]         = WelsClip1 (pPred[i              ]         + ((kiVerSumL + kiVerSumR + 32) >> 6));
-    pRec[iStride + i		]     = WelsClip1 (pPred[iPredStride + i  ]  + ((kiVerDelL + kiVerDelR + 32) >> 6));
+    pRec[i               ] = WelsClip1 (pPred[i                ] + ((kiVerSumL + kiVerSumR + 32) >> 6));
+    pRec[iStride + i     ] = WelsClip1 (pPred[iPredStride + i  ] + ((kiVerDelL + kiVerDelR + 32) >> 6));
     pRec[iDstStridex2 + i] = WelsClip1 (pPred[iPredStridex2 + i] + ((kiVerDelL - kiVerDelR + 32) >> 6));
     pRec[iDstStridex3 + i] = WelsClip1 (pPred[iPredStridex3 + i] + ((kiVerSumL - kiVerSumR + 32) >> 6));
   }
@@ -199,10 +199,10 @@ void WelsIDctT4Rec_c (uint8_t* pRec, int32_t iStride, uint8_t* pPred, int32_t iP
 void WelsIDctFourT4Rec_c (uint8_t* pRec, int32_t iStride, uint8_t* pPred, int32_t iPredStride, int16_t* pDct) {
   int32_t iDstStridex4  = iStride << 2;
   int32_t iPredStridex4 = iPredStride << 2;
-  WelsIDctT4Rec_c (pRec,                  iStride, pPred,						iPredStride, pDct);
-  WelsIDctT4Rec_c (&pRec[4],              iStride, &pPred[4],					iPredStride, pDct + 16);
-  WelsIDctT4Rec_c (&pRec[iDstStridex4  ], iStride, &pPred[iPredStridex4  ],	iPredStride, pDct + 32);
-  WelsIDctT4Rec_c (&pRec[iDstStridex4 + 4], iStride, &pPred[iPredStridex4 + 4],	iPredStride, pDct + 48);
+  WelsIDctT4Rec_c (pRec,                    iStride, pPred,                     iPredStride, pDct);
+  WelsIDctT4Rec_c (&pRec[4],                iStride, &pPred[4],                 iPredStride, pDct + 16);
+  WelsIDctT4Rec_c (&pRec[iDstStridex4    ], iStride, &pPred[iPredStridex4  ],   iPredStride, pDct + 32);
+  WelsIDctT4Rec_c (&pRec[iDstStridex4 + 4], iStride, &pPred[iPredStridex4 + 4], iPredStride, pDct + 48);
 
 }
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -935,12 +935,12 @@ static int32_t WelsGenerateNewSps (sWelsEncCtx* pCtx, const bool kbUseSubsetSps,
 
 static bool CheckMatchedSps (SWelsSPS* const pSps1, SWelsSPS* const pSps2) {
 
-  if ((pSps1->iMbWidth	!= pSps2->iMbWidth)
+  if ((pSps1->iMbWidth != pSps2->iMbWidth)
       || (pSps1->iMbHeight != pSps2->iMbHeight)) {
     return false;
   }
 
-  if ((pSps1->uiLog2MaxFrameNum	!= pSps2->uiLog2MaxFrameNum)
+  if ((pSps1->uiLog2MaxFrameNum != pSps2->uiLog2MaxFrameNum)
       || (pSps1->iLog2MaxPocLsb != pSps2->iLog2MaxPocLsb)) {
     return false;
   }
@@ -949,7 +949,7 @@ static bool CheckMatchedSps (SWelsSPS* const pSps1, SWelsSPS* const pSps2) {
     return false;
   }
 
-  if ((pSps1->bFrameCroppingFlag	!= pSps2->bFrameCroppingFlag)
+  if ((pSps1->bFrameCroppingFlag != pSps2->bFrameCroppingFlag)
       || (pSps1->sFrameCrop.iCropLeft != pSps2->sFrameCrop.iCropLeft)
       || (pSps1->sFrameCrop.iCropRight != pSps2->sFrameCrop.iCropRight)
       || (pSps1->sFrameCrop.iCropTop != pSps2->sFrameCrop.iCropTop)
@@ -975,8 +975,8 @@ static bool CheckMatchedSubsetSps (SSubsetSps* const pSubsetSps1, SSubsetSps* co
     return false;
   }
 
-  if ((pSubsetSps1->sSpsSvcExt.iExtendedSpatialScalability	!= pSubsetSps2->sSpsSvcExt.iExtendedSpatialScalability)
-      || (pSubsetSps1->sSpsSvcExt.bAdaptiveTcoeffLevelPredFlag	!= pSubsetSps2->sSpsSvcExt.bAdaptiveTcoeffLevelPredFlag)
+  if ((pSubsetSps1->sSpsSvcExt.iExtendedSpatialScalability      != pSubsetSps2->sSpsSvcExt.iExtendedSpatialScalability)
+      || (pSubsetSps1->sSpsSvcExt.bAdaptiveTcoeffLevelPredFlag  != pSubsetSps2->sSpsSvcExt.bAdaptiveTcoeffLevelPredFlag)
       || (pSubsetSps1->sSpsSvcExt.bSeqTcoeffLevelPredFlag != pSubsetSps2->sSpsSvcExt.bSeqTcoeffLevelPredFlag)
       || (pSubsetSps1->sSpsSvcExt.bSliceHeaderRestrictionFlag != pSubsetSps2->sSpsSvcExt.bSliceHeaderRestrictionFlag)) {
     return false;

--- a/codec/encoder/core/src/get_intra_predictor.cpp
+++ b/codec/encoder/core/src/get_intra_predictor.cpp
@@ -660,9 +660,9 @@ void WelsInitIntraPredFuncs (SWelsFuncPtrList* pFuncList, const uint32_t kuiCpuF
     pFuncList->pfGetLumaI16x16Pred[I16_PRED_DC] = WelsI16x16LumaPredDc_neon;
     pFuncList->pfGetLumaI16x16Pred[I16_PRED_P] = WelsI16x16LumaPredPlane_neon;
 
-    pFuncList->pfGetChromaPred[C_PRED_DC]	= WelsIChromaPredDc_neon;
-    pFuncList->pfGetChromaPred[C_PRED_V]	= WelsIChromaPredV_neon;
-    pFuncList->pfGetChromaPred[C_PRED_P]	= WelsIChromaPredPlane_neon;
+    pFuncList->pfGetChromaPred[C_PRED_DC]   = WelsIChromaPredDc_neon;
+    pFuncList->pfGetChromaPred[C_PRED_V]    = WelsIChromaPredV_neon;
+    pFuncList->pfGetChromaPred[C_PRED_P]    = WelsIChromaPredPlane_neon;
     pFuncList->pfGetChromaPred[C_PRED_H]    = WelsIChromaPredH_neon;
   }
 #endif
@@ -715,9 +715,9 @@ void WelsInitIntraPredFuncs (SWelsFuncPtrList* pFuncList, const uint32_t kuiCpuF
     pFuncList->pfGetLumaI16x16Pred[I16_PRED_DC] = WelsI16x16LumaPredDc_sse2;
     pFuncList->pfGetLumaI16x16Pred[I16_PRED_P] = WelsI16x16LumaPredPlane_sse2;
 
-    pFuncList->pfGetChromaPred[C_PRED_DC]	= WelsIChromaPredDc_sse2;
-    pFuncList->pfGetChromaPred[C_PRED_V]	= WelsIChromaPredV_sse2;
-    pFuncList->pfGetChromaPred[C_PRED_P]	= WelsIChromaPredPlane_sse2;
+    pFuncList->pfGetChromaPred[C_PRED_DC]   = WelsIChromaPredDc_sse2;
+    pFuncList->pfGetChromaPred[C_PRED_V]    = WelsIChromaPredV_sse2;
+    pFuncList->pfGetChromaPred[C_PRED_P]    = WelsIChromaPredPlane_sse2;
   }
 #endif
 }

--- a/codec/encoder/core/src/md.cpp
+++ b/codec/encoder/core/src/md.cpp
@@ -446,15 +446,11 @@ int32_t AnalysisVaaInfoIntra_c (uint8_t* pDataY, const int32_t kiLineSize) {
   for (; j < 16; j += 4) {
     num = 0;
     for (i = 0; i < 16; i += 4, num ++) {
-      pBlock[num]	=  pEncData[i          ] + pEncData[i + 1          ] + pEncData[i + 2          ] + pEncData[i +
-                     3          ];
-      pBlock[num]	+= pEncData[i + kiLineSize ] + pEncData[i + kiLineSize + 1 ] + pEncData[i + kiLineSize + 2 ] + pEncData[i +
-                     kiLineSize + 3 ];
-      pBlock[num]	+= pEncData[i + kiLineSize2] + pEncData[i + kiLineSize2 + 1] + pEncData[i + kiLineSize2 + 2] + pEncData[i +
-                     kiLineSize2 + 3];
-      pBlock[num]	+= pEncData[i + kiLineSize3] + pEncData[i + kiLineSize3 + 1] + pEncData[i + kiLineSize3 + 2] + pEncData[i +
-                     kiLineSize3 + 3];
-      pBlock[num]	>>=  4;
+      pBlock[num] =  pEncData[i              ] + pEncData[i + 1              ] + pEncData[i + 2              ] + pEncData[i + 3              ];
+      pBlock[num] += pEncData[i + kiLineSize ] + pEncData[i + kiLineSize  + 1] + pEncData[i + kiLineSize  + 2] + pEncData[i + kiLineSize  + 3];
+      pBlock[num] += pEncData[i + kiLineSize2] + pEncData[i + kiLineSize2 + 1] + pEncData[i + kiLineSize2 + 2] + pEncData[i + kiLineSize2 + 3];
+      pBlock[num] += pEncData[i + kiLineSize3] + pEncData[i + kiLineSize3 + 1] + pEncData[i + kiLineSize3 + 2] + pEncData[i + kiLineSize3 + 3];
+      pBlock[num] >>=  4;
     }
     pBlock += 4;
     pEncData += kiLineSize4;

--- a/codec/encoder/core/src/md.cpp
+++ b/codec/encoder/core/src/md.cpp
@@ -559,7 +559,7 @@ inline void MeRefineQuarPixel (SWelsFuncPtrList* pFunc, SWelsME* pMe, SMeRefineP
   }
   //==========================(1, 0)=========================//
   pSampleAvg (pMeRefine->pQuarPixTmp, ME_REFINE_BUF_STRIDE, pParams->pSrcA[3],
-              ME_REFINE_BUF_STRIDE,	pParams->pSrcB[3], pParams->iStrideB,  kiWidth, kiHeight);
+              ME_REFINE_BUF_STRIDE, pParams->pSrcB[3], pParams->iStrideB,  kiWidth, kiHeight);
 
   iCurCost = CALC_COST (pMeRefine->pQuarPixTmp, pParams->iLms[3]);
   if (iCurCost < pParams->iBestCost) {

--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -552,7 +552,7 @@ void RcDecideTargetBits (sWelsEncCtx* pEncCtx) {
                                            && (pEncCtx->pSvcParam->bEnableFrameSkip == false))) {
       pWelsSvcRc->iCurrentBitsLevel = BITS_EXCEEDED;
     }
-    pWelsSvcRc->iTargetBits = WELS_CLIP3 (pWelsSvcRc->iTargetBits, pTOverRc->iMinBitsTl,	pTOverRc->iMaxBitsTl);
+    pWelsSvcRc->iTargetBits = WELS_CLIP3 (pWelsSvcRc->iTargetBits, pTOverRc->iMinBitsTl, pTOverRc->iMaxBitsTl);
   }
   pWelsSvcRc->iRemainingWeights -= pTOverRc->iTlayerWeight;
 }
@@ -706,7 +706,7 @@ void   RcVBufferCalculationSkip (sWelsEncCtx* pEncCtx) {
                        (double)VGOP_BITS_PERCENTAGE_DIFF;
 
   if ((pWelsSvcRc->iBufferFullnessSkip > pWelsSvcRc->iBufferSizeSkip
-       &&	pWelsSvcRc->iAverageFrameQp > pWelsSvcRc->iSkipQpValue)
+       && pWelsSvcRc->iAverageFrameQp > pWelsSvcRc->iSkipQpValue)
       || (dIncPercent > pWelsSvcRc->iRcVaryPercentage)) {
     pEncCtx->iSkipFrameFlag = 1;
   }

--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -166,7 +166,7 @@ static inline void DeleteInvalidLTR (sWelsEncCtx* pCtx) {
         pLongRefList[i]->SetUnref();
         DeleteLTRFromLongList (pCtx, i);
         pLtr->bLTRMarkEnable = true;
-        if (pRefList->uiLongRefCount == 0) 	{
+        if (pRefList->uiLongRefCount == 0) {
           pCtx->bEncCurFrmAsIdrFlag = true;
         }
       } else if (CompareFrameNum (pLongRefList[i]->iMarkFrameNum , pLtr->iLastCorFrameNumDec ,
@@ -179,7 +179,7 @@ static inline void DeleteInvalidLTR (sWelsEncCtx* pCtx) {
         pLongRefList[i]->SetUnref();
         DeleteLTRFromLongList (pCtx, i);
         pLtr->bLTRMarkEnable = true;
-        if (pRefList->uiLongRefCount == 0) 	{
+        if (pRefList->uiLongRefCount == 0) {
           pCtx->bEncCurFrmAsIdrFlag = true;
         }
       }

--- a/codec/encoder/core/src/svc_base_layer_md.cpp
+++ b/codec/encoder/core/src/svc_base_layer_md.cpp
@@ -1392,11 +1392,11 @@ bool WelsMdPSkipEnc (sWelsEncCtx* pEncCtx, SWelsMD* pWelsMd, SMB* pCurMb, SMbCac
     iEncStride = pEncCtx->pCurDqLayer->iEncStride[1];
     pEncMb = pMbCache->SPicData.pEncMb[1];
     pEncBlockOffset = pStrideEncBlockOffset + 16;
-    pFunc->pfDctFourT4 (pMbCache->pCoeffLevel + 256, & (pEncMb[*pEncBlockOffset]), iEncStride,	pMbCache->pSkipMb + 256, 8);
+    pFunc->pfDctFourT4 (pMbCache->pCoeffLevel + 256, & (pEncMb[*pEncBlockOffset]), iEncStride, pMbCache->pSkipMb + 256, 8);
     if (WelsTryPUVskip (pEncCtx, pCurMb, pMbCache, 1)) {
       pEncMb = pMbCache->SPicData.pEncMb[2];
       pEncBlockOffset = pStrideEncBlockOffset + 20;
-      pFunc->pfDctFourT4 (pMbCache->pCoeffLevel + 320, & (pEncMb[*pEncBlockOffset]), iEncStride,	pMbCache->pSkipMb + 320, 8);
+      pFunc->pfDctFourT4 (pMbCache->pCoeffLevel + 320, & (pEncMb[*pEncBlockOffset]), iEncStride, pMbCache->pSkipMb + 320, 8);
       if (WelsTryPUVskip (pEncCtx, pCurMb, pMbCache, 2)) {
         //update motion info to current MB
         ST32 (pCurMb->pRefIndex, 0);
@@ -1539,7 +1539,7 @@ void WelsMdInterMbRefinement (sWelsEncCtx* pEncCtx, SWelsMD* pWelsMd, SMB* pCurM
     sMeRefine.pfCopyBlockByMode = pFunc->pfCopy8x8Aligned;
     for (i = 0; i < 4; i++) {
       int32_t iBlk8Idx = i << 2; //0, 4, 8, 12
-      int32_t	iBlk4X, iBlk4Y;
+      int32_t iBlk4X, iBlk4Y;
 
       pCurMb->pRefIndex[i] = pWelsMd->uiRef;
 

--- a/codec/encoder/core/src/svc_enc_slice_segment.cpp
+++ b/codec/encoder/core/src/svc_enc_slice_segment.cpp
@@ -247,8 +247,8 @@ bool GomValidCheckSliceNum (const int32_t kiMbWidth, const int32_t kiMbHeight, u
     break;
   }
 
-  if (*pSliceNum	!= iSliceNum) {
-    *pSliceNum	= (0 != iSliceNum) ? iSliceNum : 1;
+  if (*pSliceNum != iSliceNum) {
+    *pSliceNum = (0 != iSliceNum) ? iSliceNum : 1;
     return false;
   }
   return true;

--- a/codec/encoder/core/src/svc_encode_mb.cpp
+++ b/codec/encoder/core/src/svc_encode_mb.cpp
@@ -45,10 +45,10 @@
 
 namespace WelsEnc {
 void WelsDctMb (int16_t* pRes, uint8_t* pEncMb, int32_t iEncStride, uint8_t* pBestPred, PDctFunc pfDctFourT4) {
-  pfDctFourT4 (pRes,			    pEncMb,							    iEncStride, pBestPred,			16);
-  pfDctFourT4 (pRes + 64,		pEncMb + 8,						    iEncStride, pBestPred + 8,		16);
-  pfDctFourT4 (pRes + 128,	pEncMb + 8 * iEncStride,		iEncStride, pBestPred + 128,	16);
-  pfDctFourT4 (pRes + 192,	pEncMb + 8 * iEncStride + 8,	iEncStride, pBestPred + 136,	16);
+  pfDctFourT4 (pRes,       pEncMb,                      iEncStride, pBestPred,       16);
+  pfDctFourT4 (pRes + 64,  pEncMb + 8,                  iEncStride, pBestPred + 8,   16);
+  pfDctFourT4 (pRes + 128, pEncMb + 8 * iEncStride,     iEncStride, pBestPred + 128, 16);
+  pfDctFourT4 (pRes + 192, pEncMb + 8 * iEncStride + 8, iEncStride, pBestPred + 136, 16);
 }
 
 void WelsEncRecI16x16Y (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {
@@ -77,7 +77,7 @@ void WelsEncRecI16x16Y (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {
 
   for (i = 0; i < 4; i++) {
     pFuncList->pfQuantizationFour4x4 (pRes, pFF,  pMF);
-    pFuncList->pfScan4x4Ac (pBlock,		pRes);
+    pFuncList->pfScan4x4Ac (pBlock,      pRes);
     pFuncList->pfScan4x4Ac (pBlock + 16, pRes + 16);
     pFuncList->pfScan4x4Ac (pBlock + 32, pRes + 32);
     pFuncList->pfScan4x4Ac (pBlock + 48, pRes + 48);
@@ -126,12 +126,12 @@ void WelsEncRecI16x16Y (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {
     pRes[224] = aDctT4Dc[14];
     pRes[240] = aDctT4Dc[15];
 
-    pFuncList->pfIDctFourT4 (pPred,					              kiRecStride, pBestPred,		       16, pRes);
-    pFuncList->pfIDctFourT4 (pPred + 8,				          kiRecStride, pBestPred + 8,	   16, pRes + 64);
-    pFuncList->pfIDctFourT4 (pPred + kiRecStride * 8,	      kiRecStride, pBestPred + 128,  16, pRes + 128);
+    pFuncList->pfIDctFourT4 (pPred,                       kiRecStride, pBestPred,        16, pRes);
+    pFuncList->pfIDctFourT4 (pPred + 8,                   kiRecStride, pBestPred + 8,    16, pRes + 64);
+    pFuncList->pfIDctFourT4 (pPred + kiRecStride * 8,     kiRecStride, pBestPred + 128,  16, pRes + 128);
     pFuncList->pfIDctFourT4 (pPred + kiRecStride * 8 + 8, kiRecStride, pBestPred + 136,  16, pRes + 192);
   } else if (uiCountI16x16Dc > 0) {
-    pFuncList->pfIDctI16x16Dc (pPred,	kiRecStride, pBestPred,	16, aDctT4Dc);
+    pFuncList->pfIDctI16x16Dc (pPred, kiRecStride, pBestPred, 16, aDctT4Dc);
   } else {
     pFuncList->pfCopy16x16Aligned (pPred, kiRecStride, pBestPred, 16);
   }
@@ -319,10 +319,10 @@ void    WelsRecPskip (SDqLayer* pCurLayer, SWelsFuncPtrList* pFuncList, SMB* pCu
   int32_t* iRecStride	= pCurLayer->iCsStride;
   uint8_t** pCsMb		= &pMbCache->SPicData.pCsMb[0];
 
-  pFuncList->pfCopy16x16Aligned (pCsMb[0],	*iRecStride++,	pMbCache->pSkipMb,		16);
-  pFuncList->pfCopy8x8Aligned (pCsMb[1],	*iRecStride++,	pMbCache->pSkipMb + 256,	8);
-  pFuncList->pfCopy8x8Aligned (pCsMb[2],	*iRecStride,	pMbCache->pSkipMb + 320,	8);
-  pFuncList->pfSetMemZeroSize8 (pCurMb->pNonZeroCount,	24);
+  pFuncList->pfCopy16x16Aligned (pCsMb[0],  *iRecStride++,  pMbCache->pSkipMb,       16);
+  pFuncList->pfCopy8x8Aligned (pCsMb[1],    *iRecStride++,  pMbCache->pSkipMb + 256, 8);
+  pFuncList->pfCopy8x8Aligned (pCsMb[2],    *iRecStride,    pMbCache->pSkipMb + 320, 8);
+  pFuncList->pfSetMemZeroSize8 (pCurMb->pNonZeroCount,  24);
 }
 
 bool WelsTryPYskip (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {

--- a/codec/encoder/core/src/svc_encode_mb.cpp
+++ b/codec/encoder/core/src/svc_encode_mb.cpp
@@ -344,7 +344,7 @@ bool WelsTryPYskip (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {
         pEncCtx->pFuncList->pfScan4x4 (pBlock, pRes); //
         iSingleCtrMb += pEncCtx->pFuncList->pfCalculateSingleCtr4x4 (pBlock);
       }
-      if (iSingleCtrMb >= 6) 	return false; //from JVT-O079
+      if (iSingleCtrMb >= 6) return false; //from JVT-O079
       pRes += 16;
       pBlock += 16;
     }
@@ -370,7 +370,7 @@ bool    WelsTryPUVskip (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache, i
     pEncCtx->pFuncList->pfQuantizationFour4x4Max (pRes, pFF,  pMF, (int16_t*)aMax);
 
     for (j = 0; j < 4; j++) {
-      if (aMax[j] > 1)		return false;	// iSingleCtrMb += 9, can't be P_SKIP
+      if (aMax[j] > 1) return false;   // iSingleCtrMb += 9, can't be P_SKIP
       else if (aMax[j] == 1) {
         pEncCtx->pFuncList->pfScan4x4Ac (pBlock, pRes);
         iSingleCtrMb += pEncCtx->pFuncList->pfCalculateSingleCtr4x4 (pBlock);

--- a/codec/encoder/core/src/svc_encode_slice.cpp
+++ b/codec/encoder/core/src/svc_encode_slice.cpp
@@ -448,8 +448,8 @@ void WelsPMbChromaEncode (sWelsEncCtx* pEncCtx, SSlice* pSlice, SMB* pCurMb) {
   int16_t* pCurRS				= pMbCache->pCoeffLevel + 256;
   uint8_t* pBestPred			= pMbCache->pMemPredChroma;
 
-  pFunc->pfDctFourT4 (pCurRS,		pMbCache->SPicData.pEncMb[1],	kiEncStride,		pBestPred,		8);
-  pFunc->pfDctFourT4 (pCurRS + 64,	pMbCache->SPicData.pEncMb[2],	kiEncStride,		pBestPred + 64,	8);
+  pFunc->pfDctFourT4 (pCurRS,       pMbCache->SPicData.pEncMb[1],   kiEncStride,    pBestPred,      8);
+  pFunc->pfDctFourT4 (pCurRS + 64,  pMbCache->SPicData.pEncMb[2],   kiEncStride,    pBestPred + 64, 8);
 
   WelsEncRecUV (pFunc, pCurMb, pMbCache, pCurRS, 1);
   WelsEncRecUV (pFunc, pCurMb, pMbCache, pCurRS + 64, 2);

--- a/codec/encoder/core/src/svc_encode_slice.cpp
+++ b/codec/encoder/core/src/svc_encode_slice.cpp
@@ -700,11 +700,11 @@ int32_t WelsCodePOverDynamicSlice (sWelsEncCtx* pEncCtx, SSlice* pSlice) {
 
 // 1st index: 0: for P pSlice; 1: for I pSlice;
 // 2nd index: 0: for non-dynamic pSlice; 1: for dynamic I pSlice;
-static const PWelsCodingSliceFunc	g_pWelsSliceCoding[2][2] = {
-  { WelsCodePSlice, WelsCodePOverDynamicSlice },	// P SSlice
-  { WelsISliceMdEnc, WelsISliceMdEncDynamic }	// I SSlice
+static const PWelsCodingSliceFunc g_pWelsSliceCoding[2][2] = {
+  { WelsCodePSlice, WelsCodePOverDynamicSlice }, // P SSlice
+  { WelsISliceMdEnc, WelsISliceMdEncDynamic }    // I SSlice
 };
-static const PWelsSliceHeaderWriteFunc		g_pWelsWriteSliceHeader[2] = {	// 0: for base; 1: for ext;
+static const PWelsSliceHeaderWriteFunc g_pWelsWriteSliceHeader[2] = {  // 0: for base; 1: for ext;
   WelsSliceHeaderWrite,
   WelsSliceHeaderExtWrite
 };
@@ -913,7 +913,7 @@ bool DynSlcJudgeSliceBoundaryStepBack (void* pCtx, void* pSlice, SSliceCtx* pSli
 
     if ((kbSliceNumReachConstraint || !kbSliceIdxNotExceedConstraint)
         && kbCurMbNotLastMbOfCurPartition
-        && JUMPPACKETSIZE_JUDGE (uiLen,	iCurMbIdx,
+        && JUMPPACKETSIZE_JUDGE (uiLen, iCurMbIdx,
                                  pSliceCtx->uiSliceSizeConstraint - ((kiLastMbIdxInPartition - iCurMbIdx) <<
                                      (pCurSlice->uiAssumeLog2BytePerMb) //assume each MB consumes these byte under largest QP
                                                                     ))

--- a/codec/encoder/core/src/svc_motion_estimate.cpp
+++ b/codec/encoder/core/src/svc_motion_estimate.cpp
@@ -864,7 +864,7 @@ bool CalculateFeatureOfBlock (SWelsFuncPtrList* pFunc, SPicture* pRef,
   return true;
 }
 
-void PerformFMEPreprocess (SWelsFuncPtrList* pFunc, SPicture* pRef, uint16_t*	pFeatureOfBlock,
+void PerformFMEPreprocess (SWelsFuncPtrList* pFunc, SPicture* pRef, uint16_t* pFeatureOfBlock,
                            SScreenBlockFeatureStorage* pScreenBlockFeatureStorage) {
   pScreenBlockFeatureStorage->pFeatureOfBlockPointer = pFeatureOfBlock;
   pScreenBlockFeatureStorage->bRefBlockFeatureCalculated = CalculateFeatureOfBlock (pFunc, pRef,

--- a/codec/encoder/core/src/svc_set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/svc_set_mb_syn_cavlc.cpp
@@ -208,7 +208,7 @@ void WelsSpatialWriteSubMbPred (sWelsEncCtx* pEncCtx, SSlice* pSlice, SMB* pCurM
   }
 }
 
-int32_t CheckBitstreamBuffer (const uint32_t	kuiSliceIdx, sWelsEncCtx* pEncCtx,  SBitStringAux* pBs) {
+int32_t CheckBitstreamBuffer (const uint32_t kuiSliceIdx, sWelsEncCtx* pEncCtx, SBitStringAux* pBs) {
   const intX_t iLeftLength = pBs->pEndBuf - pBs->pCurBuf - 1;
   assert (iLeftLength > 0);
 

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -582,7 +582,7 @@ int32_t CWelsPreProcess::DownsamplePadding (SPicture* pSrc, SPicture* pDstPic,  
   iShrinkWidth -= (iShrinkWidth & 1);
   iShrinkHeight -= (iShrinkHeight & 1);
   Padding ((uint8_t*)sDstPicMap.pPixel[0], (uint8_t*)sDstPicMap.pPixel[1], (uint8_t*)sDstPicMap.pPixel[2],
-           sDstPicMap.iStride[0], sDstPicMap.iStride[1],	iShrinkWidth, iTargetWidth, iShrinkHeight, iTargetHeight);
+           sDstPicMap.iStride[0], sDstPicMap.iStride[1], iShrinkWidth, iTargetWidth, iShrinkHeight, iTargetHeight);
 
   return iRet;
 }
@@ -1209,7 +1209,7 @@ void CWelsPreProcess::WelsExchangeSpatialPictures (SPicture** ppPic1, SPicture**
   *ppPic2 = tmp;
 }
 
-void CWelsPreProcess::UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture*	pCurPicture, const int32_t kiCurDid,
+void CWelsPreProcess::UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* pCurPicture, const int32_t kiCurDid,
     const int32_t kuiMarkLongTermPicIdx, SPicture** pLongRefList) {
   SPicture** pLongRefSrcList = &m_pSpatialPic[kiCurDid][0];
   for (int32_t i = 0; i < MAX_REF_PIC_COUNT; ++i) {
@@ -1225,7 +1225,7 @@ void CWelsPreProcess::UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture*	
   m_iAvaliableRefInSpatialPicList = MAX_REF_PIC_COUNT;
   (GetCurrentFrameFromOrigList (kiCurDid))->SetUnref();
 }
-void CWelsPreProcess::UpdateSrcList (SPicture*	pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
+void CWelsPreProcess::UpdateSrcList (SPicture* pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
                                      const uint32_t kuiShortRefCount) {
   SPicture** pRefSrcList = &m_pSpatialPic[kiCurDid][0];
 

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -194,7 +194,7 @@ int CWelsH264SVCEncoder::Initialize (const SEncParamBase* argv) {
     return cmInitParaError;
   }
 
-  SWelsSvcCodingParam	sConfig;
+  SWelsSvcCodingParam sConfig;
   // Convert SEncParamBase into WelsSVCParamConfig here..
   if (sConfig.ParamBaseTranscode (*argv)) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR,
@@ -221,7 +221,7 @@ int CWelsH264SVCEncoder::InitializeExt (const SEncParamExt* argv) {
     return cmInitParaError;
   }
 
-  SWelsSvcCodingParam	sConfig;
+  SWelsSvcCodingParam sConfig;
   // Convert SEncParamExt into WelsSVCParamConfig here..
   if (sConfig.ParamTranscode (*argv)) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR,

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -60,7 +60,7 @@ namespace WelsEnc {
  *  CWelsH264SVCEncoder class implementation
  */
 CWelsH264SVCEncoder::CWelsH264SVCEncoder()
-  :	m_pEncContext (NULL),
+  : m_pEncContext (NULL),
     m_pWelsTrace (NULL),
     m_iMaxPicWidth (0),
     m_iMaxPicHeight (0),

--- a/codec/processing/src/backgrounddetection/BackgroundDetection.cpp
+++ b/codec/processing/src/backgrounddetection/BackgroundDetection.cpp
@@ -261,7 +261,7 @@ inline bool CBackgroundDetection::ForegroundDilation23Chroma (int8_t iNeighbourF
 }
 
 inline void CBackgroundDetection::ForegroundDilation (SBackgroundOU* pBackgroundOU, SBackgroundOU* pOUNeighbours[],
-    vBGDParam* pBgdParam, int32_t	iChromaSampleStartPos) {
+    vBGDParam* pBgdParam, int32_t iChromaSampleStartPos) {
   int32_t iPicStrideUV	= pBgdParam->iStride[1];
   int32_t iSumNeighBackgroundFlags	= pOUNeighbours[0]->iBackgroundFlag + pOUNeighbours[1]->iBackgroundFlag +
                                       pOUNeighbours[2]->iBackgroundFlag + pOUNeighbours[3]->iBackgroundFlag;

--- a/codec/processing/src/backgrounddetection/BackgroundDetection.h
+++ b/codec/processing/src/backgrounddetection/BackgroundDetection.h
@@ -87,7 +87,7 @@ class CBackgroundDetection : public IStrategy {
   inline bool   ForegroundDilation23Chroma (int8_t iNeighbourForegroundFlags, int32_t iStartSamplePos,
       int32_t iPicStrideUV, vBGDParam* pBgdParam);//Foreground_Dilation_2_3_Chroma
   inline void     ForegroundDilation (SBackgroundOU* pBackgroundOU, SBackgroundOU* pOUNeighbours[], vBGDParam* pBgdParam,
-                                      int32_t	iChromaSampleStartPos);
+                                      int32_t iChromaSampleStartPos);
   inline void     BackgroundErosion (SBackgroundOU* pBackgroundOU, SBackgroundOU* pOUNeighbours[]);
   inline void     SetBackgroundMbFlag (int8_t* pBackgroundMbFlag, int32_t iPicWidthInMb, int32_t iBackgroundMbFlag);
   inline void     UpperOUForegroundCheck (SBackgroundOU* pCurOU, int8_t* pBackgroundMbFlag, int32_t iPicWidthInOU,

--- a/codec/processing/src/denoise/denoise_filter.cpp
+++ b/codec/processing/src/denoise/denoise_filter.cpp
@@ -40,7 +40,7 @@
 
 WELSVP_NAMESPACE_BEGIN
 
-void	BilateralLumaFilter8_c (uint8_t* pSample, int32_t iStride) {
+void BilateralLumaFilter8_c (uint8_t* pSample, int32_t iStride) {
   int32_t nSum = 0, nTotWeight = 0;
   int32_t iCenterSample = *pSample;
   uint8_t* pCurLine = pSample - iStride - DENOISE_GRAY_RADIUS;
@@ -59,7 +59,7 @@ void	BilateralLumaFilter8_c (uint8_t* pSample, int32_t iStride) {
         iCurSample = pCurLine[x];
         iCurWeight = WELS_ABS (iCurSample - iCenterSample);
         iGreyDiff = 32 - iCurWeight;
-        if (iGreyDiff < 0)	continue;
+        if (iGreyDiff < 0) continue;
         else iCurWeight = (iGreyDiff * iGreyDiff) >> 5;
         nSum += iCurSample * iCurWeight;
         nTotWeight +=  iCurWeight;
@@ -86,7 +86,7 @@ void	BilateralLumaFilter8_c (uint8_t* pSample, int32_t iStride) {
 #define SUM_LINE1(pSample)	(pSample[0] +(pSample[1]) +(pSample[2]<<1)  + pSample[3] + pSample[4])
 #define SUM_LINE2(pSample)	(pSample[0] +(pSample[1]<<1) +(pSample[2]<<2)  +(pSample[3]<<1) +pSample[4])
 #define SUM_LINE3(pSample)	((pSample[0]<<1) +(pSample[1]<<2) +(pSample[2]*20)  +(pSample[3]<<2) +(pSample[4]<<1))
-void	WaverageChromaFilter8_c (uint8_t* pSample, int32_t iStride) {
+void WaverageChromaFilter8_c (uint8_t* pSample, int32_t iStride) {
   int32_t sum;
   uint8_t* pStartPixels = pSample - UV_WINDOWS_RADIUS * iStride - UV_WINDOWS_RADIUS;
   uint8_t* pCurLine1 = pStartPixels;
@@ -111,7 +111,7 @@ edge of y/uv use a 3x3 Gauss filter, radius = 1:
 2   4   2
 1   2   1
 ***************************************************************************/
-void	Gauss3x3Filter (uint8_t* pSrc, int32_t iStride) {
+void Gauss3x3Filter (uint8_t* pSrc, int32_t iStride) {
   int32_t nSum = 0;
   uint8_t* pCurLine1 = pSrc - iStride - 1;
   uint8_t* pCurLine2 = pCurLine1 + iStride;

--- a/codec/processing/src/denoise/denoise_filter.cpp
+++ b/codec/processing/src/denoise/denoise_filter.cpp
@@ -117,9 +117,9 @@ void	Gauss3x3Filter (uint8_t* pSrc, int32_t iStride) {
   uint8_t* pCurLine2 = pCurLine1 + iStride;
   uint8_t* pCurLine3 = pCurLine2 + iStride;
 
-  nSum =	 pCurLine1[0]		+ (pCurLine1[1] << 1) +  pCurLine1[2]		+
-           (pCurLine2[0] << 1)	+ (pCurLine2[1] << 2) + (pCurLine2[2] << 1) +
-           pCurLine3[0]		+ (pCurLine3[1] << 1) +  pCurLine3[2];
+  nSum =  pCurLine1[0]       + (pCurLine1[1] << 1) +  pCurLine1[2]       +
+         (pCurLine2[0] << 1) + (pCurLine2[1] << 2) + (pCurLine2[2] << 1) +
+          pCurLine3[0]       + (pCurLine3[1] << 1) +  pCurLine3[2];
   *pSrc = nSum >> 4;
 }
 

--- a/codec/processing/src/imagerotate/imagerotate.h
+++ b/codec/processing/src/imagerotate/imagerotate.h
@@ -51,7 +51,7 @@ WELSVP_NAMESPACE_BEGIN
 typedef void (ImageRotateFunc) (uint8_t* pSrc, uint32_t uiBytesPerPixel, uint32_t iWidth, uint32_t iHeight,
                                 uint8_t* pDst);
 
-typedef ImageRotateFunc*		ImageRotateFuncPtr;
+typedef ImageRotateFunc* ImageRotateFuncPtr;
 
 ImageRotateFunc   ImageRotate90D_c;
 ImageRotateFunc   ImageRotate180D_c;

--- a/test/common/ExpandPicture.cpp
+++ b/test/common/ExpandPicture.cpp
@@ -109,7 +109,7 @@ bool CompareImage (uint8_t* pSrc0, uint8_t* pSrc1, int32_t iSize) {
 }
 
 TEST (ExpandPicture, ExpandPictureLuma) {
-  SExpandPicFunc	    sExpandPicFunc;
+  SExpandPicFunc sExpandPicFunc;
   int32_t iCpuCores = 1;
   uint32_t uiCpuFlag = 0;
   for (int32_t k = 0; k < 2; k++) {
@@ -151,7 +151,7 @@ TEST (ExpandPicture, ExpandPictureLuma) {
 }
 
 TEST (ExpandPicture, ExpandPictureChroma) {
-  SExpandPicFunc	    sExpandPicFunc;
+  SExpandPicFunc sExpandPicFunc;
   int32_t iCpuCores = 1;
   uint32_t uiCpuFlag = 0;
   for (int32_t k = 0; k < 2; k++) {
@@ -197,7 +197,7 @@ TEST (ExpandPicture, ExpandPictureChroma) {
 }
 
 TEST (ExpandPicture, ExpandPicForMotion) {
-  SExpandPicFunc	    sExpandPicFunc;
+  SExpandPicFunc sExpandPicFunc;
   int32_t iCpuCores = 1;
   uint32_t uiCpuFlag = 0;
   for (int32_t k = 0; k < 2; k++) {

--- a/test/decoder/DecUT_IntraPrediction.cpp
+++ b/test/decoder/DecUT_IntraPrediction.cpp
@@ -114,7 +114,7 @@ void WelsI4x4LumaPredDDL_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDDL6	= (2 + kuiT6 + kuiT7 + (kuiT7 << 1)) >> 2;	// kDDL6
   const uint8_t kuiList[8] = { kuiDDL0, kuiDDL1, kuiDDL2, kuiDDL3, kuiDDL4, kuiDDL5, kuiDDL6, 0 };
 
-  ST32 (pPred          , LD32 (kuiList));
+  ST32 (pPred            , LD32 (kuiList));
   ST32 (pPred + kiStride , LD32 (kuiList + 1));
   ST32 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32 (pPred + kiStride3, LD32 (kuiList + 3));
@@ -140,7 +140,7 @@ void WelsI4x4LumaPredDDLTop_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDLT3	= kuiT33 >> 1;			// kDLT3
   const uint8_t kuiList[8] = { kuiDLT0, kuiDLT1, kuiDLT2, kuiDLT3, kuiDLT3, kuiDLT3, kuiDLT3 , kuiDLT3 };
 
-  ST32 (pPred,           LD32 (kuiList));
+  ST32 (pPred,             LD32 (kuiList));
   ST32 (pPred + kiStride,  LD32 (kuiList + 1));
   ST32 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32 (pPred + kiStride3, LD32 (kuiList + 3));
@@ -180,7 +180,7 @@ void WelsI4x4LumaPredDDR_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiDDR6	= (kuiL12 + kuiL23) >> 2;	// kuiDDR6
   const uint8_t kuiList[8] = { kuiDDR6, kuiDDR5, kuiDDR4, kuiDDR0, kuiDDR1, kuiDDR2, kuiDDR3, 0	};
 
-  ST32 (pPred          , LD32 (kuiList + 3));
+  ST32 (pPred            , LD32 (kuiList + 3));
   ST32 (pPred + kiStride , LD32 (kuiList + 2));
   ST32 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32 (pPred + kiStride3, LD32 (kuiList));
@@ -218,7 +218,7 @@ void WelsI4x4LumaPredVL_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVL9		= (kuiT45 + kuiT56) >> 2;	// kuiVL9
   const uint8_t kuiList[10]	= { kuiVL0, kuiVL1, kuiVL2, kuiVL3, kuiVL4, kuiVL5, kuiVL6, kuiVL7, kuiVL8, kuiVL9 };
 
-  ST32 (pPred,           LD32 (kuiList));
+  ST32 (pPred,             LD32 (kuiList));
   ST32 (pPred + kiStride,  LD32 (kuiList + 5));
   ST32 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -248,7 +248,7 @@ void WelsI4x4LumaPredVLTop_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVL7		= kuiVL3;
   const uint8_t kuiList[10]	= { kuiVL0, kuiVL1, kuiVL2, kuiVL3, kuiVL3, kuiVL4, kuiVL5, kuiVL6, kuiVL7, kuiVL7 };
 
-  ST32 (pPred          , LD32 (kuiList));
+  ST32 (pPred            , LD32 (kuiList));
   ST32 (pPred + kiStride , LD32 (kuiList + 5));
   ST32 (pPred + kiStride2, LD32 (kuiList + 1));
   ST32 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -280,7 +280,7 @@ void WelsI4x4LumaPredVR_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiVR9		= (2 + kuiL0 + (kuiL1 << 1) + kuiL2) >> 2;	// kuiVR9
   const uint8_t kuiList[10]	= { kuiVR8, kuiVR0, kuiVR1, kuiVR2, kuiVR3, kuiVR9, kuiVR4, kuiVR5, kuiVR6, kuiVR7 };
 
-  ST32 (pPred          , LD32 (kuiList + 1));
+  ST32 (pPred            , LD32 (kuiList + 1));
   ST32 (pPred + kiStride , LD32 (kuiList + 6));
   ST32 (pPred + kiStride2, LD32 (kuiList));
   ST32 (pPred + kiStride3, LD32 (kuiList + 5));
@@ -306,7 +306,7 @@ void WelsI4x4LumaPredHU_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiHU5		= (1 + kuiL23 + (kuiL3 << 1)) >> 2;
   const uint8_t kuiList[10]	= { kuiHU0, kuiHU1, kuiHU2, kuiHU3, kuiHU4, kuiHU5, kuiL3, kuiL3, kuiL3, kuiL3 };
 
-  ST32 (pPred          , LD32 (kuiList));
+  ST32 (pPred            , LD32 (kuiList));
   ST32 (pPred + kiStride , LD32 (kuiList + 2));
   ST32 (pPred + kiStride2, LD32 (kuiList + 4));
   ST32 (pPred + kiStride3, LD32 (kuiList + 6));
@@ -344,7 +344,7 @@ void WelsI4x4LumaPredHD_ref (uint8_t* pPred, const int32_t kiStride) {
   const uint8_t kuiHD9	    = (kuiL12 + kuiL23) >> 2;
   const uint8_t kuiList[10]	= { kuiHD8, kuiHD9, kuiHD6, kuiHD7, kuiHD4, kuiHD5, kuiHD0, kuiHD1, kuiHD2, kuiHD3 };
 
-  ST32 (pPred          , LD32 (kuiList + 6));
+  ST32 (pPred            , LD32 (kuiList + 6));
   ST32 (pPred + kiStride , LD32 (kuiList + 4));
   ST32 (pPred + kiStride2, LD32 (kuiList + 2));
   ST32 (pPred + kiStride3, LD32 (kuiList));

--- a/test/encoder/EncUT_MemoryZero.cpp
+++ b/test/encoder/EncUT_MemoryZero.cpp
@@ -18,17 +18,17 @@ TEST (SetMemZeroFunTest, WelsSetMemZero) {
   SWelsFuncPtrList sFuncPtrList;
   uint32_t uiCpuFlag = WelsCPUFeatureDetect (&iCpuCores);
   /* Functionality utilization of CPU instructions dependency */
-  sFuncPtrList.pfSetMemZeroSize8	= WelsSetMemZero_c;		// confirmed_safe_unsafe_usage
-  sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZero_c;	// confirmed_safe_unsafe_usage
-  sFuncPtrList.pfSetMemZeroSize64	= WelsSetMemZero_c;	// confirmed_safe_unsafe_usage
+  sFuncPtrList.pfSetMemZeroSize8           = WelsSetMemZero_c; // confirmed_safe_unsafe_usage
+  sFuncPtrList.pfSetMemZeroSize64Aligned16 = WelsSetMemZero_c; // confirmed_safe_unsafe_usage
+  sFuncPtrList.pfSetMemZeroSize64          = WelsSetMemZero_c; // confirmed_safe_unsafe_usage
 #if defined(X86_ASM)
   if (uiCpuFlag & WELS_CPU_MMXEXT) {
-    sFuncPtrList.pfSetMemZeroSize8	= WelsSetMemZeroSize8_mmx;		// confirmed_safe_unsafe_usage
-    sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZeroSize64_mmx;	// confirmed_safe_unsafe_usage
-    sFuncPtrList.pfSetMemZeroSize64	= WelsSetMemZeroSize64_mmx;	// confirmed_safe_unsafe_usage
+    sFuncPtrList.pfSetMemZeroSize8           = WelsSetMemZeroSize8_mmx;  // confirmed_safe_unsafe_usage
+    sFuncPtrList.pfSetMemZeroSize64Aligned16 = WelsSetMemZeroSize64_mmx; // confirmed_safe_unsafe_usage
+    sFuncPtrList.pfSetMemZeroSize64          = WelsSetMemZeroSize64_mmx; // confirmed_safe_unsafe_usage
   }
   if (uiCpuFlag & WELS_CPU_SSE2) {
-    sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZeroAligned64_sse2;	// confirmed_safe_unsafe_usage
+    sFuncPtrList.pfSetMemZeroSize64Aligned16 = WelsSetMemZeroAligned64_sse2; // confirmed_safe_unsafe_usage
   }
 #else
   (void) uiCpuFlag; // Avoid warnings if no assembly is enabled
@@ -36,17 +36,17 @@ TEST (SetMemZeroFunTest, WelsSetMemZero) {
 
 #if defined(HAVE_NEON)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    sFuncPtrList.pfSetMemZeroSize8	= WelsSetMemZero_neon;
-    sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZero_neon;
-    sFuncPtrList.pfSetMemZeroSize64	= WelsSetMemZero_neon;
+    sFuncPtrList.pfSetMemZeroSize8           = WelsSetMemZero_neon;
+    sFuncPtrList.pfSetMemZeroSize64Aligned16 = WelsSetMemZero_neon;
+    sFuncPtrList.pfSetMemZeroSize64          = WelsSetMemZero_neon;
   }
 #endif
 
 #if defined(HAVE_NEON_AARCH64)
   if (uiCpuFlag & WELS_CPU_NEON) {
-    sFuncPtrList.pfSetMemZeroSize8	= WelsSetMemZero_AArch64_neon;
-    sFuncPtrList.pfSetMemZeroSize64Aligned16	= WelsSetMemZero_AArch64_neon;
-    sFuncPtrList.pfSetMemZeroSize64	= WelsSetMemZero_AArch64_neon;
+    sFuncPtrList.pfSetMemZeroSize8           = WelsSetMemZero_AArch64_neon;
+    sFuncPtrList.pfSetMemZeroSize64Aligned16 = WelsSetMemZero_AArch64_neon;
+    sFuncPtrList.pfSetMemZeroSize64          = WelsSetMemZero_AArch64_neon;
   }
 #endif
 


### PR DESCRIPTION
The astyle configuration makes sure normal code is indented consistently
with 2 spaces, but astyle doesn't touch tabs in the middle of lines.

There's plenty more cases of stray tabs in the codebase that ruin the code
readability, but I'm sending the cleanup in small pieces to ease review
and readability of the cleanup.

Review at https://rbcommons.com/s/OpenH264/r/1230/.