### PR TITLE
replace LayerBsInfo with FrameBsInfo in thread-based private data str…

### DIFF
--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -112,6 +112,7 @@ void WelsEncoderApplyFrameRate (SWelsSvcCodingParam* pParam);
 int32_t WelsEncoderApplyBitRate (SLogContext* pLogCtx, SWelsSvcCodingParam* pParam, int32_t iLayer);
 int32_t WelsEncoderApplyBitVaryRang(SLogContext* pLogCtx, SWelsSvcCodingParam* pParam, int32_t iRang);
 int32_t WelsEncoderApplyLTR (SLogContext* pLogCtx, sWelsEncCtx** ppCtx, SLTRConfig* pLTRValue);
+int32_t DynSliceRealloc(sWelsEncCtx* pCtx,SFrameBSInfo* pFrameBsInfo,SLayerBSInfo* pLayerBsInfo);
 int32_t FilterLTRRecoveryRequest (sWelsEncCtx* pCtx, SLTRRecoverRequest* pLTRRecoverRequest);
 void CheckProfileSetting (SLogContext* pLogCtx,SWelsSvcCodingParam* pParam,int32_t iLayer, EProfileIdc uiProfileIdc);
 void CheckLevelSetting (SLogContext* pLogCtx,SWelsSvcCodingParam* pParam,int32_t iLayer, ELevelIdc uiLevelIdc);

--- a/codec/encoder/core/inc/mt_defs.h
+++ b/codec/encoder/core/inc/mt_defs.h
@@ -57,7 +57,7 @@
 
 typedef struct TagSliceThreadPrivateData {
 void*           pWelsPEncCtx;
-SLayerBSInfo*   pLayerBs;
+SFrameBSInfo*   pFrameBsInfo;
 int32_t         iSliceIndex;    // slice index, zero based
 int32_t         iThreadIndex;   // thread index, zero based
 

--- a/codec/encoder/core/inc/nal_encap.h
+++ b/codec/encoder/core/inc/nal_encap.h
@@ -77,7 +77,7 @@ int32_t*        pNalLen;
 int32_t         iCountNals;             // count number of NAL in list
 // SVC: num_sps (MAX_D) + num_pps (MAX_D) + num_vcl (MAX_D * MAX_Q)
 int32_t         iNalIndex;              // coding NAL currently, 0 based
-
+int32_t         iLayerBsIndex;          // layer index of  bit stream for SFrameBsIfo
 // bool            bAnnexBFlag;            // annexeb flag, to figure it pOut the packetization mode whether need 4 bytes (0 0 0 1) of start code prefix
 } SWelsEncoderOutput;
 

--- a/codec/encoder/core/inc/slice_multi_threading.h
+++ b/codec/encoder/core/inc/slice_multi_threading.h
@@ -80,8 +80,8 @@ WELS_THREAD_ROUTINE_TYPE CodingSliceThreadProc (void* arg);
 int32_t CreateSliceThreads (sWelsEncCtx* pCtx);
 
 int32_t FiredSliceThreads (sWelsEncCtx* pCtx, SSliceThreadPrivateData* pPriData, WELS_EVENT* pEventsList,
-                           WELS_EVENT* pMasterEventsList, SLayerBSInfo* pLayerBsInfo,
-                           const uint32_t kuiNumThreads/*, int32_t *iLayerNum*/, SSliceCtx* pSliceCtx, const bool kbIsDynamicSlicingMode);
+                           WELS_EVENT* pMasterEventsList, SFrameBSInfo* pFrameBsInfo,
+                           const uint32_t kuiNumThreads, SSliceCtx* pSliceCtx, const bool kbIsDynamicSlicingMode);
 
 int32_t DynamicDetectCpuCores();
 

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -233,6 +233,7 @@ void InitFrameCoding (sWelsEncCtx* pEncCtx, const EVideoFrameType keFrameType) {
   // for bitstream writing
   pEncCtx->iPosBsBuffer         = 0;    // reset bs pBuffer position
   pEncCtx->pOut->iNalIndex      = 0;    // reset NAL index
+  pEncCtx->pOut->iLayerBsIndex  = 0;    // reset index of Layer Bs
 
   InitBits (&pEncCtx->pOut->sBsWrite, pEncCtx->pOut->pBsBuffer, pEncCtx->pOut->uiSize);
 


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/1295/

----for more easy operation on FrameBS data during multiple-thread encoding, replace
     LayerBsInfo with FrameBsInfo in thread-private data structure
----LayerBsInfo is part of FrameBsInfo with plus iLayerBsIndex in Ctx-pOut;

----it is for later dynamic re-allocate function in multi-thread encoding under slice mode 4
