### PR TITLE
change the AbsDiffPicNumMinus1 check logic

### DIFF
--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -637,6 +637,13 @@ void WelsUpdateRefSyntax (sWelsEncCtx* pCtx, const int32_t iPOC, const int32_t u
   if (pCtx->iNumRef0 > 0)
     iAbsDiffPicNumMinus1 = pCtx->iFrameNum - (pCtx->pRefList0[0]->iFrameNum) - 1;
 
+  if (iAbsDiffPicNumMinus1 < 0) {
+    WelsLog(&(pCtx->sLogCtx), WELS_LOG_INFO, "WelsUpdateRefSyntax():::uiAbsDiffPicNumMinus1:%d", iAbsDiffPicNumMinus1);
+    iAbsDiffPicNumMinus1 += (1 << (pCtx->pSps->uiLog2MaxFrameNum));
+    WelsLog(&(pCtx->sLogCtx), WELS_LOG_INFO, "WelsUpdateRefSyntax():::uiAbsDiffPicNumMinus1< 0, update as:%d",
+             iAbsDiffPicNumMinus1);
+  }
+
   for (iIdx = 0; iIdx < kiCountSliceNum; iIdx++) {
     SSliceHeaderExt*    pSliceHdrExt        = &pCtx->pCurDqLayer->sLayerInfo.pSliceInLayer[iIdx].sSliceHeaderExt;
     SSliceHeader*       pSliceHdr           = &pSliceHdrExt->sSliceHeader;
@@ -647,12 +654,6 @@ void WelsUpdateRefSyntax (sWelsEncCtx* pCtx, const int32_t iPOC, const int32_t u
     pSliceHdr->uiRefCount = pCtx->iNumRef0;
     if (pCtx->iNumRef0 > 0) {
       if ((!pCtx->pRefList0[0]->bIsLongRef) || (!pCtx->pSvcParam->bEnableLongTermReference)) {
-        if (iAbsDiffPicNumMinus1 < 0) {
-          WelsLog (& (pCtx->sLogCtx), WELS_LOG_INFO, "WelsUpdateRefSyntax():::uiAbsDiffPicNumMinus1:%d", iAbsDiffPicNumMinus1);
-          iAbsDiffPicNumMinus1 += (1 << (pCtx->pSps->uiLog2MaxFrameNum));
-          WelsLog (& (pCtx->sLogCtx), WELS_LOG_INFO, "WelsUpdateRefSyntax():::uiAbsDiffPicNumMinus1< 0, update as:%d",
-                   iAbsDiffPicNumMinus1);
-        }
 
         pRefReorder->SReorderingSyntax[0].uiReorderingOfPicNumsIdc = 0;
         pRefReorder->SReorderingSyntax[0].uiAbsDiffPicNumMinus1    = iAbsDiffPicNumMinus1;


### PR DESCRIPTION

1. change  the check position for iAbsDiffPicNumMinus1

  ----1). iAbsDiffPicNumMinus1 = pCtx->iFrameNum - (pCtx->pRefList0[0]->iFrameNum) - 1;

        here iAbsDiffPicNumMinus1 is larger  -2^15 + 1 (1 << (pCtx->pSps->uiLog2MaxFrameNum -1)
   
  ----2). if (iAbsDiffPicNumMinus1 < 0) 
           iAbsDiffPicNumMinus1 += (1 << (pCtx->pSps->uiLog2MaxFrameNum));
           
           
        here this line will only called one time 
    
        so no need to put it in the loop for the checking 

2. code review:

https://rbcommons.com/s/OpenH264/r/1348/diff/1#index_header