### PR TITLE
Add protection for unsigned int output

### DIFF
--- a/codec/decoder/core/inc/dec_golomb.h
+++ b/codec/decoder/core/inc/dec_golomb.h
@@ -179,7 +179,7 @@ static inline uint32_t BsGetUe (PBitStringAux pBs, uint32_t* pCode) {
     DUMP_BITS (pBs->uiCurBits, pBs->pCurBuf, pBs->iLeftBits, iLeadingZeroBits, iAllowedBytes, iReadBytes);
   }
 
-  *pCode = ((1 << iLeadingZeroBits) - 1 + iValue);
+  *pCode = ((1u << iLeadingZeroBits) - 1 + iValue);
   return ERR_NONE;
 }
 

--- a/codec/decoder/core/src/cabac_decoder.cpp
+++ b/codec/decoder/core/src/cabac_decoder.cpp
@@ -273,8 +273,8 @@ int32_t DecodeExpBypassCabac (PWelsCabacDecEngine pDecEngine, int32_t iCount, ui
       iSymTmp += (1 << iCount);
       ++iCount;
     }
-  } while (uiCode != 0 && iCount != 31);
-  if (iCount == 31) {
+  } while (uiCode != 0 && iCount != 16);
+  if (iCount == 16) {
     return ERR_CABAC_UNEXPECTED_VALUE;
   }
 


### PR DESCRIPTION
See code review at: https://rbcommons.com/s/OpenH264/r/1339/
(1) add protection for golomb GetUe output value
(2) change the max length of cabac bypass to 16