### PR TITLE
prevent error RPLR number overflow case

### DIFF
--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -197,7 +197,8 @@ int32_t WelsReorderRefList (PWelsDecoderContext pCtx) {
   }
 
   if (pRefPicListReorderSyn->bRefPicListReorderingFlag[LIST_0]) {
-    while (pRefPicListReorderSyn->sReorderingSyn[LIST_0][iReorderingIndex].uiReorderingOfPicNumsIdc != 3) {
+    while ((iReorderingIndex < iMaxRefIdx)
+           && (pRefPicListReorderSyn->sReorderingSyn[LIST_0][iReorderingIndex].uiReorderingOfPicNumsIdc != 3)) {
       uint16_t uiReorderingOfPicNumsIdc =
         pRefPicListReorderSyn->sReorderingSyn[LIST_0][iReorderingIndex].uiReorderingOfPicNumsIdc;
       if (uiReorderingOfPicNumsIdc < 2) {


### PR DESCRIPTION
prevent RPLR erroneous bs overflow.
see:
https://rbcommons.com/s/OpenH264/r/1282/