### PR TITLE
[Encoder] put pSliceBsBuffer to thread buffer rather than per slice, so as …

### DIFF
--- a/codec/encoder/core/inc/mt_defs.h
+++ b/codec/encoder/core/inc/mt_defs.h
@@ -87,6 +87,7 @@ int32_t*                        pSliceComplexRatio[MAX_DEPENDENCY_LAYER]; // *IN
 FILE*                           pFSliceDiff;    // file handle for debug
 #endif//MT_DEBUG
 
+uint8_t*                        pThreadBsBuffer[MAX_THREADS_NUM]; //actual memory for slice buffer
 } SSliceThreading;
 
 #endif//MULTIPLE_THREADING_DEFINES_H__

--- a/codec/encoder/core/inc/slice_multi_threading.h
+++ b/codec/encoder/core/inc/slice_multi_threading.h
@@ -100,6 +100,7 @@ void TrackSliceComplexities (sWelsEncCtx* pCtx, const int32_t kiCurDid);
 void TrackSliceConsumeTime (sWelsEncCtx* pCtx, int32_t* pDidList, const int32_t kiSpatialNum);
 #endif//defined(MT_DEBUG)
 
+void SetOneSliceBsBufferUnderMultithread(sWelsEncCtx* pCtx, const int32_t kiThreadIdx, const int32_t iSliceIdx);
 }
 
 #endif//SVC_SLICE_MULTIPLE_THREADING_H__

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -4061,9 +4061,9 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
                 // pick up succeeding slice for threading
                 // thread_id equal to iEventId per implementation here
                 pCtx->pSliceThreading->pThreadPEncCtx[iEventId].iSliceIndex = iIndexOfSliceToBeCoded;
+                SetOneSliceBsBufferUnderMultithread(pCtx, iEventId, iIndexOfSliceToBeCoded);
                 WelsEventSignal (&pCtx->pSliceThreading->pReadySliceCodingEvent[iEventId]);
                 WelsEventSignal (&pCtx->pSliceThreading->pThreadMasterEvent[iEventId]);
-
                 ++ iIndexOfSliceToBeCoded;
               } else { // no other slices left for coding
                 -- iNumThreadsRunning;


### PR DESCRIPTION
…to save memory usage

https://rbcommons.com/s/OpenH264/r/1252
put pSliceBsBuffer to thread buffer rather than per slice, so as to save memory usage
in some test, the change can save memory usage by 30% under SM_DYN_SLICE