### PR TITLE
Allow compilation to JavaScript via emscripten

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Adam Roach
 Sawyer Shan
 Siping Tao
 Martin Storsjö
+Brion Vibber
 James Wang
 Juanny Wang
 Zhiliang Wang

--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -483,6 +483,12 @@ WELS_THREAD_ERROR_CODE    WelsQueryLogicalProcessInfo (WelsLogicalProcessInfo* p
 
   return WELS_THREAD_ERROR_OK;
 
+#elif defined(__EMSCRIPTEN__)
+
+  // There is not yet a way to determine CPU count in emscripten JS environment.
+  pInfo->ProcessorCount = 1;
+  return WELS_THREAD_ERROR_OK;
+
 #else
 
   size_t len = sizeof (pInfo->ProcessorCount);


### PR DESCRIPTION
Currently the emscripten JavaScript environment for C/C++ programs cannot do multithreading, and doesn't have a sysctl implementation to get hardware CPU count. Hardcode to 1.

Builds using the Linux platform settings; to build with emscripten (tested 1.30.0):

  emmake make OS=linux ARCH=asmjs

The resulting libopenh264.so is LLVM bitcode which can be further linked into an emscripten project for final JavaScript output.