### PR TITLE
Make astyle convert tabs to spaces

### DIFF
--- a/build/astyle.cfg
+++ b/build/astyle.cfg
@@ -7,3 +7,4 @@
 --unpad-paren
 --pad-first-paren-out
 --lineend=linux
+--convert-tabs


### PR DESCRIPTION
Previously astyle only changed tabs to spaces if they were used for
indentation, but tabs in the middle of lines were left untouched.

Review at https://rbcommons.com/s/OpenH264/r/1265/.