### PR TITLE
Avoid reading iCountMbNumInSlice out of bounds on slice realloc

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -4877,7 +4877,7 @@ int32_t SliceBufferRealloc (sWelsEncCtx* pCtx) {
     pSliceIdx->sSlicingOverRc.iTotalQpSlice         = 0;
     pSliceIdx->sSlicingOverRc.iTotalMbSlice         = 0;
     pSliceIdx->sSlicingOverRc.iTargetBitsSlice      = WELS_DIV_ROUND (kiBitsPerMb *
-                                                      pCurLayer->sLayerInfo.pSliceInLayer[uiSliceIdx].iCountMbNumInSlice,
+                                                      pSlice[uiSliceIdx].iCountMbNumInSlice,
                                                       INT_MULTIPLY);
     pSliceIdx->sSlicingOverRc.iFrameBitsSlice       = 0;
     pSliceIdx->sSlicingOverRc.iGomBitsSlice         = 0;


### PR DESCRIPTION
Prior to 7bcb3ba4f4abf18a,
pCurLayer->sLayerInfo.pSliceInLayer[uiSliceIdx].iCountMbNumInSlice
was read after setting pCurLayer->sLayerInfo.pSliceInLayer to
the newly allocated, larger array. After this commit, it is read
before the array has been switched, and thus is read from the
old array (which only holds elements up to iMaxSliceNumOld, not
up to iMaxSliceNum).

This fixes reads out of bounds, and crashes in the test suite.

Review at https://rbcommons.com/s/OpenH264/r/1534/.