### PR TITLE
[Encoder] Refactor: add class for diff preprocess strategy

### DIFF
--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -120,6 +120,8 @@ class CWelsPreProcess {
   CWelsPreProcess (sWelsEncCtx* pEncCtx);
   virtual  ~CWelsPreProcess();
 
+  static CWelsPreProcess* CreatePreProcess (sWelsEncCtx* pEncCtx);
+
  public:
   int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx,int32_t iWidth,int32_t iHeight);
   int32_t AllocSpatialPictures (sWelsEncCtx* pCtx, SWelsSvcCodingParam* pParam);
@@ -140,6 +142,14 @@ class CWelsPreProcess {
                       const uint32_t kuiShortRefCount);
   void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* pCurPicture, const int32_t kiCurDid,
       const int32_t kuiMarkLongTermPicIdx, SPicture** pLongRefList);
+
+
+ protected:
+  bool GetSceneChangeFlag (ESceneChangeIdc eSceneChangeIdc);
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL) = 0;
+
+  void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
+
  private:
   int32_t WelsPreprocessCreate();
   int32_t WelsPreprocessDestroy();
@@ -150,7 +160,7 @@ class CWelsPreProcess {
   int32_t SingleLayerPreprocess (sWelsEncCtx* pEncCtx, const SSourcePicture* kpSrc, Scaled_Picture* m_sScaledPicture);
 
   void  BilateralDenoising (SPicture* pSrc, const int32_t iWidth, const int32_t iHeight);
-  bool  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture);
+
   int32_t DownsamplePadding (SPicture* pSrc, SPicture* pDstPic,  int32_t iSrcWidth, int32_t iSrcHeight,
                              int32_t iShrinkWidth, int32_t iShrinkHeight, int32_t iTargetWidth, int32_t iTargetHeight,
                              bool bForceCopy);
@@ -168,20 +178,6 @@ class CWelsPreProcess {
   void WelsMoveMemoryWrapper (SWelsSvcCodingParam* pSvcParam, SPicture* pDstPic, const SSourcePicture* kpSrc,
                               const int32_t kiWidth, const int32_t kiHeight);
 
-  ESceneChangeIdc DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPicture* pCurPicture);
-  void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
-  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,
-      const int32_t iClosestLtrFrameNum,
-      SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
-  void GetAvailableRefList (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
-                            SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
-  void InitRefJudgement (SRefJudgement* pRefJudgement);
-  bool JudgeBestRef (SPicture* pRefPic, const SRefJudgement& sRefJudgement, const int64_t iFrameComplexity,
-                     const bool bIsClosestLtrFrame);
-  void SaveBestRefToJudgement (const int32_t iRefPictureAvQP, const int64_t iComplexity, SRefJudgement* pRefJudgement);
-  void SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSceneChangeResult& sSceneChangeResult,
-                           SRefInfoParam* pRefSaved);
-  void SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef);
 
   /*!
   * \brief  exchange two picture pData planes
@@ -194,12 +190,13 @@ class CWelsPreProcess {
   SPicture* GetBestRefPic (EUsageType iUsageType, bool bSceneLtr, EWelsSliceType eSliceType, int32_t kiDidx,
                            int32_t iRefTemporalIdx);
   SPicture* GetBestRefPic (const int32_t kiDidx, const int32_t iRefTemporalIdx);
+ protected:
+  IWelsVP*         m_pInterfaceVp;
+  sWelsEncCtx*     m_pEncCtx;
 
  private:
   Scaled_Picture   m_sScaledPicture;
   SPicture*        m_pLastSpatialPicture[MAX_DEPENDENCY_LAYER][2];
-  IWelsVP*         m_pInterfaceVp;
-  sWelsEncCtx*     m_pEncCtx;
   bool             m_bInitDone;
   uint8_t          m_uiSpatialLayersInTemporal[MAX_DEPENDENCY_LAYER];
   uint8_t          m_uiSpatialPicNum[MAX_DEPENDENCY_LAYER];
@@ -210,6 +207,39 @@ class CWelsPreProcess {
   int32_t           m_iAvaliableRefInSpatialPicList;
 
 };
+
+class CWelsPreProcessVideo : public CWelsPreProcess {
+ public:
+  CWelsPreProcessVideo (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
+
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+};
+
+
+
+class CWelsPreProcessScreen : public CWelsPreProcess {
+ public:
+  CWelsPreProcessScreen (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
+
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+
+ private:
+  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,
+      const int32_t iClosestLtrFrameNum,
+      SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
+
+  void GetAvailableRefList (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
+                            SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
+  void InitRefJudgement (SRefJudgement* pRefJudgement);
+
+  bool JudgeBestRef (SPicture* pRefPic, const SRefJudgement& sRefJudgement, const int64_t iFrameComplexity,
+                     const bool bIsClosestLtrFrame);
+  void SaveBestRefToJudgement (const int32_t iRefPictureAvQP, const int64_t iComplexity, SRefJudgement* pRefJudgement);
+  void SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSceneChangeResult& sSceneChangeResult,
+                           SRefInfoParam* pRefSaved);
+  void SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef);
+};
+
 
 }
 

--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -122,8 +122,9 @@ class CWelsPreProcess {
 
   static CWelsPreProcess* CreatePreProcess (sWelsEncCtx* pEncCtx);
 
+  virtual SPicture* GetCurrentOrigFrame (int32_t iDIdx) = 0;
  public:
-  int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx,int32_t iWidth,int32_t iHeight);
+  int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx, int32_t iWidth, int32_t iHeight);
   int32_t AllocSpatialPictures (sWelsEncCtx* pCtx, SWelsSvcCodingParam* pParam);
   void    FreeSpatialPictures (sWelsEncCtx* pCtx);
   int32_t BuildSpatialPicList (sWelsEncCtx* pEncCtx, const SSourcePicture* kpSrcPic);
@@ -135,9 +136,7 @@ class CWelsPreProcess {
                                     const int32_t kiDependencyId, const bool kbCalculateBGD);
   int32_t UpdateBlockIdcForScreen (uint8_t*  pCurBlockStaticPointer, const SPicture* kpRefPic, const SPicture* kpSrcPic);
 
-  SPicture* GetCurrentFrameFromOrigList (int32_t iDIdx) {
-    return m_pSpatialPic[iDIdx][0];
-  }
+
   void UpdateSrcList (SPicture* pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
                       const uint32_t kuiShortRefCount);
   void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* pCurPicture, const int32_t kiCurDid,
@@ -150,11 +149,12 @@ class CWelsPreProcess {
 
   void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
 
+  int32_t GetCurPicPosition (const int32_t kiDidx);
+
  private:
   int32_t WelsPreprocessCreate();
   int32_t WelsPreprocessDestroy();
   int32_t InitLastSpatialPictures (sWelsEncCtx* pEncCtx);
-  int32_t GetCurPicPosition(const int32_t kiDidx);
 
  private:
   int32_t SingleLayerPreprocess (sWelsEncCtx* pEncCtx, const SSourcePicture* kpSrc, Scaled_Picture* m_sScaledPicture);
@@ -193,14 +193,15 @@ class CWelsPreProcess {
  protected:
   IWelsVP*         m_pInterfaceVp;
   sWelsEncCtx*     m_pEncCtx;
+  uint8_t          m_uiSpatialLayersInTemporal[MAX_DEPENDENCY_LAYER];
+
 
  private:
   Scaled_Picture   m_sScaledPicture;
   SPicture*        m_pLastSpatialPicture[MAX_DEPENDENCY_LAYER][2];
   bool             m_bInitDone;
-  uint8_t          m_uiSpatialLayersInTemporal[MAX_DEPENDENCY_LAYER];
   uint8_t          m_uiSpatialPicNum[MAX_DEPENDENCY_LAYER];
- public:
+ protected:
   /* For Downsampling & VAA I420 based source pictures */
   SPicture*        m_pSpatialPic[MAX_DEPENDENCY_LAYER][MAX_REF_PIC_COUNT + 1];
   // need memory requirement with total number of num_of_ref + 1, "+1" is for current frame
@@ -212,7 +213,10 @@ class CWelsPreProcessVideo : public CWelsPreProcess {
  public:
   CWelsPreProcessVideo (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
 
-  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+  virtual SPicture* GetCurrentOrigFrame (int32_t iDIdx);
+
+  virtual ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+
 };
 
 
@@ -221,7 +225,9 @@ class CWelsPreProcessScreen : public CWelsPreProcess {
  public:
   CWelsPreProcessScreen (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
 
-  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+  virtual SPicture* GetCurrentOrigFrame (int32_t iDIdx);
+
+  virtual ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
 
  private:
   void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2454,7 +2454,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
     WelsCabacInit (pCtx);
   WelsRcInitModule (pCtx,  pCtx->pSvcParam->iRCMode);
 
-  pCtx->pVpp = new CWelsPreProcess (pCtx);
+  pCtx->pVpp = CWelsPreProcess::CreatePreProcess(pCtx);
   if (pCtx->pVpp == NULL) {
     iRet = 1;
     WelsLog (pLogCtx, WELS_LOG_ERROR, "WelsInitEncoderExt(), pOut of memory in case new CWelsPreProcess().");

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -559,7 +559,6 @@ void CWelsPreProcess::BilateralDenoising (SPicture* pSrc, const int32_t kiWidth,
 }
 
 ESceneChangeIdc CWelsPreProcessVideo::DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture) {
-  bool bSceneChangeFlag = false;
   int32_t iMethodIdx = METHOD_SCENE_CHANGE_DETECTION_VIDEO;
   SSceneChangeResult sSceneChangeDetectResult = { SIMILAR_SCENE };
   SPixMap sSrcPixMap;
@@ -573,7 +572,6 @@ ESceneChangeIdc CWelsPreProcessVideo::DetectSceneChange (SPicture* pCurPicture, 
   sSrcPixMap.sRect.iRectHeight = pCurPicture->iHeightInPixel;
   sSrcPixMap.eFormat = VIDEO_FORMAT_I420;
 
-
   sRefPixMap.pPixel[0] = pRefPicture->pData[0];
   sRefPixMap.iSizeInBits = g_kiPixMapSizeInBits;
   sRefPixMap.iStride[0] = pRefPicture->iLineSize[0];
@@ -583,6 +581,7 @@ ESceneChangeIdc CWelsPreProcessVideo::DetectSceneChange (SPicture* pCurPicture, 
 
   int32_t iRet = m_pInterfaceVp->Process (iMethodIdx, &sSrcPixMap, &sRefPixMap);
   if (iRet == 0) {
+    bool bSceneChangeFlag = false;
     m_pInterfaceVp->Get (iMethodIdx, (void*)&sSceneChangeDetectResult);
     bSceneChangeFlag = (sSceneChangeDetectResult.eSceneChangeIdc == LARGE_CHANGED_SCENE) ? true : false;
   }

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -581,9 +581,8 @@ ESceneChangeIdc CWelsPreProcessVideo::DetectSceneChange (SPicture* pCurPicture, 
 
   int32_t iRet = m_pInterfaceVp->Process (iMethodIdx, &sSrcPixMap, &sRefPixMap);
   if (iRet == 0) {
-    bool bSceneChangeFlag = false;
     m_pInterfaceVp->Get (iMethodIdx, (void*)&sSceneChangeDetectResult);
-    bSceneChangeFlag = (sSceneChangeDetectResult.eSceneChangeIdc == LARGE_CHANGED_SCENE) ? true : false;
+    //bSceneChangeFlag = (sSceneChangeDetectResult.eSceneChangeIdc == LARGE_CHANGED_SCENE) ? true : false;
   }
 
   return sSceneChangeDetectResult.eSceneChangeIdc;

--- a/codec/encoder/core/src/wels_preprocess.cpp
+++ b/codec/encoder/core/src/wels_preprocess.cpp
@@ -60,7 +60,8 @@ const uint8_t g_kuiRefTemporalIdx[MAX_TEMPORAL_LEVEL][MAX_GOP_SIZE] = {
 const int32_t g_kiPixMapSizeInBits = sizeof (uint8_t) * 8;
 
 
-inline  void   WelsUpdateSpatialIdxMap (sWelsEncCtx* pEncCtx, int32_t iPos, SPicture* pPic, int32_t iDidx) {
+inline  void   WelsUpdateSpatialIdxMap (sWelsEncCtx* pEncCtx, const int32_t iPos, SPicture* const pPic,
+                                        const int32_t iDidx) {
   pEncCtx->sSpatialIndexMap[iPos].pSrc = pPic;
   pEncCtx->sSpatialIndexMap[iPos].iDid = iDidx;
 }
@@ -335,7 +336,6 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
     Scaled_Picture* pScaledPicture) {
   SWelsSvcCodingParam* pSvcParam    = pCtx->pSvcParam;
   int8_t  iDependencyId             = pSvcParam->iSpatialLayerNum - 1;
-  int32_t iPicturePos               = m_uiSpatialLayersInTemporal[iDependencyId] - 1;
 
   SPicture* pSrcPic                 = NULL; // large
   SPicture* pDstPic                 = NULL; // small
@@ -359,8 +359,8 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
   if (pSvcParam->uiIntraPeriod)
     pCtx->pVaa->bIdrPeriodFlag = (1 + pDlayerParamInternal->iFrameIndex >= (int32_t)pSvcParam->uiIntraPeriod) ? true :
                                  false;
-  pSrcPic = pScaledPicture->pScaledInputPicture ? pScaledPicture->pScaledInputPicture :
-            m_pSpatialPic[iDependencyId][iPicturePos];
+  pSrcPic = pScaledPicture->pScaledInputPicture ? pScaledPicture->pScaledInputPicture : GetCurrentOrigFrame (
+              iDependencyId);
 
   WelsMoveMemoryWrapper (pSvcParam, pSrcPic, kpSrc, iSrcWidth, iSrcHeight);
 
@@ -373,7 +373,7 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
   pDstPic = pSrcPic;
   if (pScaledPicture->pScaledInputPicture) {
     // for highest downsampling
-    pDstPic = m_pSpatialPic[iDependencyId][iPicturePos];
+    pDstPic = GetCurrentOrigFrame (iDependencyId);
     iShrinkWidth = pScaledPicture->iScaledWidth[iDependencyId];
     iShrinkHeight = pScaledPicture->iScaledHeight[iDependencyId];
   }
@@ -414,7 +414,7 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
     -- iActualSpatialNum;
   }
 
-  m_pLastSpatialPicture[iDependencyId][1] = m_pSpatialPic[iDependencyId][iPicturePos];
+  m_pLastSpatialPicture[iDependencyId][1] = GetCurrentOrigFrame (iDependencyId);
   -- iDependencyId;
 
 
@@ -432,12 +432,11 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
       iTargetHeight = pDlayerParam->iVideoHeight;
       iTemporalId = pDlayerParamInternal->uiCodingIdx2TemporalId[pDlayerParamInternal->iCodingIndex &
                     (pSvcParam->uiGopSize - 1)];
-      iPicturePos = m_uiSpatialLayersInTemporal[iDependencyId] - 1;
 
       // down sampling performed
       int32_t iSrcWidth                 = pScaledPicture->iScaledWidth[iClosestDid];
       int32_t iSrcHeight                = pScaledPicture->iScaledHeight[iClosestDid];
-      pDstPic = m_pSpatialPic[iDependencyId][iPicturePos]; // small
+      pDstPic = GetCurrentOrigFrame (iDependencyId); // small
       iShrinkWidth = pScaledPicture->iScaledWidth[iDependencyId];
       iShrinkHeight = pScaledPicture->iScaledHeight[iDependencyId];
       DownsamplePadding (pSrcPic, pDstPic, iSrcWidth, iSrcHeight, iShrinkWidth, iShrinkHeight, iTargetWidth, iTargetHeight,
@@ -447,7 +446,8 @@ int32_t CWelsPreProcess::SingleLayerPreprocess (sWelsEncCtx* pCtx, const SSource
         WelsUpdateSpatialIdxMap (pCtx, iActualSpatialNum, pDstPic, iDependencyId);
         iActualSpatialNum--;
       }
-      m_pLastSpatialPicture[iDependencyId][1] = m_pSpatialPic[iDependencyId][iPicturePos];
+
+      m_pLastSpatialPicture[iDependencyId][1] = pDstPic;
 
       iClosestDid = iDependencyId;
       -- iDependencyId;
@@ -588,6 +588,10 @@ ESceneChangeIdc CWelsPreProcessVideo::DetectSceneChange (SPicture* pCurPicture, 
   }
 
   return sSceneChangeDetectResult.eSceneChangeIdc;
+}
+
+SPicture* CWelsPreProcessVideo::GetCurrentOrigFrame (int32_t iDIdx) {
+  return m_pSpatialPic[iDIdx][GetCurPicPosition(iDIdx)];
 }
 
 int32_t CWelsPreProcess::DownsamplePadding (SPicture* pSrc, SPicture* pDstPic,  int32_t iSrcWidth, int32_t iSrcHeight,
@@ -1043,7 +1047,11 @@ void CWelsPreProcessScreen::SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfo
   (*pVaaBestRef) = sRefSaved;
 }
 
-ESceneChangeIdc CWelsPreProcessScreen::DetectSceneChange (SPicture* pCurPicture, SPicture* pRef ) {
+SPicture* CWelsPreProcessScreen::GetCurrentOrigFrame (int32_t iDIdx) {
+  return m_pSpatialPic[iDIdx][0];
+}
+
+ESceneChangeIdc CWelsPreProcessScreen::DetectSceneChange (SPicture* pCurPicture, SPicture* pRef) {
   sWelsEncCtx* pCtx = m_pEncCtx;
 #define STATIC_SCENE_MOTION_RATIO 0.01f
   SWelsSvcCodingParam* pSvcParam = pCtx->pSvcParam;
@@ -1284,7 +1292,7 @@ void CWelsPreProcess::UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* 
   WelsExchangeSpatialPictures (&m_pSpatialPic[kiCurDid][0],
                                &m_pSpatialPic[kiCurDid][1 + kuiMarkLongTermPicIdx]);
   m_iAvaliableRefInSpatialPicList = MAX_REF_PIC_COUNT;
-  (GetCurrentFrameFromOrigList (kiCurDid))->SetUnref();
+  (GetCurrentOrigFrame (kiCurDid))->SetUnref();
 }
 void CWelsPreProcess::UpdateSrcList (SPicture* pCurPicture, const int32_t kiCurDid, SPicture** pShortRefList,
                                      const uint32_t kuiShortRefCount) {
@@ -1308,7 +1316,7 @@ void CWelsPreProcess::UpdateSrcList (SPicture* pCurPicture, const int32_t kiCurD
       m_iAvaliableRefInSpatialPicList = 1;
     }
   }
-  (GetCurrentFrameFromOrigList (kiCurDid))->SetUnref();
+  (GetCurrentOrigFrame (kiCurDid))->SetUnref();
 }
 
 //TODO: may opti later


### PR DESCRIPTION
add class for diff preprocess strategy
https://rbcommons.com/s/OpenH264/r/1604

different preprocess actually used diff source picture management, using function to avoid directly visit memory position and ease of making mistakes
https://rbcommons.com/s/OpenH264/r/1617