### PR TITLE
Fix the build errors when open the encoder info output

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -4189,7 +4189,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
              (iSpatialIdx == 0) ? "#AU" : "   ",
              pCtx->iPOC,
              pCtx->iFrameNum,
-             (uiFrameType == videoFrameTypeI || uiFrameType == videoFrameTypeIDR) ? "I" : "P",
+             (eFrameType == videoFrameTypeI || eFrameType == videoFrameTypeIDR) ? "I" : "P",
              iCurTid,
              iCurDid,
              0,
@@ -4898,7 +4898,7 @@ int32_t WelsCodeOnePicPartition (sWelsEncCtx* pCtx,
              "@slice=%-6d sliceType:%c idc:%d size:%-6d\n",
              iSliceIdx,
              (pCtx->eSliceType == P_SLICE ? 'P' : 'I'),
-             eNalRefIdc,
+             keNalRefIdc,
              iSliceSize);
 #endif//SLICE_INFO_OUTPUT
 


### PR DESCRIPTION
See code review at: https://rbcommons.com/s/OpenH264/r/1459/
When enable the info output macros in codec/encoder/core/inc/as264_common.h , there were some build errors.