### PR TITLE
Add a missing include of stdlib.h

### DIFF
--- a/codec/common/inc/WelsCircleQueue.h
+++ b/codec/common/inc/WelsCircleQueue.h
@@ -43,6 +43,7 @@
 #define _WELS_CIRCLE_QUEUE_H_
 
 #include "typedefs.h"
+#include <stdlib.h>
 
 namespace WelsCommon {
 


### PR DESCRIPTION
This is required for malloc in this header.

This fixes building for Windows Phone.

Review at https://rbcommons.com/s/OpenH264/r/1343/.