### PR TITLE
[Encoder] Refactor: add class for diff preprocess strategy

### DIFF
--- a/codec/encoder/core/inc/wels_preprocess.h
+++ b/codec/encoder/core/inc/wels_preprocess.h
@@ -120,6 +120,8 @@ class CWelsPreProcess {
   CWelsPreProcess (sWelsEncCtx* pEncCtx);
   virtual  ~CWelsPreProcess();
 
+  static CWelsPreProcess* CreatePreProcess (sWelsEncCtx* pEncCtx);
+
  public:
   int32_t WelsPreprocessReset (sWelsEncCtx* pEncCtx,int32_t iWidth,int32_t iHeight);
   int32_t AllocSpatialPictures (sWelsEncCtx* pCtx, SWelsSvcCodingParam* pParam);
@@ -140,6 +142,14 @@ class CWelsPreProcess {
                       const uint32_t kuiShortRefCount);
   void UpdateSrcListLosslessScreenRefSelectionWithLtr (SPicture* pCurPicture, const int32_t kiCurDid,
       const int32_t kuiMarkLongTermPicIdx, SPicture** pLongRefList);
+
+
+ protected:
+  bool GetSceneChangeFlag (ESceneChangeIdc eSceneChangeIdc);
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL) = 0;
+
+  void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
+
  private:
   int32_t WelsPreprocessCreate();
   int32_t WelsPreprocessDestroy();
@@ -150,7 +160,7 @@ class CWelsPreProcess {
   int32_t SingleLayerPreprocess (sWelsEncCtx* pEncCtx, const SSourcePicture* kpSrc, Scaled_Picture* m_sScaledPicture);
 
   void  BilateralDenoising (SPicture* pSrc, const int32_t iWidth, const int32_t iHeight);
-  bool  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture);
+
   int32_t DownsamplePadding (SPicture* pSrc, SPicture* pDstPic,  int32_t iSrcWidth, int32_t iSrcHeight,
                              int32_t iShrinkWidth, int32_t iShrinkHeight, int32_t iTargetWidth, int32_t iTargetHeight,
                              bool bForceCopy);
@@ -168,20 +178,6 @@ class CWelsPreProcess {
   void WelsMoveMemoryWrapper (SWelsSvcCodingParam* pSvcParam, SPicture* pDstPic, const SSourcePicture* kpSrc,
                               const int32_t kiWidth, const int32_t kiHeight);
 
-  ESceneChangeIdc DetectSceneChangeScreen (sWelsEncCtx* pCtx, SPicture* pCurPicture);
-  void InitPixMap (const SPicture* pPicture, SPixMap* pPixMap);
-  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,
-      const int32_t iClosestLtrFrameNum,
-      SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
-  void GetAvailableRefList (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
-                            SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
-  void InitRefJudgement (SRefJudgement* pRefJudgement);
-  bool JudgeBestRef (SPicture* pRefPic, const SRefJudgement& sRefJudgement, const int64_t iFrameComplexity,
-                     const bool bIsClosestLtrFrame);
-  void SaveBestRefToJudgement (const int32_t iRefPictureAvQP, const int64_t iComplexity, SRefJudgement* pRefJudgement);
-  void SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSceneChangeResult& sSceneChangeResult,
-                           SRefInfoParam* pRefSaved);
-  void SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef);
 
   /*!
   * \brief  exchange two picture pData planes
@@ -194,12 +190,13 @@ class CWelsPreProcess {
   SPicture* GetBestRefPic (EUsageType iUsageType, bool bSceneLtr, EWelsSliceType eSliceType, int32_t kiDidx,
                            int32_t iRefTemporalIdx);
   SPicture* GetBestRefPic (const int32_t kiDidx, const int32_t iRefTemporalIdx);
+ protected:
+  IWelsVP*         m_pInterfaceVp;
+  sWelsEncCtx*     m_pEncCtx;
 
  private:
   Scaled_Picture   m_sScaledPicture;
   SPicture*        m_pLastSpatialPicture[MAX_DEPENDENCY_LAYER][2];
-  IWelsVP*         m_pInterfaceVp;
-  sWelsEncCtx*     m_pEncCtx;
   bool             m_bInitDone;
   uint8_t          m_uiSpatialLayersInTemporal[MAX_DEPENDENCY_LAYER];
   uint8_t          m_uiSpatialPicNum[MAX_DEPENDENCY_LAYER];
@@ -210,6 +207,39 @@ class CWelsPreProcess {
   int32_t           m_iAvaliableRefInSpatialPicList;
 
 };
+
+class CWelsPreProcessVideo : public CWelsPreProcess {
+ public:
+  CWelsPreProcessVideo (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
+
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+};
+
+
+
+class CWelsPreProcessScreen : public CWelsPreProcess {
+ public:
+  CWelsPreProcessScreen (sWelsEncCtx* pEncCtx) : CWelsPreProcess (pEncCtx) {};
+
+  virtual  ESceneChangeIdc  DetectSceneChange (SPicture* pCurPicture, SPicture* pRefPicture = NULL);
+
+ private:
+  void GetAvailableRefListLosslessScreenRefSelection (SPicture** pSrcPicList, uint8_t iCurTid,
+      const int32_t iClosestLtrFrameNum,
+      SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
+
+  void GetAvailableRefList (SPicture** pSrcPicList, uint8_t iCurTid, const int32_t iClosestLtrFrameNum,
+                            SRefInfoParam* pAvailableRefList, int32_t& iAvailableRefNum, int32_t& iAvailableSceneRefNum);
+  void InitRefJudgement (SRefJudgement* pRefJudgement);
+
+  bool JudgeBestRef (SPicture* pRefPic, const SRefJudgement& sRefJudgement, const int64_t iFrameComplexity,
+                     const bool bIsClosestLtrFrame);
+  void SaveBestRefToJudgement (const int32_t iRefPictureAvQP, const int64_t iComplexity, SRefJudgement* pRefJudgement);
+  void SaveBestRefToLocal (SRefInfoParam* pRefPicInfo, const SSceneChangeResult& sSceneChangeResult,
+                           SRefInfoParam* pRefSaved);
+  void SaveBestRefToVaa (SRefInfoParam& sRefSaved, SRefInfoParam* pVaaBestRef);
+};
+
 
 }
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2454,7 +2454,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
     WelsCabacInit (pCtx);
   WelsRcInitModule (pCtx,  pCtx->pSvcParam->iRCMode);
 
-  pCtx->pVpp = new CWelsPreProcess (pCtx);
+  pCtx->pVpp = CWelsPreProcess::CreatePreProcess(pCtx);
   if (pCtx->pVpp == NULL) {
     iRet = 1;
     WelsLog (pLogCtx, WELS_LOG_ERROR, "WelsInitEncoderExt(), pOut of memory in case new CWelsPreProcess().");


### PR DESCRIPTION
add class for diff preprocess strategy
https://rbcommons.com/s/OpenH264/r/1604

different preprocess actually used diff source picture management, using function to avoid directly visit memory position and ease of making mistakes
https://rbcommons.com/s/OpenH264/r/1617