### PR TITLE
[Encoder] let qp clip to min/max qp available in all rc settings

### DIFF
--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -506,10 +506,7 @@ void RcCalculatePictureQp (sWelsEncCtx* pEncCtx) {
 
     iLumaQp =  WELS_DIV_ROUND (iLumaQp * INT_MULTIPLY - pEncCtx->pVaa->sAdaptiveQuantParam.iAverMotionTextureIndexToDeltaQp,
                                INT_MULTIPLY);
-
-    if (! ((pEncCtx->pSvcParam->iRCMode == RC_BITRATE_MODE) && (pEncCtx->pSvcParam->bEnableFrameSkip == false)))
-      iLumaQp = WELS_CLIP3 (iLumaQp, pWelsSvcRc->iMinQp, pWelsSvcRc->iMaxQp);
-
+    iLumaQp = WELS_CLIP3 (iLumaQp, pWelsSvcRc->iMinQp, pWelsSvcRc->iMaxQp);
   }
   pEncCtx->iGlobalQp = iLumaQp;
 }


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/1260/
let qp clip to min/max qp available in all rc settings, so as to avoid qp exceed 51