### PR TITLE
Remove UBSAN warnings about negative left shift

### DIFF
--- a/codec/common/src/deblocking_common.cpp
+++ b/codec/common/src/deblocking_common.cpp
@@ -21,14 +21,14 @@ void DeblockLumaLt4_c (uint8_t* pPix, int32_t iStrideX, int32_t iStrideY, int32_
         bool bDetaP2P0 =  WELS_ABS (p2 - p0) < iBeta;
         bool bDetaQ2Q0 =  WELS_ABS (q2 - q0) < iBeta;
         if (bDetaP2P0) {
-          pPix[-2 * iStrideX] = p1 + WELS_CLIP3 ((p2 + ((p0 + q0 + 1) >> 1) - (p1 << 1)) >> 1, -iTc0, iTc0);
+          pPix[-2 * iStrideX] = p1 + WELS_CLIP3 ((p2 + ((p0 + q0 + 1) >> 1) - (p1 * (1 << 1))) >> 1, -iTc0, iTc0);
           iTc++;
         }
         if (bDetaQ2Q0) {
-          pPix[iStrideX] = q1 + WELS_CLIP3 ((q2 + ((p0 + q0 + 1) >> 1) - (q1 << 1)) >> 1, -iTc0, iTc0);
+          pPix[iStrideX] = q1 + WELS_CLIP3 ((q2 + ((p0 + q0 + 1) >> 1) - (q1 * (1 << 1))) >> 1, -iTc0, iTc0);
           iTc++;
         }
-        int32_t iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc, iTc);
+        int32_t iDeta = WELS_CLIP3 ((((q0 - p0) * (1 << 2)) + (p1 - q1) + 4) >> 3, -iTc, iTc);
         pPix[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPix[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
       }
@@ -56,23 +56,23 @@ void DeblockLumaEq4_c (uint8_t* pPix, int32_t iStrideX, int32_t iStrideY, int32_
         bool bDetaQ2Q0 =  WELS_ABS (q2 - q0) < iBeta;
         if (bDetaP2P0) {
           const int32_t p3 = pPix[-4 * iStrideX];
-          pPix[-iStrideX] = (p2 + (p1 << 1) + (p0 << 1) + (q0 << 1) + q1 + 4) >> 3;   //p0
+          pPix[-iStrideX] = (p2 + (p1 * (1 << 1)) + (p0 * (1 << 1)) + (q0 * (1 << 1)) + q1 + 4) >> 3;   //p0
           pPix[-2 * iStrideX] = (p2 + p1 + p0 + q0 + 2) >> 2;                         //p1
-          pPix[-3 * iStrideX] = ((p3 << 1) + p2 + (p2 << 1) + p1 + p0 + q0 + 4) >> 3; //p2
+          pPix[-3 * iStrideX] = ((p3 * (1 << 1)) + p2 + (p2 * (1 << 1)) + p1 + p0 + q0 + 4) >> 3; //p2
         } else {
-          pPix[-1 * iStrideX] = ((p1 << 1) + p0 + q1 + 2) >> 2;                       //p0
+          pPix[-1 * iStrideX] = ((p1 * (1 << 1)) + p0 + q1 + 2) >> 2;                       //p0
         }
         if (bDetaQ2Q0) {
           const int32_t q3 = pPix[3 * iStrideX];
-          pPix[0] = (p1 + (p0 << 1) + (q0 << 1) + (q1 << 1) + q2 + 4) >> 3;           //q0
+          pPix[0] = (p1 + (p0 * (1 << 1)) + (q0 * (1 << 1)) + (q1 * (1 << 1)) + q2 + 4) >> 3;           //q0
           pPix[iStrideX] = (p0 + q0 + q1 + q2 + 2) >> 2;                              //q1
-          pPix[2 * iStrideX] = ((q3 << 1) + q2 + (q2 << 1) + q1 + q0 + p0 + 4) >> 3;  //q2
+          pPix[2 * iStrideX] = ((q3 * (1 << 1)) + q2 + (q2 * (1 << 1)) + q1 + q0 + p0 + 4) >> 3;  //q2
         } else {
-          pPix[0] = ((q1 << 1) + q0 + p1 + 2) >> 2;                                   //q0
+          pPix[0] = ((q1 * (1 << 1)) + q0 + p1 + 2) >> 2;                                   //q0
         }
       } else {
-        pPix[-iStrideX] = ((p1 << 1) + p0 + q1 + 2) >> 2;   //p0
-        pPix[ 0] = ((q1 << 1) + q0 + p1 + 2) >> 2;          //q0
+        pPix[-iStrideX] = ((p1 * (1 << 1)) + p0 + q1 + 2) >> 2;   //p0
+        pPix[ 0] = ((q1 * (1 << 1)) + q0 + p1 + 2) >> 2;          //q0
       }
     }
     pPix += iStrideY;
@@ -107,7 +107,7 @@ void DeblockChromaLt4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
       bDetaP1P0 =  WELS_ABS (p1 - p0) < iBeta;
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
       if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-        iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
+        iDeta = WELS_CLIP3 ((((q0 - p0) * (1 << 2)) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCb[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCb[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
       }
@@ -123,7 +123,7 @@ void DeblockChromaLt4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
 
       if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-        iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
+        iDeta = WELS_CLIP3 ((((q0 - p0) * (1 << 2)) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCr[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCr[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
       }
@@ -146,8 +146,8 @@ void DeblockChromaEq4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
     bDetaP1P0 = WELS_ABS (p1 - p0) < iBeta;
     bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
     if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-      pPixCb[-iStrideX] = ((p1 << 1) + p0 + q1 + 2) >> 2;     /* p0' */
-      pPixCb[0]  = ((q1 << 1) + q0 + p1 + 2) >> 2;     /* q0' */
+      pPixCb[-iStrideX] = ((p1 * (1 << 1)) + p0 + q1 + 2) >> 2;     /* p0' */
+      pPixCb[0]  = ((q1 * (1 << 1)) + q0 + p1 + 2) >> 2;     /* q0' */
     }
 
     //cr
@@ -159,8 +159,8 @@ void DeblockChromaEq4_c (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iStrideX, int
     bDetaP1P0 = WELS_ABS (p1 - p0) < iBeta;
     bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
     if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-      pPixCr[-iStrideX] = ((p1 << 1) + p0 + q1 + 2) >> 2;     /* p0' */
-      pPixCr[0]  = ((q1 << 1) + q0 + p1 + 2) >> 2;     /* q0' */
+      pPixCr[-iStrideX] = ((p1 * (1 << 1)) + p0 + q1 + 2) >> 2;     /* p0' */
+      pPixCr[0]  = ((q1 * (1 << 1)) + q0 + p1 + 2) >> 2;     /* q0' */
     }
     pPixCr += iStrideY;
     pPixCb += iStrideY;
@@ -198,7 +198,7 @@ void DeblockChromaLt42_c (uint8_t* pPixCbCr, int32_t iStrideX, int32_t iStrideY,
       bDetaP1P0 =  WELS_ABS (p1 - p0) < iBeta;
       bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
       if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-        iDeta = WELS_CLIP3 ((((q0 - p0) << 2) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
+        iDeta = WELS_CLIP3 ((((q0 - p0) * (1 << 2)) + (p1 - q1) + 4) >> 3, -iTc0, iTc0);
         pPixCbCr[-iStrideX] = WelsClip1 (p0 + iDeta);     /* p0' */
         pPixCbCr[0]  = WelsClip1 (q0 - iDeta);     /* q0' */
       }
@@ -221,8 +221,8 @@ void DeblockChromaEq42_c (uint8_t* pPixCbCr, int32_t iStrideX, int32_t iStrideY,
     bDetaP1P0 = WELS_ABS (p1 - p0) < iBeta;
     bDetaQ1Q0 = WELS_ABS (q1 - q0) < iBeta;
     if (bDetaP0Q0 && bDetaP1P0 && bDetaQ1Q0) {
-      pPixCbCr[-iStrideX] = ((p1 << 1) + p0 + q1 + 2) >> 2;     /* p0' */
-      pPixCbCr[0]  = ((q1 << 1) + q0 + p1 + 2) >> 2;     /* q0' */
+      pPixCbCr[-iStrideX] = ((p1 * (1 << 1)) + p0 + q1 + 2) >> 2;     /* p0' */
+      pPixCbCr[0]  = ((q1 * (1 << 1)) + q0 + p1 + 2) >> 2;     /* q0' */
     }
 
     pPixCbCr += iStrideY;

--- a/codec/decoder/core/src/error_concealment.cpp
+++ b/codec/decoder/core/src/error_concealment.cpp
@@ -224,23 +224,23 @@ void DoMbECMvCopy (PWelsDecoderContext pCtx, PPicture pDec, PPicture pRef, int32
       iPicHeightBottomLimit = (pMCRefMem->iPicHeight - pCtx->sFrameCrop.iTopOffset * 2);
     }
     // further make sure no need to expand picture
-    int32_t iMinLeftOffset = (iPicWidthLeftLimit + 2) << 2;
-    int32_t iMaxRightOffset = ((iPicWidthRightLimit - 19) << 2);
-    int32_t iMinTopOffset = (iPicHeightTopLimit + 2) << 2;
-    int32_t iMaxBottomOffset = ((iPicHeightBottomLimit - 19) << 2);
+    int32_t iMinLeftOffset = (iPicWidthLeftLimit + 2) * (1 << 2);
+    int32_t iMaxRightOffset = ((iPicWidthRightLimit - 19) * (1 << 2));
+    int32_t iMinTopOffset = (iPicHeightTopLimit + 2) * (1 << 2);
+    int32_t iMaxBottomOffset = ((iPicHeightBottomLimit - 19) * (1 << 2));
     if (iFullMVx < iMinLeftOffset) {
-      iFullMVx = (iFullMVx >> 2) << 2;
+      iFullMVx = (iFullMVx >> 2) * (1 << 2);
       iFullMVx = WELS_MAX (iPicWidthLeftLimit, iFullMVx);
     } else if (iFullMVx > iMaxRightOffset) {
-      iFullMVx = (iFullMVx >> 2) << 2;
-      iFullMVx = WELS_MIN (((iPicWidthRightLimit - 17) << 2), iFullMVx);
+      iFullMVx = (iFullMVx >> 2) * (1 << 2);
+      iFullMVx = WELS_MIN (((iPicWidthRightLimit - 17) * (1 << 2)), iFullMVx);
     }
     if (iFullMVy < iMinTopOffset) {
-      iFullMVy = (iFullMVy >> 2) << 2;
+      iFullMVy = (iFullMVy >> 2) * (1 << 2);
       iFullMVy = WELS_MAX (iPicHeightTopLimit, iFullMVy);
     } else if (iFullMVy > iMaxBottomOffset) {
-      iFullMVy = (iFullMVy >> 2) << 2;
-      iFullMVy = WELS_MIN (((iPicHeightBottomLimit - 17) << 2), iFullMVy);
+      iFullMVy = (iFullMVy >> 2) * (1 << 2);
+      iFullMVy = WELS_MIN (((iPicHeightBottomLimit - 17) * (1 << 2)), iFullMVy);
     }
     iMVs[0] = iFullMVx - (iMbXInPix << 2);
     iMVs[1] = iFullMVy - (iMbYInPix << 2);

--- a/codec/decoder/core/src/parse_mb_syn_cabac.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cabac.cpp
@@ -889,7 +889,7 @@ int32_t ParseResidualBlockCabac8x8 (PWelsNeighAvail pNeighAvail, uint8_t* pNonZe
     do {
       if (pSignificantMap[j] != 0) {
         i = pScanTable[ j ];
-        sTCoeff[i] = uiQp >= 36 ? ((pSignificantMap[j] * pDeQuantMul[i]) << (uiQp / 6 - 6)) : ((
+        sTCoeff[i] = uiQp >= 36 ? ((pSignificantMap[j] * pDeQuantMul[i]) * (1 << (uiQp / 6 - 6))) : ((
                        pSignificantMap[j] * pDeQuantMul[i] + (1 << (5 - uiQp / 6))) >> (6 - uiQp / 6));
       }
       ++j;

--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -981,7 +981,7 @@ int32_t WelsResidualBlockCavlc8x8 (SVlcTable* pVlcTable, uint8_t* pNonZeroCountC
     iCoeffNum += iRun[i] + 1; //FIXME add 1 earlier ?
     j = (iCoeffNum << 2) + iIdx4x4;
     j          = kpZigzagTable[ j ];
-    pTCoeff[j] = uiQp >= 36 ? ((iLevel[i] * kpDequantCoeff[j]) << (uiQp / 6 - 6))
+    pTCoeff[j] = uiQp >= 36 ? ((iLevel[i] * kpDequantCoeff[j]) * (1 << (uiQp / 6 - 6)))
                  : ((iLevel[i] * kpDequantCoeff[j] + (1 << (5 - uiQp / 6))) >> (6 - uiQp / 6));
   }
 

--- a/codec/decoder/core/src/rec_mb.cpp
+++ b/codec/decoder/core/src/rec_mb.cpp
@@ -243,8 +243,8 @@ void BaseMC (sMCRefMember* pMCRefMem, int32_t iXOffset, int32_t iYOffset, SMcFun
              int32_t iBlkWidth, int32_t iBlkHeight, int16_t iMVs[2]) {
   int32_t iFullMVx = (iXOffset << 2) + iMVs[0]; //quarter pixel
   int32_t iFullMVy = (iYOffset << 2) + iMVs[1];
-  iFullMVx = WELS_CLIP3 (iFullMVx, ((-PADDING_LENGTH + 2) << 2), ((pMCRefMem->iPicWidth + PADDING_LENGTH - 19) << 2));
-  iFullMVy = WELS_CLIP3 (iFullMVy, ((-PADDING_LENGTH + 2) << 2), ((pMCRefMem->iPicHeight + PADDING_LENGTH - 19) << 2));
+  iFullMVx = WELS_CLIP3 (iFullMVx, ((-PADDING_LENGTH + 2) * (1 << 2)), ((pMCRefMem->iPicWidth + PADDING_LENGTH - 19) * (1 << 2)));
+  iFullMVy = WELS_CLIP3 (iFullMVy, ((-PADDING_LENGTH + 2) * (1 << 2)), ((pMCRefMem->iPicHeight + PADDING_LENGTH - 19) * (1 << 2)));
 
   int32_t iSrcPixOffsetLuma = (iFullMVx >> 2) + (iFullMVy >> 2) * pMCRefMem->iSrcLineLuma;
   int32_t iSrcPixOffsetChroma = (iFullMVx >> 3) + (iFullMVy >> 3) * pMCRefMem->iSrcLineChroma;

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -215,8 +215,8 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
 
     SUsedPicRect.iLeft = 0;
     SUsedPicRect.iTop  = 0;
-    SUsedPicRect.iWidth = ((iPicWidth >> 1) << 1);
-    SUsedPicRect.iHeight = ((iPicHeight >> 1) << 1);
+    SUsedPicRect.iWidth = ((iPicWidth >> 1) * (1 << 1));
+    SUsedPicRect.iHeight = ((iPicHeight >> 1) * (1 << 1));
 
     iRCMode = pCodingParam.iRCMode;    // rc mode
 

--- a/codec/encoder/core/inc/svc_motion_estimate.h
+++ b/codec/encoder/core/inc/svc_motion_estimate.h
@@ -336,10 +336,10 @@ inline void SetMvWithinIntegerMvRange (const int32_t kiMbWidth, const int32_t ki
                                        const int32_t kiMbY,
                                        const int32_t kiMaxMvRange,
                                        SMVUnitXY* pMvMin, SMVUnitXY* pMvMax) {
-pMvMin->iMvX = WELS_MAX (-1 * ((kiMbX + 1) << 4) + INTPEL_NEEDED_MARGIN, -1 * kiMaxMvRange);
-pMvMin->iMvY = WELS_MAX (-1 * ((kiMbY + 1) << 4) + INTPEL_NEEDED_MARGIN, -1 * kiMaxMvRange);
-pMvMax->iMvX = WELS_MIN (((kiMbWidth - kiMbX) << 4) - INTPEL_NEEDED_MARGIN, kiMaxMvRange);
-pMvMax->iMvY = WELS_MIN (((kiMbHeight - kiMbY) << 4) - INTPEL_NEEDED_MARGIN, kiMaxMvRange);
+pMvMin->iMvX = WELS_MAX (-1 * ((kiMbX + 1) * (1 << 4)) + INTPEL_NEEDED_MARGIN, -1 * kiMaxMvRange);
+pMvMin->iMvY = WELS_MAX (-1 * ((kiMbY + 1) * (1 << 4)) + INTPEL_NEEDED_MARGIN, -1 * kiMaxMvRange);
+pMvMax->iMvX = WELS_MIN (((kiMbWidth - kiMbX) * (1 << 4)) - INTPEL_NEEDED_MARGIN, kiMaxMvRange);
+pMvMax->iMvY = WELS_MIN (((kiMbHeight - kiMbY) * (1 << 4)) - INTPEL_NEEDED_MARGIN, kiMaxMvRange);
 }
 
 inline bool CheckMvInRange (const SMVUnitXY ksCurrentMv, const SMVUnitXY ksMinMv, const SMVUnitXY ksMaxMv) {

--- a/codec/encoder/core/src/encode_mb_aux.cpp
+++ b/codec/encoder/core/src/encode_mb_aux.cpp
@@ -333,8 +333,8 @@ void WelsDctT4_c (int16_t* pDct, uint8_t* pPixel1, int32_t iStride1, uint8_t* pP
 
     pDct[i ]   = s[0] + s[1];
     pDct[kiI2] = s[0] - s[1];
-    pDct[kiI1] = (s[3] << 1) + s[2];
-    pDct[kiI3] = s[3] - (s[2] << 1);
+    pDct[kiI1] = (s[3] * (1 << 1)) + s[2];
+    pDct[kiI3] = s[3] - (s[2] * (1 << 1));
   }
 
   /* vertical transform */
@@ -350,8 +350,8 @@ void WelsDctT4_c (int16_t* pDct, uint8_t* pPixel1, int32_t iStride1, uint8_t* pP
 
     pDct[i  ]   = s[0] + s[1];
     pDct[kiI8 ] = s[0] - s[1];
-    pDct[kiI4 ] = (s[3] << 1) + s[2];
-    pDct[kiI12] = s[3] - (s[2] << 1);
+    pDct[kiI4 ] = (s[3] * (1 << 1)) + s[2];
+    pDct[kiI12] = s[3] - (s[2] * (1 << 1));
   }
 }
 

--- a/codec/encoder/core/src/set_mb_syn_cavlc.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cavlc.cpp
@@ -165,7 +165,7 @@ int32_t  WriteBlockResidualCavlc (SWelsFuncPtrList* pFuncList, int16_t* pCoffLev
   for (i = iTrailingOnes; i < iTotalCoeffs; i++) {
     int32_t iVal = iLevel[i];
 
-    iLevelCode = (iVal - 1) << 1;
+    iLevelCode = (iVal - 1) * (1 << 1);
     uiSign = (iLevelCode >> 31);
     iLevelCode = (iLevelCode ^ uiSign) + (uiSign << 1);
     iLevelCode -= ((i == iTrailingOnes) && (iTrailingOnes < 3)) << 1;

--- a/codec/encoder/core/src/svc_mode_decision.cpp
+++ b/codec/encoder/core/src/svc_mode_decision.cpp
@@ -133,8 +133,8 @@ void SetMvBaseEnhancelayer (SWelsMD* pMd, SMB* pCurMb, const SMB* kpRefMb) {
     SMVUnitXY sMv;
     int32_t iRefMbPartIdx = ((pCurMb->iMbY & 0x01) << 1) + (pCurMb->iMbX & 0x01); //may be need modified
     int32_t iScan4RefPartIdx = g_kuiMbCountScan4Idx[ (iRefMbPartIdx << 2)];
-    sMv.iMvX = kpRefMb->sMv[iScan4RefPartIdx].iMvX << 1;
-    sMv.iMvY = kpRefMb->sMv[iScan4RefPartIdx].iMvY << 1;
+    sMv.iMvX = kpRefMb->sMv[iScan4RefPartIdx].iMvX * (1 << 1);
+    sMv.iMvY = kpRefMb->sMv[iScan4RefPartIdx].iMvY * (1 << 1);
 
     pMd->sMe.sMe16x16.sMvBase = sMv;
 

--- a/codec/encoder/core/src/svc_motion_estimate.cpp
+++ b/codec/encoder/core/src/svc_motion_estimate.cpp
@@ -65,8 +65,8 @@ static inline void UpdateMeResults (const SMVUnitXY ksBestMv, const uint32_t kiB
 }
 static inline void MeEndIntepelSearch (SWelsME* pMe) {
   /* -> qpel mv */
-  pMe->sMv.iMvX <<= 2;
-  pMe->sMv.iMvY <<= 2;
+  pMe->sMv.iMvX *= (1 << 2);
+  pMe->sMv.iMvY *= (1 << 2);
   pMe->uiSatdCost = pMe->uiSadCost;
 }
 
@@ -194,7 +194,7 @@ void WelsMotionEstimateSearchScrolled (SWelsFuncPtrList* pFuncList, SDqLayer* pC
   pMe->pRefMb = pMe->pColoRefMb + pMe->sMv.iMvY * kiStrideRef + pMe->sMv.iMvX;
   pMe->uiSadCost =
     pFuncList->sSampleDealingFuncs.pfSampleSad[pMe->uiBlockSize] (pMe->pEncMb, kiStrideEnc, pMe->pRefMb, kiStrideRef)
-    + COST_MVD (pMe->pMvdCost, (pMe->sMv.iMvX << 2) - pMe->sMvp.iMvX, (pMe->sMv.iMvY << 2) - pMe->sMvp.iMvY);
+    + COST_MVD (pMe->pMvdCost, (pMe->sMv.iMvX * (1 << 2)) - pMe->sMvp.iMvX, (pMe->sMv.iMvY * (1 << 2)) - pMe->sMvp.iMvY);
   MeEndIntepelSearch (pMe);
   pFuncList->pfCalculateSatd (pFuncList->sSampleDealingFuncs.pfSampleSatd[pMe->uiBlockSize], pMe, kiStrideEnc,
                               kiStrideRef);
@@ -235,7 +235,7 @@ bool WelsMotionEstimateInitialPoint (SWelsFuncPtrList* pFuncList, SWelsME* pMe, 
   pRefMb = &pMe->pRefMb[sMv.iMvY * iStrideRef + sMv.iMvX];
 
   iBestSadCost = pSad (kpEncMb, iStrideEnc, pRefMb, iStrideRef);
-  iBestSadCost += COST_MVD (kpMvdCost, ((sMv.iMvX) << 2) - ksMvp.iMvX, ((sMv.iMvY) << 2) - ksMvp.iMvY);
+  iBestSadCost += COST_MVD (kpMvdCost, ((sMv.iMvX) * (1 << 2)) - ksMvp.iMvX, ((sMv.iMvY) * (1 << 2)) - ksMvp.iMvY);
 
   for (i = 0; i < kuiMvcNum; i++) {
     //clipping here is essential since some pOut-of-range MVC may happen here (i.e., refer to baseMV)
@@ -246,7 +246,7 @@ bool WelsMotionEstimateInitialPoint (SWelsFuncPtrList* pFuncList, SWelsME* pMe, 
       pFref2 = &pMe->pRefMb[iMvc1 * iStrideRef + iMvc0];
 
       iSadCost = pSad (kpEncMb, iStrideEnc, pFref2, iStrideRef) +
-                 COST_MVD (kpMvdCost, (iMvc0 << 2) - ksMvp.iMvX, (iMvc1 << 2) - ksMvp.iMvY);
+                 COST_MVD (kpMvdCost, (iMvc0 * (1 << 2)) - ksMvp.iMvX, (iMvc1 * (1 << 2)) - ksMvp.iMvY);
 
       if (iSadCost < iBestSadCost) {
         sMv.iMvX = iMvc0;
@@ -333,8 +333,8 @@ void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, SWelsME* pMe, SSlice* pSlic
   const SMVUnitXY ksMvStartMin    = pSlice->sMvStartMin;
   const SMVUnitXY ksMvStartMax    = pSlice->sMvStartMax;
 
-  int32_t iMvDx = ((pMe->sMv.iMvX) << 2) - pMe->sMvp.iMvX;
-  int32_t iMvDy = ((pMe->sMv.iMvY) << 2) - pMe->sMvp.iMvY;
+  int32_t iMvDx = ((pMe->sMv.iMvX) * (1 << 2)) - pMe->sMvp.iMvX;
+  int32_t iMvDy = ((pMe->sMv.iMvY) * (1 << 2)) - pMe->sMvp.iMvY;
 
   uint8_t* pRefMb = pFref;
   int32_t iBestCost = (pMe->uiSadCost);
@@ -355,8 +355,8 @@ void WelsDiamondSearch (SWelsFuncPtrList* pFuncList, SWelsME* pMe, SSlice* pSlic
     if (kbIsBestCostWorse)
       break;
 
-    iMvDx -= iX << 2 ;
-    iMvDy -= iY << 2 ;
+    iMvDx -= (iX * (1 << 2)) ;
+    iMvDy -= (iY * (1 << 2)) ;
 
     pRefMb -= (iX + iY * kiStrideRef);
 
@@ -384,7 +384,7 @@ bool CheckDirectionalMv (PSampleSadSatdCostFunc pSad, SWelsME* pMe,
       && CheckMvInRange (pMe->sDirectionalMv, ksMinMv, ksMaxMv)) {
     uint8_t* pRef = &pMe->pColoRefMb[kiMvY * kiRefStride + kiMvX];
     uint32_t uiCurrentSadCost = pSad (pMe->pEncMb, kiEncStride,  pRef, kiRefStride) +
-                                COST_MVD (pMe->pMvdCost, (kiMvX << 2) - pMe->sMvp.iMvX, (kiMvY << 2) - pMe->sMvp.iMvY);
+                                COST_MVD (pMe->pMvdCost, (kiMvX * (1 << 2)) - pMe->sMvp.iMvX, (kiMvY * (1 << 2)) - pMe->sMvp.iMvY);
     if (uiCurrentSadCost < pMe->uiSadCost) {
       iBestSadCost = uiCurrentSadCost;
       return true;
@@ -405,7 +405,7 @@ bool CheckDirectionalMvFalse (PSampleSadSatdCostFunc pSad, SWelsME* vpMe,
 #if defined (X86_ASM)
 void CalcMvdCostx8_c (uint16_t* pMvdCost, const int32_t kiStartMv, uint16_t* pMvdTable, const uint16_t kiFixedCost) {
   uint16_t* pBaseCost  = pMvdCost;
-  const int32_t kiOffset = (kiStartMv << 2);
+  const int32_t kiOffset = (kiStartMv * (1 << 2));
   uint16_t* pMvd  = pMvdTable + kiOffset;
   for (int32_t i = 0; i < 8; ++ i) {
     pBaseCost[i] = ((*pMvd) + kiFixedCost);
@@ -426,7 +426,7 @@ void VerticalFullSearchUsingSSE41 (SWelsFuncPtrList* pFuncList, SWelsME* pMe,
   int32_t iMinPos = kiCurMeBlockPixY + kiMinMv;
   int32_t iMaxPos = kiCurMeBlockPixY + kiMaxMv;
   int32_t iFixedMvd = * (pMvdTable - pMe->sMvp.iMvX);
-  uint16_t* pMvdCost  = & (pMvdTable[ (kiMinMv << 2) - pMe->sMvp.iMvY]);
+  uint16_t* pMvdCost  = & (pMvdTable[ (kiMinMv * (1 << 2)) - pMe->sMvp.iMvY]);
   int16_t iStartMv = 0;
 
 
@@ -476,7 +476,7 @@ void VerticalFullSearchUsingSSE41 (SWelsFuncPtrList* pFuncList, SWelsME* pMe,
     kpEncMb = pMe->pEncMb;
     pRef = &pMe->pColoRefMb[ (iTargetPos - kiCurMeBlockPix) * kiRefStride];
     while (iTargetPos < iMaxPos) {
-      const uint16_t uiMvdCost = pMvdCost[iStartMv << 2];
+      const uint16_t uiMvdCost = pMvdCost[iStartMv * (1 << 2)];
       uint32_t uiSadCost = pSad (kpEncMb, kiEncStride, pRef, kiRefStride) + (iFixedMvd + uiMvdCost);
       if (uiSadCost < uiBestCost) {
         uiBestCost = uiSadCost;
@@ -506,7 +506,7 @@ void HorizontalFullSearchUsingSSE41 (SWelsFuncPtrList* pFuncList, SWelsME* pMe,
   int32_t iMinPos = iCurMeBlockPixX + kiMinMv;
   int32_t iMaxPos = iCurMeBlockPixX + kiMaxMv;
   int32_t iFixedMvd = * (pMvdTable - pMe->sMvp.iMvY);
-  uint16_t* pMvdCost  = & (pMvdTable[ (kiMinMv << 2) - pMe->sMvp.iMvX]);
+  uint16_t* pMvdCost  = & (pMvdTable[ (kiMinMv * (1 << 2)) - pMe->sMvp.iMvX]);
   int16_t iStartMv = 0;
   uint8_t* pRef         = &pMe->pColoRefMb[kiMinMv];
   const int32_t kIsBlock16x16 = pMe->uiBlockSize == BLOCK_16x16;
@@ -536,7 +536,7 @@ void HorizontalFullSearchUsingSSE41 (SWelsFuncPtrList* pFuncList, SWelsME* pMe,
   }
   if (kiRemainingLoop8 > 0) {
     while (iTargetPos < iMaxPos) {
-      const uint16_t uiMvdCost = pMvdCost[iStartMv << 2];
+      const uint16_t uiMvdCost = pMvdCost[iStartMv * (1 << 2)];
       uint32_t uiSadCost = pSad (kpEncMb, kiEncStride, pRef, kiRefStride) + (iFixedMvd + uiMvdCost);
       if (uiSadCost < uiBestCost) {
         uiBestCost = uiSadCost;
@@ -575,14 +575,14 @@ void LineFullSearch_c (SWelsFuncPtrList* pFuncList, SWelsME* pMe,
     iFixedMvd = * (pMvdTable - pMe->sMvp.iMvX);
     iCurMeBlockPix = pMe->iCurMeBlockPixY;
     iStride = kiRefStride;
-    pMvdCost  = & (pMvdTable[ (iMinMv << 2) - pMe->sMvp.iMvY]);
+    pMvdCost  = & (pMvdTable[ (iMinMv * (1 << 2)) - pMe->sMvp.iMvY]);
   } else {
     iMinPos = kiCurMeBlockPixX + iMinMv;
     iMaxPos = kiCurMeBlockPixX + iMaxMv;
     iFixedMvd = * (pMvdTable - pMe->sMvp.iMvY);
     iCurMeBlockPix = pMe->iCurMeBlockPixX;
     iStride = 1;
-    pMvdCost  = & (pMvdTable[ (iMinMv << 2) - pMe->sMvp.iMvX]);
+    pMvdCost  = & (pMvdTable[ (iMinMv * (1 << 2)) - pMe->sMvp.iMvX]);
   }
   uint8_t* pRef            = &pMe->pColoRefMb[ iMinMv * iStride];
   uint32_t uiBestCost    = 0xFFFFFFFF;
@@ -906,10 +906,10 @@ bool SetFeatureSearchIn (SWelsFuncPtrList* pFunc,  const SWelsME& sMe,
   pFeatureSearchIn->pMvdCostX = sMe.pMvdCost - pFeatureSearchIn->iCurPixXQpel - sMe.sMvp.iMvX;
   pFeatureSearchIn->pMvdCostY = sMe.pMvdCost - pFeatureSearchIn->iCurPixYQpel - sMe.sMvp.iMvY;
 
-  pFeatureSearchIn->iMinQpelX = pFeatureSearchIn->iCurPixXQpel + ((pSlice->sMvStartMin.iMvX) << 2);
-  pFeatureSearchIn->iMinQpelY = pFeatureSearchIn->iCurPixYQpel + ((pSlice->sMvStartMin.iMvY) << 2);
-  pFeatureSearchIn->iMaxQpelX = pFeatureSearchIn->iCurPixXQpel + ((pSlice->sMvStartMax.iMvX) << 2);
-  pFeatureSearchIn->iMaxQpelY = pFeatureSearchIn->iCurPixYQpel + ((pSlice->sMvStartMax.iMvY) << 2);
+  pFeatureSearchIn->iMinQpelX = pFeatureSearchIn->iCurPixXQpel + ((pSlice->sMvStartMin.iMvX) * (1 << 2));
+  pFeatureSearchIn->iMinQpelY = pFeatureSearchIn->iCurPixYQpel + ((pSlice->sMvStartMin.iMvY) * (1 << 2));
+  pFeatureSearchIn->iMaxQpelX = pFeatureSearchIn->iCurPixXQpel + ((pSlice->sMvStartMax.iMvX) * (1 << 2));
+  pFeatureSearchIn->iMaxQpelY = pFeatureSearchIn->iCurPixYQpel + ((pSlice->sMvStartMax.iMvY) * (1 << 2));
 
   if (NULL == pFeatureSearchIn->pSad || NULL == pFeatureSearchIn->pTimesOfFeature
       || NULL == pFeatureSearchIn->pQpelLocationOfFeature) {

--- a/test/decoder/DecUT_DeblockCommon.cpp
+++ b/test/decoder/DecUT_DeblockCommon.cpp
@@ -122,7 +122,7 @@ void anchor_DeblockingLumaNormal (uint8_t* pPix, int32_t iStrideX, int32_t iStri
         iTc++;
       }
       // 8-467,468,469
-      iDelta = WELS_CLIP3 (((((q[0] - p[0]) << 2) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
+      iDelta = WELS_CLIP3 (((((q[0] - p[0]) * (1 << 2)) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
       pPix[iStrideX * -1] = WELS_CLIP3 ((p[0] + iDelta), 0, 255);
       pPix[0] = WELS_CLIP3 ((q[0] - iDelta), 0, 255);
     }
@@ -194,7 +194,7 @@ void anchor_DeblockingChromaNormal (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iS
     // filterSampleFlag, 8-460
     if (abs (p[0] - q[0]) < iAlpha && abs (p[1] - p[0]) < iBeta && abs (q[1] - q[0]) < iBeta) {
       // 8-467, 468, 469
-      iDelta = WELS_CLIP3 (((((q[0] - p[0]) << 2) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
+      iDelta = WELS_CLIP3 (((((q[0] - p[0]) * (1 << 2)) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
       pPixCb[iStrideX * -1] = WELS_CLIP3 ((p[0] + iDelta), 0, 255);
       pPixCb[iStrideX * 0 ] = WELS_CLIP3 ((q[0] - iDelta), 0, 255);
     }
@@ -209,7 +209,7 @@ void anchor_DeblockingChromaNormal (uint8_t* pPixCb, uint8_t* pPixCr, int32_t iS
     // filterSampleFlag, 8-460
     if (abs (p[0] - q[0]) < iAlpha && abs (p[1] - p[0]) < iBeta && abs (q[1] - q[0]) < iBeta) {
       // 8-467, 468, 469
-      iDelta = WELS_CLIP3 (((((q[0] - p[0]) << 2) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
+      iDelta = WELS_CLIP3 (((((q[0] - p[0]) * (1 << 2)) + (p[1] - q[1]) + 4) >> 3), -1 * iTc, iTc);
       pPixCr[iStrideX * -1] = WELS_CLIP3 ((p[0] + iDelta), 0, 255);
       pPixCr[iStrideX * 0 ] = WELS_CLIP3 ((q[0] - iDelta), 0, 255);
     }


### PR DESCRIPTION
See code review at: https://rbcommons.com/s/OpenH264/r/1330/
Using "A * (1 << i)" instead of "A << i" when A is negative