### PR TITLE
Don't concatenate $@ to AR_OPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LIBSUFFIX=a
 CCAS=$(CC)
 CXX_O=-o $@
 CXX_LINK_O=-o $@
-AR_OPTS=cr
+AR_OPTS=cr $@
 LINK_LOCAL_DIR=-L.
 LINK_LIB=-l$(1)
 CFLAGS_OPT=-O3
@@ -70,7 +70,6 @@ include $(SRC_PATH)build/platform-$(OS).mk
 
 CFLAGS += -DGENERATED_VERSION_HEADER
 LDFLAGS +=
-AR_OPTS += $@
 
 ifeq (Yes, $(GCOV))
 CFLAGS += -fprofile-arcs -ftest-coverage

--- a/build/platform-linux.mk
+++ b/build/platform-linux.mk
@@ -4,7 +4,7 @@ SHAREDLIBSUFFIXVER=$(SHAREDLIBSUFFIX).$(SHAREDLIBVERSION)
 SHLDFLAGS = -Wl,-soname,$(LIBPREFIX)$(PROJECT_NAME).$(SHAREDLIBSUFFIXVER)
 CFLAGS += -Wall -fno-strict-aliasing -fPIC -MMD -MP
 LDFLAGS += -lpthread
-AR_OPTS += -D
+AR_OPTS = crD $@
 ifeq ($(ASM_ARCH), x86)
 ifeq ($(ARCH), x86_64)
 ASMFLAGS += -f elf64


### PR DESCRIPTION
The MSVC version of AR_OPTS already contains $@, in a very specific
way.

This fixes MSVC builds after c8bed8a9.