### PR TITLE
bugfix for T1 error decoder dealing

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2416,8 +2416,10 @@ bool CheckAndFinishLastPic (PWelsDecoderContext pCtx, uint8_t** ppDst, SBufferIn
       pCtx->bFrameFinish = true; //clear frame pending status here!
     } else {
       if (DecodeFrameConstruction (pCtx, ppDst, pDstInfo)) {
-        if (pCtx->sLastNalHdrExt.sNalUnitHeader.uiNalRefIdc > 0)
+        if ((pCtx->sLastNalHdrExt.sNalUnitHeader.uiNalRefIdc > 0) && (pCtx->sLastNalHdrExt.uiTemporalId == 0))
           pCtx->iErrorCode |= dsNoParamSets;
+        else
+          pCtx->iErrorCode |= dsBitstreamError;
         pCtx->pDec = NULL;
         return false;
       }


### PR DESCRIPTION
Under no EC, when T1 data is not correctly decoded, should not reset the decoder. Just mark error is OK.
review request see:
https://rbcommons.com/s/OpenH264/r/1273/