### PR TITLE
Fix DecoderInterfaceTest::TestInitUninit()

### DIFF
--- a/test/decoder/DecUT_DecExt.cpp
+++ b/test/decoder/DecUT_DecExt.cpp
@@ -203,6 +203,7 @@ void DecoderInterfaceTest::TestInitUninit() {
     EXPECT_EQ (eRet, cmInitExpected);
   }
   //Initialize first, can get input color format
+  Init();
   m_sDecParam.bParseOnly = false;
   m_pDec->Initialize (&m_sDecParam);
 

--- a/test/decoder/DecUT_DecExt.cpp
+++ b/test/decoder/DecUT_DecExt.cpp
@@ -206,6 +206,9 @@ void DecoderInterfaceTest::TestInitUninit() {
   Init();
   m_sDecParam.bParseOnly = false;
   m_pDec->Initialize (&m_sDecParam);
+  eRet = (CM_RETURN) m_pDec->GetOption (DECODER_OPTION_END_OF_STREAM, &iOutput);
+  EXPECT_EQ (eRet, cmResultSuccess);
+  EXPECT_EQ (iOutput, 0);
 
   //Uninitialize, no GetOption can be done
   m_pDec->Uninitialize();


### PR DESCRIPTION
This fixes valgrind warnings, and makes the test more useful again.

Review at https://rbcommons.com/s/OpenH264/r/1405/.