### PR TITLE
[Encoder] fix a simulcast case for 3 spatial layers

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3116,8 +3116,6 @@ void PreprocessSliceCoding (sWelsEncCtx* pCtx) {
 
 static inline void WelsSwapDqLayers (sWelsEncCtx* pCtx, const int32_t kiNextDqIdx) {
   // swap and assign reference
-  const int32_t kiDid           = pCtx->uiDependencyId;
-
   SDqLayer* pTmpLayer           = pCtx->ppDqLayerList[kiNextDqIdx];
   SDqLayer* pRefLayer           = pCtx->pCurDqLayer;
   pCtx->pCurDqLayer             = pTmpLayer;


### PR DESCRIPTION
Add fix for simulcast if frame rate in the middle spatial layer is smaller