### PR TITLE
[Encoder] refactor: to avoid only use idx0 in syntax writing, for now it has no impact on bs

### DIFF
--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -663,8 +663,11 @@ void WelsUpdateSliceHeaderSyntax (sWelsEncCtx* pCtx,  const int32_t iAbsDiffPicN
         pRefReorder->SReorderingSyntax[0].uiAbsDiffPicNumMinus1 = iAbsDiffPicNumMinus1;
         pRefReorder->SReorderingSyntax[1].uiReorderingOfPicNumsIdc = 3;
       } else {
-        pRefReorder->SReorderingSyntax[0].uiReorderingOfPicNumsIdc = 2;
-        pRefReorder->SReorderingSyntax[0].iLongTermPicNum = pCtx->pRefList0[0]->iLongTermPicNum;
+        int32_t iRefIdx = 0;
+        for (iRefIdx = 0; iRefIdx < pCtx->iNumRef0; iRefIdx++) {
+          pRefReorder->SReorderingSyntax[iRefIdx].uiReorderingOfPicNumsIdc = 2;
+          pRefReorder->SReorderingSyntax[iRefIdx].iLongTermPicNum = pCtx->pRefList0[iRefIdx]->iLongTermPicNum;
+        }
         pRefReorder->SReorderingSyntax[1].uiReorderingOfPicNumsIdc = 3;
       }
     }

--- a/codec/encoder/core/src/ref_list_mgr_svc.cpp
+++ b/codec/encoder/core/src/ref_list_mgr_svc.cpp
@@ -668,7 +668,7 @@ void WelsUpdateSliceHeaderSyntax (sWelsEncCtx* pCtx,  const int32_t iAbsDiffPicN
           pRefReorder->SReorderingSyntax[iRefIdx].uiReorderingOfPicNumsIdc = 2;
           pRefReorder->SReorderingSyntax[iRefIdx].iLongTermPicNum = pCtx->pRefList0[iRefIdx]->iLongTermPicNum;
         }
-        pRefReorder->SReorderingSyntax[1].uiReorderingOfPicNumsIdc = 3;
+        pRefReorder->SReorderingSyntax[iRefIdx].uiReorderingOfPicNumsIdc = 3;
       }
     }
 


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/1619/