### PR TITLE
remove parseonly in decoder ctx

### DIFF
--- a/codec/decoder/core/inc/decoder.h
+++ b/codec/decoder/core/inc/decoder.h
@@ -55,6 +55,11 @@ extern "C" {
 int32_t DecoderConfigParam (PWelsDecoderContext pCtx, const SDecodingParam* kpParam);
 
 /*!
+ * \brief   fill in default values of decoder context
+ */
+void WelsDecoderDefaults (PWelsDecoderContext pCtx, SLogContext* pLogCtx);
+
+/*!
  *************************************************************************************
  * \brief   Initialize Wels decoder parameters and memory
  *
@@ -68,7 +73,7 @@ int32_t DecoderConfigParam (PWelsDecoderContext pCtx, const SDecodingParam* kpPa
  * \note    N/A
  *************************************************************************************
  */
-int32_t WelsInitDecoder (PWelsDecoderContext pCtx, const bool bParseOnly, SLogContext* pLogCtx);
+int32_t WelsInitDecoder (PWelsDecoderContext pCtx, SLogContext* pLogCtx);
 
 /*!
  *************************************************************************************
@@ -110,9 +115,9 @@ int32_t WelsRequestMem (PWelsDecoderContext pCtx, const int32_t kiMbWidth, const
 
 
 /*
- *  free memory blocks in avc
+ *  free memory dynamically allocated during decoder
  */
-void WelsFreeMem (PWelsDecoderContext pCtx);
+void WelsFreeDynamicMemory (PWelsDecoderContext pCtx);
 
 /*!
  * \brief   make sure synchonozization picture resolution (get from slice header) among different parts (i.e, memory related and so on)
@@ -125,7 +130,19 @@ void WelsFreeMem (PWelsDecoderContext pCtx);
  */
 int32_t SyncPictureResolutionExt (PWelsDecoderContext pCtx, const int32_t kiMbWidth, const int32_t kiMbHeight);
 
-void AssignFuncPointerForRec (PWelsDecoderContext pCtx);
+/*!
+ * \brief   init decoder predictive function pointers including ASM functions during MB reconstruction
+ * \param   pCtx        Wels decoder context
+ * \param   uiCpuFlag   cpu assembly indication
+ */
+void InitPredFunc (PWelsDecoderContext pCtx, uint32_t uiCpuFlag);
+
+/*!
+ * \brief   init decoder internal function pointers including ASM functions
+ * \param   pCtx        Wels decoder context
+ * \param   uiCpuFlag   cpu assembly indication
+ */
+void InitDecFuncs (PWelsDecoderContext pCtx, uint32_t uiCpuFlag);
 
 void GetVclNalTemporalId (PWelsDecoderContext pCtx); //get the info that whether or not have VCL NAL in current AU,
 //and if YES, get the temporal ID

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -375,7 +375,6 @@ typedef struct TagWelsDecoderContext {
   ERROR_CON_IDC eErrorConMethod; //
 
 //for Parse only
-  bool bParseOnly;
   bool bFramePending;
   bool bFrameFinish;
   int32_t iNalNum;

--- a/codec/decoder/core/inc/decoder_core.h
+++ b/codec/decoder/core/inc/decoder_core.h
@@ -72,21 +72,21 @@ int32_t ExpandBsBuffer (PWelsDecoderContext pCtx, const int32_t kiSrcLen);
 int32_t CheckBsBuffer (PWelsDecoderContext pCtx, const int32_t kiSrcLen);
 
 /*
- * WelsInitMemory
- * Memory request for introduced data
+ * WelsInitStaticMemory
+ * Memory request for introduced data at decoder start
  * Especially for:
  * rbsp_au_buffer, cur_dq_layer_ptr and ref_dq_layer_ptr in MB info cache.
  * return:
  *  0 - success; otherwise returned error_no defined in error_no.h.
  */
-int32_t WelsInitMemory (PWelsDecoderContext pCtx);
+int32_t WelsInitStaticMemory (PWelsDecoderContext pCtx);
 
 /*
- * WelsFreeMemory
- * Free memory introduced in WelsInitMemory at destruction of decoder.
+ * WelsFreeStaticMemory
+ * Free memory introduced in WelsInitStaticMemory at destruction of decoder.
  *
  */
-void WelsFreeMemory (PWelsDecoderContext pCtx);
+void WelsFreeStaticMemory (PWelsDecoderContext pCtx);
 
 /*!
  * \brief   request memory when maximal picture width and height are available

--- a/codec/decoder/core/src/au_parser.cpp
+++ b/codec/decoder/core/src/au_parser.cpp
@@ -317,7 +317,7 @@ uint8_t* ParseNalHeader (PWelsDecoderContext pCtx, SNalUnitHeader* pNalUnitHeade
       iNalSize        -= NAL_UNIT_HEADER_EXT_SIZE;
       *pConsumedBytes += NAL_UNIT_HEADER_EXT_SIZE;
 
-      if (pCtx->bParseOnly) {
+      if (pCtx->pParam->bParseOnly) {
         pCurNal->sNalData.sVclNal.pNalPos = pSavedData->pCurPos;
         int32_t iTrailingZeroByte = 0;
         while (pSrcNal[iSrcNalLen - iTrailingZeroByte - 1] == 0x0) //remove final trailing 0 bytes
@@ -346,7 +346,7 @@ uint8_t* ParseNalHeader (PWelsDecoderContext pCtx, SNalUnitHeader* pNalUnitHeade
         pSavedData->pCurPos += iActualLen - iOffset;
       }
     } else {
-      if (pCtx->bParseOnly) {
+      if (pCtx->pParam->bParseOnly) {
         pCurNal->sNalData.sVclNal.pNalPos = pSavedData->pCurPos;
         int32_t iTrailingZeroByte = 0;
         while (pSrcNal[iSrcNalLen - iTrailingZeroByte - 1] == 0x0) //remove final trailing 0 bytes
@@ -1119,7 +1119,7 @@ int32_t ParseSps (PWelsDecoderContext pCtx, PBitStringAux pBsAux, int32_t* pPicW
   WELS_READ_VERIFY (BsGetOneBit (pBs, &uiCode)); //vui_parameters_present_flag
   pSps->bVuiParamPresentFlag = !!uiCode;
 
-  if (pCtx->bParseOnly) {
+  if (pCtx->pParam->bParseOnly) {
     if (kSrcNalLen >= SPS_PPS_BS_SIZE - 4) { //sps bs exceeds!
       pCtx->iErrorCode |= dsOutOfMemory;
       return GENERATE_ERROR_NO (ERR_LEVEL_PARAM_SETS, ERR_INFO_OUT_OF_MEMORY);
@@ -1422,7 +1422,7 @@ int32_t ParsePps (PWelsDecoderContext pCtx, PPps pPpsList, PBitStringAux pBsAux,
     memcpy (&pCtx->sPpsBuffer[uiPpsId], pPps, sizeof (SPps));
     pCtx->bPpsAvailFlags[uiPpsId] = true;
   }
-  if (pCtx->bParseOnly) {
+  if (pCtx->pParam->bParseOnly) {
     if (kSrcNalLen >= SPS_PPS_BS_SIZE - 4) { //pps bs exceeds
       pCtx->iErrorCode |= dsOutOfMemory;
       return GENERATE_ERROR_NO (ERR_LEVEL_PARAM_SETS, ERR_INFO_OUT_OF_MEMORY);

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -90,7 +90,7 @@ int32_t WelsTargetSliceConstruction (PWelsDecoderContext pCtx) {
       break;
     }
 
-    if (!pCtx->bParseOnly) { //for parse only, actual recon MB unnecessary
+    if (!pCtx->pParam->bParseOnly) { //for parse only, actual recon MB unnecessary
       if (WelsTargetMbConstruction (pCtx)) {
         WelsLog (& (pCtx->sLogCtx), WELS_LOG_WARNING,
                  "WelsTargetSliceConstruction():::MB(%d, %d) construction error. pCurSlice_type:%d",
@@ -134,7 +134,7 @@ int32_t WelsTargetSliceConstruction (PWelsDecoderContext pCtx) {
   if ((pCurSlice->eSliceType != I_SLICE) && (pCurSlice->eSliceType != P_SLICE))
     return 0;
 
-  if (pCtx->bParseOnly) //for parse only, deblocking should not go on
+  if (pCtx->pParam->bParseOnly) //for parse only, deblocking should not go on
     return 0;
 
   pDeblockMb = WelsDeblockingMb;

--- a/codec/decoder/core/src/pic_queue.cpp
+++ b/codec/decoder/core/src/pic_queue.cpp
@@ -83,7 +83,7 @@ PPicture AllocPicture (PWelsDecoderContext pCtx, const int32_t kiPicWidth, const
   iLumaSize     = iPicWidth * iPicHeight;
   iChromaSize   = iPicChromaWidth * iPicChromaHeight;
 
-  if (pCtx->bParseOnly) {
+  if (pCtx->pParam->bParseOnly) {
     pPic->pBuffer[0] = pPic->pBuffer[1] = pPic->pBuffer[2] = NULL;
     pPic->pData[0] = pPic->pData[1] = pPic->pData[2] = NULL;
     pPic->iLinesize[0] = iPicWidth;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -243,6 +243,7 @@ int32_t CWelsDecoder::InitDecoder (const SDecodingParam* pParam) {
            "CWelsDecoder::init_decoder(), openh264 codec version = %s, ParseOnly = %d",
            VERSION_NUMBER, (int32_t)pParam->bParseOnly);
 
+  //reset decoder context
   if (m_pDecContext) //free
     UninitDecoder();
   m_pDecContext = (PWelsDecoderContext)WelsMallocz (sizeof (SWelsDecoderContext), "m_pDecContext");
@@ -252,8 +253,8 @@ int32_t CWelsDecoder::InitDecoder (const SDecodingParam* pParam) {
   m_pDecContext->pMemAlign = new CMemoryAlign (iCacheLineSize);
   WELS_VERIFY_RETURN_PROC_IF (1, (NULL == m_pDecContext->pMemAlign), UninitDecoder())
 
-  WELS_VERIFY_RETURN_PROC_IF (cmInitParaError, WelsInitDecoder (m_pDecContext, pParam->bParseOnly,
-                              &m_pWelsTrace->m_sLogCtx), UninitDecoder())
+  //fill in default value into context
+  WelsDecoderDefaults (m_pDecContext, &m_pWelsTrace->m_sLogCtx);
 
   //check param and update decoder context
   m_pDecContext->pParam = (SDecodingParam*) m_pDecContext->pMemAlign->WelsMallocz (sizeof (SDecodingParam),
@@ -261,6 +262,9 @@ int32_t CWelsDecoder::InitDecoder (const SDecodingParam* pParam) {
   WELS_VERIFY_RETURN_PROC_IF (cmMallocMemeError, (NULL == m_pDecContext->pParam), UninitDecoder());
   int32_t iRet = DecoderConfigParam (m_pDecContext, pParam);
   WELS_VERIFY_RETURN_IFNEQ (iRet, cmResultSuccess);
+
+  //init decoder
+  WELS_VERIFY_RETURN_PROC_IF (cmInitParaError, WelsInitDecoder (m_pDecContext, &m_pWelsTrace->m_sLogCtx), UninitDecoder())
 
   return cmResultSuccess;
 }
@@ -304,7 +308,7 @@ long CWelsDecoder::SetOption (DECODER_OPTION eOptID, void* pOption) {
 
     iVal = * ((int*)pOption); // int value for error concealment idc
     iVal = WELS_CLIP3 (iVal, (int32_t) ERROR_CON_DISABLE, (int32_t) ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE);
-    if ((m_pDecContext->bParseOnly) && (iVal != (int32_t) ERROR_CON_DISABLE)) {
+    if ((m_pDecContext->pParam->bParseOnly) && (iVal != (int32_t) ERROR_CON_DISABLE)) {
       WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO,
                "CWelsDecoder::SetOption for ERROR_CON_IDC = %d not allowd for parse only!.", iVal);
       return cmInitParaError;
@@ -438,7 +442,7 @@ DECODING_STATE CWelsDecoder::DecodeFrame2 (const unsigned char* kpSrc,
     const int kiSrcLen,
     unsigned char** ppDst,
     SBufferInfo* pDstInfo) {
-  if (m_pDecContext->bParseOnly) {
+  if (m_pDecContext->pParam->bParseOnly) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "bParseOnly should be false for this API calling! \n");
     m_pDecContext->iErrorCode |= dsInvalidArgument;
     return dsInvalidArgument;
@@ -583,7 +587,7 @@ DECODING_STATE CWelsDecoder::DecodeFrame2 (const unsigned char* kpSrc,
 DECODING_STATE CWelsDecoder::DecodeParser (const unsigned char* kpSrc,
     const int kiSrcLen,
     SParserBsInfo* pDstInfo) {
-  if (!m_pDecContext->bParseOnly) {
+  if (!m_pDecContext->pParam->bParseOnly) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "bParseOnly should be true for this API calling! \n");
     m_pDecContext->iErrorCode |= dsInvalidArgument;
     return dsInvalidArgument;

--- a/test/decoder/DecUT_DecExt.cpp
+++ b/test/decoder/DecUT_DecExt.cpp
@@ -26,6 +26,8 @@ class DecoderInterfaceTest : public ::testing::Test {
   }
   //Init members
   void Init();
+  //Init valid members
+  void ValidInit();
   //Uninit members
   void Uninit();
   //Mock input data for test
@@ -86,6 +88,24 @@ void DecoderInterfaceTest::Init() {
   m_sDecParam.sVideoProperty.size = sizeof (SVideoProperty);
   m_sDecParam.sVideoProperty.eVideoBsType = (VIDEO_BITSTREAM_TYPE) (rand() % 3);
 
+  m_pData[0] = m_pData[1] = m_pData[2] = NULL;
+  m_szBuffer[0] = m_szBuffer[1] = m_szBuffer[2] = 0;
+  m_szBuffer[3] = 1;
+  m_iBufLength = 4;
+  CM_RETURN eRet = (CM_RETURN) m_pDec->Initialize (&m_sDecParam);
+  ASSERT_EQ (eRet, cmResultSuccess);
+}
+
+void DecoderInterfaceTest::ValidInit() {
+  memset (&m_sBufferInfo, 0, sizeof (SBufferInfo));
+  memset (&m_sDecParam, 0, sizeof (SDecodingParam));
+  m_sDecParam.pFileNameRestructed = NULL;
+  m_sDecParam.uiCpuLoad = 1;
+  m_sDecParam.uiTargetDqLayer = 1;
+  m_sDecParam.eEcActiveIdc = (ERROR_CON_IDC) (rand() & 7);
+  m_sDecParam.sVideoProperty.size = sizeof (SVideoProperty);
+  m_sDecParam.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;
+  
   m_pData[0] = m_pData[1] = m_pData[2] = NULL;
   m_szBuffer[0] = m_szBuffer[1] = m_szBuffer[2] = 0;
   m_szBuffer[3] = 1;
@@ -310,7 +330,7 @@ void DecoderInterfaceTest::TestEndOfStream() {
   int iTmp, iOut;
   CM_RETURN eRet;
 
-  Init();
+  ValidInit();
 
   //invalid input
   eRet = (CM_RETURN) m_pDec->SetOption (DECODER_OPTION_END_OF_STREAM, NULL);
@@ -372,7 +392,7 @@ void DecoderInterfaceTest::TestVclNal() {
   int iTmp, iOut;
   CM_RETURN eRet;
 
-  Init();
+  ValidInit();
 
   //Test SetOption
   //VclNal never supports SetOption
@@ -481,7 +501,7 @@ void DecoderInterfaceTest::TestGetDecStatistics() {
   SDecoderStatistics sDecStatic;
   int32_t iError = 0;
 
-  Init();
+  ValidInit();
   // setoption not support,
   eRet = (CM_RETURN)m_pDec->SetOption (DECODER_OPTION_GET_STATISTICS, NULL);
   EXPECT_EQ (eRet, cmInitParaError);
@@ -504,7 +524,7 @@ void DecoderInterfaceTest::TestGetDecStatistics() {
   Uninit();
 
   //Decoder error bs when the first IDR lost
-  Init();
+  ValidInit();
   iError = 2;
   m_pDec->SetOption (DECODER_OPTION_ERROR_CON_IDC, &iError);
   DecoderBs ("res/BA_MW_D_IDR_LOST.264");
@@ -522,7 +542,7 @@ void DecoderInterfaceTest::TestGetDecStatistics() {
   Uninit();
 
   //ecoder error bs when the first P lost
-  Init();
+  ValidInit();
   iError = 2;
   m_pDec->SetOption (DECODER_OPTION_ERROR_CON_IDC, &iError);
 
@@ -543,7 +563,7 @@ void DecoderInterfaceTest::TestGetDecStatistics() {
   //EC enable
 
   //EC Off UT just correc bitstream
-  Init();
+  ValidInit();
   iError = 0;
   m_pDec->SetOption (DECODER_OPTION_ERROR_CON_IDC, &iError);
   DecoderBs ("res/test_vd_1d.264");

--- a/test/decoder/DecUT_ParseSyntax.cpp
+++ b/test/decoder/DecUT_ParseSyntax.cpp
@@ -86,12 +86,15 @@ int32_t InitDecoder (const SDecodingParam* pParam, PWelsDecoderContext pCtx, SLo
       return cmMallocMemeError;
   }
 
-  WELS_VERIFY_RETURN_PROC_IF (cmInitParaError, WelsInitDecoder (pCtx, pParam->bParseOnly, pLogCtx), UninitDecoder (pCtx));
+  pCtx->sLogCtx = *pLogCtx;
+
   //check param and update decoder context
   pCtx->pParam = (SDecodingParam*) pCtx->pMemAlign->WelsMallocz (sizeof (SDecodingParam), "SDecodingParam");
   WELS_VERIFY_RETURN_PROC_IF (cmMallocMemeError, (NULL == pCtx->pParam), UninitDecoder (pCtx));
-  int32_t iRet = DecoderConfigParam (pCtx, pCtx->pParam);
+  int32_t iRet = DecoderConfigParam (pCtx, pParam);
   WELS_VERIFY_RETURN_IFNEQ (iRet, cmResultSuccess);
+
+  WELS_VERIFY_RETURN_PROC_IF (cmInitParaError, WelsInitDecoder (pCtx, pLogCtx), UninitDecoder (pCtx));
 
   return cmResultSuccess;
 }


### PR DESCRIPTION
almost the same as #2217 ,which was then reverted due to some bugs.
see:
https://rbcommons.com/s/OpenH264/r/1433/