### PR TITLE
Remove unnecessary tabs in the middle of lines

### DIFF
--- a/codec/encoder/core/inc/rc.h
+++ b/codec/encoder/core/inc/rc.h
@@ -272,7 +272,7 @@ PWelsCheckFrameSkipBasedMaxbrFunc pfWelsCheckSkipBasedMaxbr;
 PWelsUpdateBufferWhenFrameSkippedFunc pfWelsUpdateBufferWhenSkip;
 PWelsUpdateMaxBrCheckWindowStatusFunc pfWelsUpdateMaxBrWindowStatus;
 
-PWelsRCPostFrameSkippingFunc			pfWelsRcPostFrameSkipping;
+PWelsRCPostFrameSkippingFunc    pfWelsRcPostFrameSkipping;
 } SWelsRcFunc;
 
 bool CheckFrameSkipBasedMaxbr (sWelsEncCtx* pCtx, int32_t iSpatialNum, EVideoFrameType eFrameType,

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3670,16 +3670,16 @@ int32_t WriteSavcParaset_Listing (sWelsEncCtx* pCtx, const int32_t kiSpatialNum,
 void StackBackEncoderStatus (sWelsEncCtx* pEncCtx,
                              EVideoFrameType keFrameType) {
   // for bitstream writing
-  pEncCtx->iPosBsBuffer	 = 0;	// reset bs pBuffer position
-  pEncCtx->pOut->iNalIndex	 = 0;	// reset NAL index
+  pEncCtx->iPosBsBuffer      = 0;   // reset bs pBuffer position
+  pEncCtx->pOut->iNalIndex   = 0;   // reset NAL index
 
   InitBits (&pEncCtx->pOut->sBsWrite, pEncCtx->pOut->pBsBuffer, pEncCtx->pOut->uiSize);
   if ((keFrameType == videoFrameTypeP) || (keFrameType == videoFrameTypeI)) {
     pEncCtx->iFrameIndex --;
     if (pEncCtx->iPOC != 0) {
-      pEncCtx->iPOC	 -= 2;
+      pEncCtx->iPOC -= 2;
     } else {
-      pEncCtx->iPOC	= (1 << pEncCtx->pSps->iLog2MaxPocLsb) - 2;
+      pEncCtx->iPOC = (1 << pEncCtx->pSps->iLog2MaxPocLsb) - 2;
     }
 
     if (pEncCtx->eLastNalPriority != 0) {
@@ -3690,15 +3690,15 @@ void StackBackEncoderStatus (sWelsEncCtx* pEncCtx,
       }
     }
 
-    pEncCtx->eNalType	 = NAL_UNIT_CODED_SLICE;
-    pEncCtx->eSliceType	= P_SLICE;
-    pEncCtx->eNalPriority	= pEncCtx->eLastNalPriority;
+    pEncCtx->eNalType     = NAL_UNIT_CODED_SLICE;
+    pEncCtx->eSliceType   = P_SLICE;
+    pEncCtx->eNalPriority = pEncCtx->eLastNalPriority;
   } else if (keFrameType == videoFrameTypeIDR) {
     pEncCtx->uiIdrPicId --;
 
     //set the next frame to be IDR
     ForceCodingIDR (pEncCtx);
-  } else {	// B pictures are not supported now, any else?
+  } else { // B pictures are not supported now, any else?
     assert (0);
   }
 
@@ -3707,7 +3707,7 @@ void StackBackEncoderStatus (sWelsEncCtx* pEncCtx,
 }
 
 void ClearFrameBsInfo (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi) {
-  pFbi->sLayerInfo[0].pBsBuf	= pCtx->pFrameBs;
+  pFbi->sLayerInfo[0].pBsBuf           = pCtx->pFrameBs;
   pFbi->sLayerInfo[0].pNalLengthInByte = pCtx->pOut->pNalLen;
 
   for (int i = 0; i < pFbi->iLayerNum; i++) {

--- a/codec/encoder/core/src/mv_pred.cpp
+++ b/codec/encoder/core/src/mv_pred.cpp
@@ -305,8 +305,8 @@ void UpdateP8x8MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPart
 void UpdateP4x4MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPartIdx, const int8_t kiRef,
                            SMVUnitXY* pMv) {
   SMVComponentUnit* pMvComp = &pMbCache->sMvComponents;
-  const int16_t kiScan4Idx		= g_kuiMbCountScan4Idx[kiPartIdx];
-  const int16_t kiCacheIdx		= g_kuiCache30ScanIdx[kiPartIdx];
+  const int16_t kiScan4Idx  = g_kuiMbCountScan4Idx[kiPartIdx];
+  const int16_t kiCacheIdx  = g_kuiCache30ScanIdx[kiPartIdx];
 
   //mb
   pCurMb->sMv[kiScan4Idx] = *pMv;
@@ -318,8 +318,8 @@ void UpdateP4x4MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPart
 void UpdateP8x4MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPartIdx, const int8_t kiRef,
                            SMVUnitXY* pMv) {
   SMVComponentUnit* pMvComp = &pMbCache->sMvComponents;
-  const int16_t kiScan4Idx		= g_kuiMbCountScan4Idx[kiPartIdx];
-  const int16_t kiCacheIdx		= g_kuiCache30ScanIdx[kiPartIdx];
+  const int16_t kiScan4Idx  = g_kuiMbCountScan4Idx[kiPartIdx];
+  const int16_t kiCacheIdx  = g_kuiCache30ScanIdx[kiPartIdx];
 
   //mb
   pCurMb->sMv[    kiScan4Idx] = *pMv;
@@ -334,8 +334,8 @@ void UpdateP8x4MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPart
 void UpdateP4x8MotionInfo (SMbCache* pMbCache, SMB* pCurMb, const int32_t kiPartIdx, const int8_t kiRef,
                            SMVUnitXY* pMv) {
   SMVComponentUnit* pMvComp = &pMbCache->sMvComponents;
-  const int16_t kiScan4Idx		= g_kuiMbCountScan4Idx[kiPartIdx];
-  const int16_t kiCacheIdx		= g_kuiCache30ScanIdx[kiPartIdx];
+  const int16_t kiScan4Idx  = g_kuiMbCountScan4Idx[kiPartIdx];
+  const int16_t kiCacheIdx  = g_kuiCache30ScanIdx[kiPartIdx];
 
   //mb
   pCurMb->sMv[    kiScan4Idx] = *pMv;

--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -1127,9 +1127,9 @@ void  WelsRcPictureInfoUpdateDisable (sWelsEncCtx* pEncCtx, int32_t iLayerSize) 
 }
 
 void  WelsRcMbInitDisable (sWelsEncCtx* pEncCtx, SMB* pCurMb, SSlice* pSlice) {
-  int32_t iLumaQp					= pEncCtx->iGlobalQp;
+  int32_t iLumaQp = pEncCtx->iGlobalQp;
   SWelsSvcRc* pWelsSvcRc = &pEncCtx->pWelsSvcRc[pEncCtx->uiDependencyId];
-  SDqLayer* pCurLayer				= pEncCtx->pCurDqLayer;
+  SDqLayer* pCurLayer = pEncCtx->pCurDqLayer;
 
   const uint8_t kuiChromaQpIndexOffset = pCurLayer->sLayerInfo.pPpsP->uiChromaQpIndexOffset;
 
@@ -1149,7 +1149,7 @@ void  WelsRcMbInfoUpdateDisable (sWelsEncCtx* pEncCtx, SMB* pCurMb, int32_t iCos
 
 void WelRcPictureInitBufferBasedQp (sWelsEncCtx* pEncCtx, long long uiTimeStamp) {
 
-  SVAAFrameInfo* pVaa			= static_cast<SVAAFrameInfo*> (pEncCtx->pVaa);
+  SVAAFrameInfo* pVaa = static_cast<SVAAFrameInfo*> (pEncCtx->pVaa);
   SWelsSvcRc* pWelsSvcRc =  &pEncCtx->pWelsSvcRc[pEncCtx->uiDependencyId];
 
   int32_t iMinQp = MIN_SCREEN_QP;


### PR DESCRIPTION
At 6ff4ef3b38 all the (stray, mixed) tabs had been cleaned out from
the source code; remove newly added tabs and convert to spaces.

Review at https://rbcommons.com/s/OpenH264/r/1264/.