### PR TITLE
bug-fixed----left length of destination buffer for writing slice bs

### DIFF
--- a/codec/encoder/core/src/slice_multi_threading.cpp
+++ b/codec/encoder/core/src/slice_multi_threading.cpp
@@ -764,7 +764,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
         WelsUnloadNalForSlice (pSliceBs);
 
         int32_t iLeftBufferSize = (iSliceIdx > 0) ?
-                                  (pSliceBs->uiSize - (int32_t) (pSliceBs->sBsWrite.pCurBuf - pSliceBs->sBsWrite.pStartBuf))
+                                  (pSliceBs->uiSize - pSliceBs->uiBsPos)
                                   : (pEncPEncCtx->iFrameBsSize - pEncPEncCtx->iPosBsBuffer);
         iReturn = WriteSliceBs (pEncPEncCtx, pSliceBs->pBs,
                                 &pSliceBs->iNalLen[0],
@@ -883,7 +883,7 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg) {
             pEncPEncCtx->iPosBsBuffer += iSliceSize;
           } else {
             iReturn = WriteSliceBs (pEncPEncCtx, pSliceBs->pBs, &pSliceBs->iNalLen[0],
-                                    pSliceBs->uiSize - (int32_t) (pSliceBs->sBsWrite.pCurBuf - pSliceBs->sBsWrite.pStartBuf),
+                                    pSliceBs->uiSize - pSliceBs->uiBsPos,
                                     iSliceIdx, iSliceSize);
             if (ENC_RETURN_SUCCESS != iReturn) {
               uiThrdRet = iReturn;


### PR DESCRIPTION
----bug-fixed----left length of destination buffer for writing  slice bs

----(pSliceBs->sBsWrite.pCurBuf point to the rawdata buffer which is different from destination buffer pSliceBs-pBs
    so the letf length parameter here is incorrect.
----this bug was expose when I tried to scale the MaxSliceBufferSize to 1/20

RCBoard link:https://rbcommons.com/s/OpenH264/r/1290/
