### PR TITLE
Revert an accidental change that broke MSVC compilation

### DIFF
--- a/codec/common/src/crt_util_safe_x.cpp
+++ b/codec/common/src/crt_util_safe_x.cpp
@@ -75,8 +75,8 @@ int32_t WelsSnprintf (char* pBuffer,  int32_t iSizeOfBuffer, const char* kpForma
   return iRc;
 }
 
-char* WelsStrncpy (char* pDest, uint32_t uiSizeInBytes, const char* kpSrc) {
-  strncpy_s (pDest, uiSizeInBytes, kpSrc, _TRUNCATE);
+char* WelsStrncpy (char* pDest, int32_t iSizeInBytes, const char* kpSrc) {
+  strncpy_s (pDest, iSizeInBytes, kpSrc, _TRUNCATE);
 
   return pDest;
 }


### PR DESCRIPTION
This reverts an unrelated part of e7e3b4f37f0.

Since the function still is declared as taking an int32_t parameter
in the header, changing the function implementation makes it end
up as a different function.

Review at https://rbcommons.com/s/OpenH264/r/1331/.