### PR TITLE
add new c and assembly functions to optimize downsampler when downscale equal 1:3/1:4

### DIFF
--- a/codec/processing/src/arm/down_sample_neon.S
+++ b/codec/processing/src/arm/down_sample_neon.S
@@ -338,4 +338,121 @@ _LAST_ROW_WIDTH:
     ldmia sp!, {r4-r12, lr}
 WELS_ASM_FUNC_END
 
+WELS_ASM_FUNC_BEGIN DyadicBilinearOneThirdDownsampler_neon
+    stmdb sp!, {r4-r8, lr}
+
+    //Get the width and height
+	ldr  r4, [sp, #24]  //src_width
+	ldr  r5, [sp, #28]	//src_height
+
+	//Initialize the register
+	mov r6, r2
+	mov r8, r0
+	mov lr, #0
+
+	//Save the tailer for the un-aligned size
+	mla  r7, r1, r5, r0
+	vld1.32 {q15}, [r7]
+
+	add r7, r2, r3
+	//processing a colume data
+comp_ds_bilinear_onethird_loop0:
+
+    vld3.8 {d0, d1, d2}, [r2]!
+    vld3.8 {d3, d4, d5}, [r2]!
+    vld3.8 {d16, d17, d18}, [r7]!
+    vld3.8 {d19, d20, d21}, [r7]!
+
+    vaddl.u8 q11, d0, d1
+    vaddl.u8 q12, d3, d4
+    vaddl.u8 q13, d16, d17
+    vaddl.u8 q14, d19, d20
+    vrshr.u16 q11, #1
+    vrshr.u16 q12, #1
+    vrshr.u16 q13, #1
+    vrshr.u16 q14, #1
+
+    vrhadd.u16 q11, q13
+    vrhadd.u16 q12, q14
+
+    vmovn.u16 d0, q11
+    vmovn.u16 d1, q12
+    vst1.8 {q0}, [r0]!
+
+    add lr, #48
+    cmp lr, r4
+    movcs lr, #0
+    addcs r6, r3, lsl #1
+    addcs r6, r6, r3
+    movcs r2, r6
+    addcs r7, r2, r3
+    addcs r8, r1
+    movcs r0, r8
+    subscs r5, #1
+    bne	comp_ds_bilinear_onethird_loop0
+
+	//restore the tailer for the un-aligned size
+	vst1.32 {q15}, [r0]
+
+    ldmia sp!, {r4-r8,lr}
+WELS_ASM_FUNC_END
+
+WELS_ASM_FUNC_BEGIN DyadicBilinearQuarterDownsampler_neon
+    stmdb sp!, {r4-r8, lr}
+
+    //Get the width and height
+	ldr  r4, [sp, #24]  //src_width
+	ldr  r5, [sp, #28]	//src_height
+
+	//Initialize the register
+	mov r6, r2
+	mov r8, r0
+	mov lr, #0
+	lsr r5, #2
+
+	//Save the tailer for the un-aligned size
+	mla  r7, r1, r5, r0
+	vld1.32 {q15}, [r7]
+
+	add r7, r2, r3
+	//processing a colume data
+comp_ds_bilinear_quarter_loop0:
+
+	vld2.16 {q0, q1}, [r2]!
+    vld2.16 {q2, q3}, [r2]!
+	vld2.16 {q8, q9}, [r7]!
+    vld2.16 {q10, q11}, [r7]!
+
+    vpaddl.u8 q0, q0
+    vpaddl.u8 q2, q2
+    vpaddl.u8 q8, q8
+    vpaddl.u8 q10, q10
+    vrshr.u16 q0, #1
+    vrshr.u16 q2, #1
+    vrshr.u16 q8, #1
+    vrshr.u16 q10, #1
+
+    vrhadd.u16 q0, q8
+    vrhadd.u16 q2, q10
+    vmovn.u16 d0, q0
+    vmovn.u16 d1, q2
+    vst1.8 {q0}, [r0]!
+
+    add lr, #64
+    cmp lr, r4
+    movcs lr, #0
+    addcs r6, r3, lsl #2
+    movcs r2, r6
+    addcs r7, r2, r3
+    addcs r8, r1
+    movcs r0, r8
+    subscs r5, #1
+    bne	comp_ds_bilinear_quarter_loop0
+
+	//restore the tailer for the un-aligned size
+	vst1.32 {q15}, [r0]
+
+    ldmia sp!, {r4-r8,lr}
+WELS_ASM_FUNC_END
+
 #endif

--- a/codec/processing/src/arm64/down_sample_aarch64_neon.S
+++ b/codec/processing/src/arm64/down_sample_aarch64_neon.S
@@ -84,7 +84,6 @@ comp_ds_bilinear_loop0:
 
 WELS_ASM_AARCH64_FUNC_END
 
-
 WELS_ASM_AARCH64_FUNC_BEGIN DyadicBilinearDownsamplerWidthx32_AArch64_neon
     sub     w9, w3, w4
     sub     w1, w1, w4, lsr #1
@@ -121,6 +120,113 @@ comp_ds_bilinear_w_x32_loop1:
     add     x0, x0, w1, sxtw
     sub     w5, w5, #1
     cbnz    w5, comp_ds_bilinear_w_x32_loop0
+WELS_ASM_AARCH64_FUNC_END
+
+WELS_ASM_AARCH64_FUNC_BEGIN DyadicBilinearOneThirdDownsampler_AArch64_neon
+
+    //Initialize the register
+    mov x6, x2
+    mov x8, x0
+    mov w9, #0
+
+    //Save the tailer   for the unasigned   size
+    smaddl  x7, w1, w5, x0
+    ld1 {v16.16b}, [x7]
+
+    add x7, x2, w3, sxtw
+    //processing a colume   data
+comp_ds_bilinear_onethird_loop0:
+
+    ld3     {v0.16b, v1.16b, v2.16b}, [x2], #48
+    ld3     {v4.16b, v5.16b, v6.16b}, [x7], #48
+
+    uaddl   v2.8h, v0.8b, v1.8b
+    uaddl2  v3.8h, v0.16b, v1.16b
+    uaddl   v6.8h, v4.8b, v5.8b
+    uaddl2  v7.8h, v4.16b, v5.16b
+    urshr   v2.8h, v2.8h, #1
+    urshr   v3.8h, v3.8h, #1
+    urshr   v6.8h, v6.8h, #1
+    urshr   v7.8h, v7.8h, #1
+
+    urhadd  v0.8h, v2.8h, v6.8h
+    urhadd  v1.8h, v3.8h, v7.8h
+    xtn     v0.8b, v0.8h
+    xtn     v1.8b, v1.8h
+    st1     {v0.8b,v1.8b}, [x0], #16
+
+    add     w9, w9, #48
+
+    cmp     w9, w4
+    b.cc    comp_ds_bilinear_onethird_loop0
+
+    mov     w9, #0
+    add     x6, x6, w3, sxtw #1
+    add     x6, x6, w3, sxtw
+    mov     x2, x6
+    add     x7, x2, w3, sxtw
+    add     x8, x8, w1, sxtw
+    mov     x0, x8
+    sub     w5, w5, #1
+
+    cbnz    w5, comp_ds_bilinear_onethird_loop0
+
+    //restore   the tailer for the unasigned size
+    st1     {v16.16b}, [x0]
+WELS_ASM_AARCH64_FUNC_END
+
+WELS_ASM_AARCH64_FUNC_BEGIN DyadicBilinearQuarterDownsampler_AArch64_neon
+    //Initialize the register
+    mov x6, x2
+    mov x8, x0
+    mov w9, #0
+    lsr w5, w5, #2
+
+    //Save the tailer   for the unasigned   size
+    smaddl  x7, w1, w5, x0
+    ld1 {v16.16b}, [x7]
+
+    add x7, x2, w3, sxtw
+    //processing a colume   data
+comp_ds_bilinear_quarter_loop0:
+
+    ld2     {v0.8h, v1.8h}, [x2], #32
+    ld2     {v2.8h, v3.8h}, [x2], #32
+    ld2     {v4.8h, v5.8h}, [x7], #32
+    ld2     {v6.8h, v7.8h}, [x7], #32
+
+    uaddlp  v0.8h, v0.16b
+    uaddlp  v1.8h, v2.16b
+    uaddlp  v4.8h, v4.16b
+    uaddlp  v5.8h, v6.16b
+    urshr   v0.8h, v0.8h, #1
+    urshr   v1.8h, v1.8h, #1
+    urshr   v4.8h, v4.8h, #1
+    urshr   v5.8h, v5.8h, #1
+
+    urhadd  v0.8h, v0.8h, v4.8h
+    urhadd  v1.8h, v1.8h, v5.8h
+    xtn     v0.8b, v0.8h
+    xtn     v1.8b, v1.8h
+    st1     {v0.8b,v1.8b}, [x0], #16
+
+    add     w9, w9, #64
+
+    cmp     w9, w4
+    b.cc    comp_ds_bilinear_quarter_loop0
+
+    mov     w9, #0
+    add     x6, x6, w3, sxtw #2
+    mov     x2, x6
+    add     x7, x2, w3, sxtw
+    add     x8, x8, w1, sxtw
+    mov     x0, x8
+    sub     w5, w5, #1
+
+    cbnz    w5, comp_ds_bilinear_quarter_loop0
+
+    //restore   the tailer for the unasigned size
+    st1     {v16.16b}, [x0]
 WELS_ASM_AARCH64_FUNC_END
 
 WELS_ASM_AARCH64_FUNC_BEGIN GeneralBilinearAccurateDownsampler_AArch64_neon

--- a/codec/processing/src/downsample/downsample.h
+++ b/codec/processing/src/downsample/downsample.h
@@ -54,20 +54,29 @@ typedef void (HalveDownsampleFunc) (uint8_t* pDst, const int32_t kiDstStride,
                                     uint8_t* pSrc, const int32_t kiSrcStride,
                                     const int32_t kiSrcWidth, const int32_t kiSrcHeight);
 
+typedef void (SpecificDownsampleFunc) (uint8_t* pDst, const int32_t kiDstStride,
+                                       uint8_t* pSrc, const int32_t kiSrcStride,
+                                       const int32_t kiSrcWidth, const int32_t kiHeight);
+
 typedef void (GeneralDownsampleFunc) (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth,
                                       const int32_t kiDstHeight,
                                       uint8_t* pSrc, const int32_t kiSrcStride, const int32_t kiSrcWidth, const int32_t kiSrcHeight);
 
 typedef HalveDownsampleFunc*    PHalveDownsampleFunc;
+typedef SpecificDownsampleFunc* PSpecificDownsampleFunc;
 typedef GeneralDownsampleFunc*  PGeneralDownsampleFunc;
 
-HalveDownsampleFunc   DyadicBilinearDownsampler_c;
+HalveDownsampleFunc		DyadicBilinearDownsampler_c;
 GeneralDownsampleFunc GeneralBilinearFastDownsampler_c;
 GeneralDownsampleFunc GeneralBilinearAccurateDownsampler_c;
+SpecificDownsampleFunc  DyadicBilinearOneThirdDownsampler_c;
+SpecificDownsampleFunc	DyadicBilinearQuarterDownsampler_c;
 
 typedef struct {
   // align_index: 0 = x32; 1 = x16; 2 = x8; 3 = common case left;
   PHalveDownsampleFunc          pfHalfAverage[4];
+  PSpecificDownsampleFunc       pfOneThirdDownsampler;
+  PSpecificDownsampleFunc       pfQuarterDownsampler;
   PGeneralDownsampleFunc        pfGeneralRatioLuma;
   PGeneralDownsampleFunc        pfGeneralRatioChroma;
 } SDownsampleFuncs;
@@ -93,10 +102,19 @@ HalveDownsampleFunc     DyadicBilinearDownsamplerWidthx32_sse4;
 GeneralDownsampleFunc GeneralBilinearFastDownsamplerWrap_sse2;
 GeneralDownsampleFunc GeneralBilinearAccurateDownsamplerWrap_sse2;
 
+SpecificDownsampleFunc  DyadicBilinearOneThirdDownsampler_ssse3;
+SpecificDownsampleFunc  DyadicBilinearOneThirdDownsampler_sse4;
+SpecificDownsampleFunc  DyadicBilinearQuarterDownsampler_sse;
+SpecificDownsampleFunc  DyadicBilinearQuarterDownsampler_ssse3;
+SpecificDownsampleFunc  DyadicBilinearQuarterDownsampler_sse4;
+
 void GeneralBilinearFastDownsampler_sse2 (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth,
-    const int32_t kiDstHeight, uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX, const uint32_t kuiScaleY);
+    const int32_t kiDstHeight, uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX,
+    const uint32_t kuiScaleY);
 void GeneralBilinearAccurateDownsampler_sse2 (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth,
-    const int32_t kiDstHeight, uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX, const uint32_t kuiScaleY);
+    const int32_t kiDstHeight, uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX,
+    const uint32_t kuiScaleY);
+
 WELSVP_EXTERN_C_END
 #endif
 
@@ -108,6 +126,10 @@ HalveDownsampleFunc     DyadicBilinearDownsampler_neon;
 HalveDownsampleFunc     DyadicBilinearDownsamplerWidthx32_neon;
 
 GeneralDownsampleFunc   GeneralBilinearAccurateDownsamplerWrap_neon;
+
+SpecificDownsampleFunc  DyadicBilinearOneThirdDownsampler_neon;
+
+SpecificDownsampleFunc  DyadicBilinearQuarterDownsampler_neon;
 
 void GeneralBilinearAccurateDownsampler_neon (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth,
     const int32_t kiDstHeight,
@@ -125,8 +147,13 @@ HalveDownsampleFunc     DyadicBilinearDownsamplerWidthx32_AArch64_neon;
 
 GeneralDownsampleFunc   GeneralBilinearAccurateDownsamplerWrap_AArch64_neon;
 
-void GeneralBilinearAccurateDownsampler_AArch64_neon (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth, const int32_t kiDstHeight,
-                                                      uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX, const uint32_t kuiScaleY);
+SpecificDownsampleFunc  DyadicBilinearOneThirdDownsampler_AArch64_neon;
+
+SpecificDownsampleFunc  DyadicBilinearQuarterDownsampler_AArch64_neon;
+
+void GeneralBilinearAccurateDownsampler_AArch64_neon (uint8_t* pDst, const int32_t kiDstStride,
+    const int32_t kiDstWidth, const int32_t kiDstHeight,
+    uint8_t* pSrc, const int32_t kiSrcStride, const uint32_t kuiScaleX, const uint32_t kuiScaleY);
 
 WELSVP_EXTERN_C_END
 #endif

--- a/codec/processing/src/downsample/downsamplefuncs.cpp
+++ b/codec/processing/src/downsample/downsamplefuncs.cpp
@@ -68,6 +68,53 @@ void DyadicBilinearDownsampler_c (uint8_t* pDst, const int32_t kiDstStride,
   }
 }
 
+void DyadicBilinearQuarterDownsampler_c (uint8_t* pDst, const int32_t kiDstStride,
+    uint8_t* pSrc, const int32_t kiSrcStride,
+    const int32_t kiSrcWidth, const int32_t kiSrcHeight)
+
+{
+  uint8_t* pDstLine     = pDst;
+  uint8_t* pSrcLine     = pSrc;
+  const int32_t kiSrcStridex4   = kiSrcStride << 2;
+  const int32_t kiDstWidth      = kiSrcWidth  >> 2;
+  const int32_t kiDstHeight     = kiSrcHeight >> 2;
+
+  for (int32_t j = 0; j < kiDstHeight; j ++) {
+    for (int32_t i = 0; i < kiDstWidth; i ++) {
+      const int32_t kiSrcX = i << 2;
+      const int32_t kiTempRow1 = (pSrcLine[kiSrcX] + pSrcLine[kiSrcX + 1] + 1) >> 1;
+      const int32_t kiTempRow2 = (pSrcLine[kiSrcX + kiSrcStride] + pSrcLine[kiSrcX + kiSrcStride + 1] + 1) >> 1;
+
+      pDstLine[i] = (uint8_t) ((kiTempRow1 + kiTempRow2 + 1) >> 1);
+    }
+    pDstLine    += kiDstStride;
+    pSrcLine    += kiSrcStridex4;
+  }
+}
+
+void DyadicBilinearOneThirdDownsampler_c (uint8_t* pDst, const int32_t kiDstStride,
+    uint8_t* pSrc, const int32_t kiSrcStride,
+    const int32_t kiSrcWidth, const int32_t kiDstHeight)
+
+{
+  uint8_t* pDstLine     = pDst;
+  uint8_t* pSrcLine     = pSrc;
+  const int32_t kiSrcStridex3   = kiSrcStride * 3;
+  const int32_t kiDstWidth      = kiSrcWidth / 3;
+
+  for (int32_t j = 0; j < kiDstHeight; j ++) {
+    for (int32_t i = 0; i < kiDstWidth; i ++) {
+      const int32_t kiSrcX = i * 3;
+      const int32_t kiTempRow1 = (pSrcLine[kiSrcX] + pSrcLine[kiSrcX + 1] + 1) >> 1;
+      const int32_t kiTempRow2 = (pSrcLine[kiSrcX + kiSrcStride] + pSrcLine[kiSrcX + kiSrcStride + 1] + 1) >> 1;
+
+      pDstLine[i] = (uint8_t) ((kiTempRow1 + kiTempRow2 + 1) >> 1);
+    }
+    pDstLine    += kiDstStride;
+    pSrcLine    += kiSrcStridex3;
+  }
+}
+
 void GeneralBilinearFastDownsampler_c (uint8_t* pDst, const int32_t kiDstStride, const int32_t kiDstWidth,
                                        const int32_t kiDstHeight,
                                        uint8_t* pSrc, const int32_t kiSrcStride, const int32_t kiSrcWidth, const int32_t kiSrcHeight) {

--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -2512,7 +2512,7 @@ const uint32_t kiHeight = 96; //DO NOT CHANGE!
 const uint32_t kiFrameRate = 12; //DO NOT CHANGE!
 const uint32_t kiFrameNum = 100; //DO NOT CHANGE!
 const char* pHashStr[] = { //DO NOT CHANGE!
-  "058076b265686fc85b2b99cf7a53106f216f16c3",
+  "585663f78cadb70d9c9f179b9b53b90ffddf3178",
   "f350001c333902029800bd291fbed915a4bdf19a",
   "eb9d853b7daec03052c4850027ac94adc84c3a7e"
 };

--- a/test/processing/ProcessUT_DownSample.cpp
+++ b/test/processing/ProcessUT_DownSample.cpp
@@ -199,6 +199,79 @@ TEST (DownSampleTest, func) { \
   } \
 }
 
+#define GENERATE_DyadicBilinearOneThirdDownsampler_UT(func, ASM, CPUFLAGS) \
+TEST (DownSampleTest, func) { \
+  if (ASM) {\
+    int32_t iCpuCores = 0; \
+    uint32_t m_uiCpuFeatureFlag = WelsCPUFeatureDetect (&iCpuCores); \
+    if (0 == (m_uiCpuFeatureFlag & CPUFLAGS)) \
+    return; \
+  } \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, dst_c, 50000, 16); \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, src_c, 50000, 16); \
+  int dst_stride_c; \
+  int src_stride_c; \
+  int src_width_c; \
+  int src_height_c; \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, dst_a, 50000, 16); \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, src_a, 50000, 16); \
+  int dst_stride_a; \
+  int src_stride_a; \
+  int src_width_a; \
+  int src_height_a; \
+  dst_stride_c = dst_stride_a = 560; \
+  src_stride_c = src_stride_a = 560; \
+  src_width_c = src_width_a = 480; \
+  src_height_c = src_height_a = 30; \
+  for (int j = 0; j < 50000; j++) { \
+    dst_c[j] = dst_a[j] = rand() % 256; \
+    src_c[j] = src_a[j] = rand() % 256; \
+  } \
+  DyadicBilinearOneThirdDownsampler_c (dst_c, dst_stride_c, src_c, src_stride_c, src_width_c, src_height_c/3); \
+  func (dst_a, dst_stride_a, src_a, src_stride_a, src_width_a, src_height_a/3); \
+  for (int j = 0; j < (src_height_c /3 ); j++) { \
+    for (int m = 0; m < (src_width_c /3); m++) { \
+      ASSERT_EQ (dst_c[m + j * dst_stride_c], dst_a[m + j * dst_stride_a]); \
+    } \
+  } \
+}
+
+#define GENERATE_DyadicBilinearQuarterDownsampler_UT(func, ASM, CPUFLAGS) \
+TEST (DownSampleTest, func) { \
+  if (ASM) {\
+    int32_t iCpuCores = 0; \
+    uint32_t m_uiCpuFeatureFlag = WelsCPUFeatureDetect (&iCpuCores); \
+    if (0 == (m_uiCpuFeatureFlag & CPUFLAGS)) \
+    return; \
+  } \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, dst_c, 50000, 16); \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, src_c, 50000, 16); \
+  int dst_stride_c; \
+  int src_stride_c; \
+  int src_width_c; \
+  int src_height_c; \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, dst_a, 50000, 16); \
+  ENFORCE_STACK_ALIGN_1D (uint8_t, src_a, 50000, 16); \
+  int dst_stride_a; \
+  int src_stride_a; \
+  int src_width_a; \
+  int src_height_a; \
+  dst_stride_c = dst_stride_a = 560; \
+  src_stride_c = src_stride_a = 560; \
+  src_width_c = src_width_a = 640; \
+  src_height_c = src_height_a = 80; \
+  for (int j = 0; j < 50000; j++) { \
+    dst_c[j] = dst_a[j] = rand() % 256; \
+    src_c[j] = src_a[j] = rand() % 256; \
+  } \
+  DyadicBilinearQuarterDownsampler_c (dst_c, dst_stride_c, src_c, src_stride_c, src_width_c, src_height_c); \
+  func (dst_a, dst_stride_a, src_a, src_stride_a, src_width_a, src_height_a); \
+  for (int j = 0; j < (src_height_c >> 2); j++) { \
+    for (int m = 0; m < (src_width_c >> 2); m++) { \
+      ASSERT_EQ (dst_c[m + j * dst_stride_c], dst_a[m + j * dst_stride_a]); \
+    } \
+  } \
+}
 #define GENERATE_GeneralBilinearDownsampler_UT(func, ref, ASM, CPUFLAGS) \
 TEST (DownSampleTest, func) { \
   if (ASM) {\
@@ -259,6 +332,13 @@ GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsamplerWidthx16_ssse3, 
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsamplerWidthx32_sse4, 1, WELS_CPU_SSE41)
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsamplerWidthx16_sse4, 1, WELS_CPU_SSE41)
 
+GENERATE_DyadicBilinearOneThirdDownsampler_UT (DyadicBilinearOneThirdDownsampler_ssse3, 1, WELS_CPU_SSSE3)
+GENERATE_DyadicBilinearOneThirdDownsampler_UT (DyadicBilinearOneThirdDownsampler_sse4, 1, WELS_CPU_SSE41)
+
+GENERATE_DyadicBilinearQuarterDownsampler_UT (DyadicBilinearQuarterDownsampler_sse, 1, WELS_CPU_SSE)
+GENERATE_DyadicBilinearQuarterDownsampler_UT (DyadicBilinearQuarterDownsampler_ssse3, 1, WELS_CPU_SSSE3)
+GENERATE_DyadicBilinearQuarterDownsampler_UT (DyadicBilinearQuarterDownsampler_sse4, 1, WELS_CPU_SSE41)
+
 GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearFastDownsamplerWrap_sse2, GeneralBilinearFastDownsampler_ref, 1,
                                         WELS_CPU_SSE2)
 GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearAccurateDownsamplerWrap_sse2,
@@ -269,6 +349,10 @@ GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearAccurateDownsamplerWrap_s
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsamplerWidthx32_neon, 1, WELS_CPU_NEON)
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsampler_neon, 1, WELS_CPU_NEON)
 
+GENERATE_DyadicBilinearOneThirdDownsampler_UT (DyadicBilinearOneThirdDownsampler_neon, 1, WELS_CPU_NEON)
+
+GENERATE_DyadicBilinearQuarterDownsampler_UT (DyadicBilinearQuarterDownsampler_neon, 1, WELS_CPU_NEON)
+
 GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearAccurateDownsamplerWrap_neon,
                                         GeneralBilinearAccurateDownsampler_ref, 1, WELS_CPU_NEON)
 #endif
@@ -276,6 +360,10 @@ GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearAccurateDownsamplerWrap_n
 #if defined(HAVE_NEON_AARCH64)
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsamplerWidthx32_AArch64_neon, 1, WELS_CPU_NEON)
 GENERATE_DyadicBilinearDownsampler_UT (DyadicBilinearDownsampler_AArch64_neon, 1, WELS_CPU_NEON)
+
+GENERATE_DyadicBilinearOneThirdDownsampler_UT (DyadicBilinearOneThirdDownsampler_AArch64_neon, 1, WELS_CPU_NEON)
+
+GENERATE_DyadicBilinearQuarterDownsampler_UT (DyadicBilinearQuarterDownsampler_AArch64_neon, 1, WELS_CPU_NEON)
 
 GENERATE_GeneralBilinearDownsampler_UT (GeneralBilinearAccurateDownsamplerWrap_AArch64_neon,
                                         GeneralBilinearAccurateDownsampler_ref, 1, WELS_CPU_NEON)


### PR DESCRIPTION
add new c and assembly functions to optimize downsampler when downscale equal 1:3/1:4. 
https://rbcommons.com/s/OpenH264/r/1293/diff/4-7/