### PR TITLE
Use stdbool.h with Visual Studio 2013 or higher

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -36,7 +36,7 @@
 #define WELS_VIDEO_CODEC_SVC_API_H__
 
 #ifndef __cplusplus
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 typedef unsigned char bool;
 #else
 #include <stdbool.h>


### PR DESCRIPTION
2013 is the first version to include the header.

Avoids "codec_api.h(40): error C2632: 'char' followed by 'bool' is illegal"
when building C code.