### PR TITLE
Refresh regenerating targets.mk

### DIFF
--- a/build/mktargets.sh
+++ b/build/mktargets.sh
@@ -14,4 +14,4 @@ python build/mktargets.py --directory test/processing --prefix processing_unitte
 python build/mktargets.py --directory test/api --prefix api_test
 python build/mktargets.py --directory test/common --prefix common_unittest
 python build/mktargets.py --directory module --prefix module
-python build/mktargets.py --directory gtest --library gtest --out build/gtest-targets.mk --cpp-suffix .cc --include gtest-all.cc
+python build/mktargets.py --directory gtest/googletest --library gtest --out build/gtest-targets.mk --cpp-suffix .cc --include gtest-all.cc

--- a/test/api/targets.mk
+++ b/test/api/targets.mk
@@ -14,7 +14,6 @@ API_TEST_CPP_SRCS=\
 	$(API_TEST_SRCDIR)/ltr_test.cpp\
 	$(API_TEST_SRCDIR)/simple_test.cpp\
 
-
 API_TEST_OBJS += $(API_TEST_CPP_SRCS:.cpp=.$(OBJ))
 
 API_TEST_C_SRCS=\


### PR DESCRIPTION
Make sure that `gtest-targets.mk` is regenerated correctly, and fix a manual change that is overwritten by regenerating the makefiles.