### PR TITLE
Remove unused STL includes

### DIFF
--- a/codec/common/src/WelsThreadPool.cpp
+++ b/codec/common/src/WelsThreadPool.cpp
@@ -39,9 +39,6 @@
  */
 
 
-#include <list>
-#include <map>
-
 #include "typedefs.h"
 #include "WelsThreadPool.h"
 


### PR DESCRIPTION
This fixes building for Android, where libopenh264.so is intended
not to link to any particular STL implementation.

Review at https://rbcommons.com/s/OpenH264/r/1340/.