### PR TITLE
[Encoder] Fix for a slicing and multi-threading setting

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3975,6 +3975,11 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
 
       WelsLoadNal (pCtx->pOut, eNalType, eNalRefIdc);
 
+      //the following line is to fix a problem with a specific setting as in test DiffSlicingInDlayerMixed:
+      //      (multi-th on with SM_SINGLE_SLICE in one of the D layers)
+      //TODO: this may not be needed any more after the slice buffer refactoring
+      pCtx->pCurDqLayer->sLayerInfo.pSliceInLayer[0].pSliceBsa = &(pCtx->pOut->sBsWrite);
+
       pCtx->iEncoderError = WelsCodeOneSlice (pCtx, 0, eNalType);
       WELS_VERIFY_RETURN_IFNEQ (pCtx->iEncoderError, ENC_RETURN_SUCCESS)
 


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/1362/

fix for a slicing and multi-threading setting
Otherwise the test DiffSlicingInDlayer currently on master may randomly failed.

It is to fix a problem with a specific setting as in test DiffSlicingInDlayerMixed:
      (multi-th on with SM_SINGLE_SLICE in one of the D layers)

Note: this may not be needed any more after the slice buffer refactoring