### PR TITLE
correct a typo along with the in-plan v1.5 release

### DIFF
--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -80,7 +80,7 @@ typedef enum {
 typedef enum {
   cmResultSuccess,          ///< successful
   cmInitParaError,          ///< parameters are invalid
-  cmUnkonwReason,
+  cmUnknownReason,
   cmMallocMemeError,        ///< malloc a memory error
   cmInitExpected,           ///< initial action is expected
   cmUnsupportedData


### PR DESCRIPTION
reviewed: https://rbcommons.com/s/OpenH264/r/1327/
for https://github.com/cisco/openh264/issues/2046