### PR TITLE
Avoid warnings in the cabac code

### DIFF
--- a/codec/encoder/core/inc/set_mb_syn_cabac.h
+++ b/codec/encoder/core/inc/set_mb_syn_cabac.h
@@ -76,7 +76,7 @@ typedef struct TagCabacCtx {
 void WelsCabacContextInit (void* pCtx, SCabacCtx* pCbCtx, int32_t iModel);
 void WelsCabacEncodeInit (SCabacCtx* pCbCtx, uint8_t* pBuf,  uint8_t* pEnd);
 inline void WelsCabacEncodeDecision (SCabacCtx* pCbCtx, int32_t iCtx, uint32_t uiBin);
-inline void WelsCabacEncodeBypassOne (SCabacCtx* pCbCtx, uint32_t uiBin);
+inline void WelsCabacEncodeBypassOne (SCabacCtx* pCbCtx, int32_t uiBin);
 void WelsCabacEncodeTerminate (SCabacCtx* pCbCtx, uint32_t uiBin);
 void WelsCabacEncodeUeBypass (SCabacCtx* pCbCtx, int32_t iExpBits, uint32_t uiVal);
 void WelsCabacEncodeFlush (SCabacCtx* pCbCtx);
@@ -116,7 +116,7 @@ void WelsCabacEncodeDecision (SCabacCtx* pCbCtx, int32_t iCtx, uint32_t uiBin) {
   }
 }
 
-void WelsCabacEncodeBypassOne (SCabacCtx* pCbCtx, uint32_t uiBin) {
+void WelsCabacEncodeBypassOne (SCabacCtx* pCbCtx, int32_t uiBin) {
   const uint32_t kuiBinBitmask = -uiBin;
   pCbCtx->m_iRenormCnt++;
   WelsCabacEncodeUpdateLow_ (pCbCtx);

--- a/codec/encoder/core/src/set_mb_syn_cabac.cpp
+++ b/codec/encoder/core/src/set_mb_syn_cabac.cpp
@@ -115,11 +115,11 @@ void WelsCabacEncodeUpdateLowNontrivial_ (SCabacCtx* pCbCtx) {
       PropagateCarry (pBufCur, pCbCtx->m_pBufStart);
 
     if (CABAC_LOW_WIDTH > 32) {
-      WRITE_BE_32 (pBufCur, uiLow >> 31);
+      WRITE_BE_32 (pBufCur, (uint32_t) (uiLow >> 31));
       pBufCur += 4;
     }
-    *pBufCur++ = uiLow >> 23;
-    *pBufCur++ = uiLow >> 15;
+    *pBufCur++ = (uint8_t) (uiLow >> 23);
+    *pBufCur++ = (uint8_t) (uiLow >> 15);
     iRenormCnt -= kiInc;
     iLowBitCnt = 15;
     uiLow &= (1u << iLowBitCnt) - 1;
@@ -193,7 +193,7 @@ void WelsCabacEncodeFlush (SCabacCtx* pCbCtx) {
   if (uiLow & cabac_low_t (1) << (CABAC_LOW_WIDTH - 1))
     PropagateCarry (pBufCur, pCbCtx->m_pBufStart);
   for (; (iLowBitCnt -= 8) >= 0; uiLow <<= 8)
-    *pBufCur++ = uiLow >> (CABAC_LOW_WIDTH - 9);
+    *pBufCur++ = (uint8_t) (uiLow >> (CABAC_LOW_WIDTH - 9));
 
   pCbCtx->m_pBufCur = pBufCur;
 }


### PR DESCRIPTION
Use int32_t for a parameter that is always 0 or 1, because it is
negated. This fixes "warning C4146: unary minus operator applied
to unsigned type, result still unsigned" in MSVC.

Also add casts to silence MSVC warnings about "conversion from
'WelsEnc::cabac_low_t' to 'uint8_t', possible loss of data".

The generated code still is identical to before, on both gcc
and clang.

@saamas - does it seem ok to you?