### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The codec and demo can be built by
 Valid `**ANDROID_TARGET**` can be found in `**ANDROID_SDK**/platforms`, such as `android-12`.
 You can also set `ARCH`, `NDKLEVEL` according to your device and NDK version.
 `ARCH` specifies the architecture of android device. Currently `arm`, `arm64`, `x86` and `x86_64` are supported, the default is `arm`. (`mips` and `mips64` can also be used, but there's no specific optimization for those architectures.)
-`NDKLEVEL` specifies android api level, the default is 12. Availabe possibilities can be found in `**ANDROID_NDK**/platforms`, such as `android-21` (strip away the `android-` prefix).
+`NDKLEVEL` specifies android api level, the default is 12. Available possibilities can be found in `**ANDROID_NDK**/platforms`, such as `android-21` (strip away the `android-` prefix).
 
 By default these commands build for the `armeabi-v7a` ABI. To build for the other android
 ABIs, add `ARCH=arm64`, `ARCH=x86`, `ARCH=x86_64`, `ARCH=mips` or `ARCH=mips64`.


### PR DESCRIPTION
Found a typo while reading -
`Availabe` → `Available`