### PR TITLE
[UT] Allow for different output depending on downsample average order

### DIFF
--- a/test/api/decode_api_test.cpp
+++ b/test/api/decode_api_test.cpp
@@ -758,18 +758,12 @@ const uint32_t kiWidth = 160; //DO NOT CHANGE!
 const uint32_t kiHeight = 96; //DO NOT CHANGE!
 const uint32_t kiFrameRate = 12; //DO NOT CHANGE!
 const uint32_t kiFrameNum = 100; //DO NOT CHANGE!
-const char* pHashStr[] = { //DO NOT CHANGE!
-// X86_ASM downsampling routines average vertically first, as opposed to
-// horizontally first, which results in different output.
-#ifdef X86_ASM
-  "244eebcb51f4c2a56e83fc5da3373cad9ec0e1e5",
-  "bbad99ef99e37b34bcb4f09a7ec4d144375f6be7",
-  "809f97e836650624d92f0b8e200a6ab25f810d6f"
-#else
-  "9c4e6146b29bac5d5d4be3c5bbab9c072dcb3f3f",
-  "f350001c333902029800bd291fbed915a4bdf19a",
-  "eb9d853b7daec03052c4850027ac94adc84c3a7e"
-#endif
+const char* const pHashStr[][2] = { //DO NOT CHANGE!
+  // Allow for different output depending on whether averaging is done
+  // vertically or horizontally first when downsampling.
+  { "244eebcb51f4c2a56e83fc5da3373cad9ec0e1e5", "9c4e6146b29bac5d5d4be3c5bbab9c072dcb3f3f" },
+  { "bbad99ef99e37b34bcb4f09a7ec4d144375f6be7", "f350001c333902029800bd291fbed915a4bdf19a" },
+  { "809f97e836650624d92f0b8e200a6ab25f810d6f", "eb9d853b7daec03052c4850027ac94adc84c3a7e" }
 };
 
 class DecodeParseAPI : public ::testing::TestWithParam<EncodeDecodeFileParamBase>, public EncodeDecodeTestBase {
@@ -905,7 +899,7 @@ TEST_F (DecodeParseAPI, ParseOnly_General) {
     unsigned char digest[SHA_DIGEST_LENGTH];
     SHA1Result (&ctx_, digest);
     if (!HasFatalFailure()) {
-      CompareHash (digest, pHashStr[uiTargetLayerId]);
+      CompareHashAnyOf (digest, pHashStr[uiTargetLayerId], sizeof *pHashStr / sizeof **pHashStr);
     }
   } //while
 #ifdef DEBUG_FILE_SAVE

--- a/test/api/encoder_test.cpp
+++ b/test/api/encoder_test.cpp
@@ -28,7 +28,7 @@ TEST_F (EncoderInitTest, JustInit) {}
 
 struct EncodeFileParam {
   const char* pkcFileName;
-  const char* pkcHashStr;
+  const char* pkcHashStr[2];
   EUsageType eUsageType;
   int iWidth;
   int iHeight;
@@ -97,89 +97,81 @@ TEST_P (EncoderOutputTest, CompareOutput) {
   unsigned char digest[SHA_DIGEST_LENGTH];
   SHA1Result (&ctx_, digest);
   if (!HasFatalFailure()) {
-    CompareHash (digest, p.pkcHashStr);
+    CompareHashAnyOf (digest, p.pkcHashStr, sizeof p.pkcHashStr / sizeof *p.pkcHashStr);
   }
 }
 static const EncodeFileParam kFileParamArray[] = {
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-    "ee97bab09041362fbe8aed16f69a55f16b106f92", CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"ee97bab09041362fbe8aed16f69a55f16b106f92"}, CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/CiscoVT2people_160x96_6fps.yuv",
-    "37b4f5b7b77b362dee9a74ac4b2bc043537f2dd0", CAMERA_VIDEO_REAL_TIME, 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"37b4f5b7b77b362dee9a74ac4b2bc043537f2dd0"}, CAMERA_VIDEO_REAL_TIME, 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/Static_152_100.yuv",
-    "b220be0163974e36fbd6662236d4e05566a21546", CAMERA_VIDEO_REAL_TIME, 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"b220be0163974e36fbd6662236d4e05566a21546"}, CAMERA_VIDEO_REAL_TIME, 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-    "21dbfaaf4f09af735298434c1f97cf95a464165b", CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_RASTER_SLICE, false, 1, false, false, false // One slice per MB row
+    {"21dbfaaf4f09af735298434c1f97cf95a464165b"}, CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_RASTER_SLICE, false, 1, false, false, false // One slice per MB row
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-    "409ced068a5a313cad7c654d27ab7a2edaed4630", CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1, false, false, false
+    {"409ced068a5a313cad7c654d27ab7a2edaed4630"}, CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, true, 1, false, false, false
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-// X86_ASM downsampling routines average vertically first, as opposed to
-// horizontally first, which results in different output.
-#ifdef X86_ASM
-    "a5341d588b769809c1f1d983e5a0fcef7362f3ad",
-#else
-    "73156dfc1dc45924349b5b79f8debcac13d7231d",
-#endif
+    // Allow for different output depending on whether averaging is done
+    // vertically or horizontally first when downsampling.
+    { "a5341d588b769809c1f1d983e5a0fcef7362f3ad", "73156dfc1dc45924349b5b79f8debcac13d7231d" },
     CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 2, false, false, false
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "8bc8813ee262b356e53eec6dbdc3c88d7d2b7b5c", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, false
+    {"8bc8813ee262b356e53eec6dbdc3c88d7d2b7b5c"}, CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, false
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-// X86_ASM downsampling routines average vertically first, as opposed to
-// horizontally first, which results in different output.
-#ifdef X86_ASM
-    "ec9d776a7d92cf0f6640065aee8af2450af0e993",
-#else
-    "3943145545a2bd27a642b2045d4e3dbae55c6870",
-#endif
+    // Allow for different output depending on whether averaging is done
+    // vertically or horizontally first when downsampling.
+    { "ec9d776a7d92cf0f6640065aee8af2450af0e993", "3943145545a2bd27a642b2045d4e3dbae55c6870" },
     CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_SINGLE_SLICE, false, 4, false, false, false
   },
   // the following values may be adjusted for times since we start tuning the strategy
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-    "c384a0dafc46573d02a38d8323304c5e1309d9d0", SCREEN_CONTENT_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"c384a0dafc46573d02a38d8323304c5e1309d9d0"}, SCREEN_CONTENT_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/CiscoVT2people_160x96_6fps.yuv",
-    "637d50652f9bb8750359c4b418f30a039908d56d", SCREEN_CONTENT_REAL_TIME, 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"637d50652f9bb8750359c4b418f30a039908d56d"}, SCREEN_CONTENT_REAL_TIME, 160, 96, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/Static_152_100.yuv",
-    "77a140c6bd80a6479ee13aecd2a8dac0a17cf03d", SCREEN_CONTENT_REAL_TIME, 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
+    {"77a140c6bd80a6479ee13aecd2a8dac0a17cf03d"}, SCREEN_CONTENT_REAL_TIME, 152, 100, 6.0f, SM_SINGLE_SLICE, false, 1, false, false, false
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "9e35aac6ee12b4516fbee114bc532faae23df76d", SCREEN_CONTENT_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, false
+    {"9e35aac6ee12b4516fbee114bc532faae23df76d"}, SCREEN_CONTENT_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, false
   },
   //for different strategy
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "1a6dc4f84cada651c4c8b24f879c858e35c2e813", SCREEN_CONTENT_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, true, true, false
+    {"1a6dc4f84cada651c4c8b24f879c858e35c2e813"}, SCREEN_CONTENT_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, true, true, false
   },
   {
     "res/CiscoVT2people_320x192_12fps.yuv",
-    "04ad01bb3872f7dae055c1ec661218f41a020dac", CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, true //turn on cabac
+    {"04ad01bb3872f7dae055c1ec661218f41a020dac"}, CAMERA_VIDEO_REAL_TIME, 320, 192, 12.0f, SM_SINGLE_SLICE, false, 1, false, false, true //turn on cabac
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "f5a92b7a0c00691e04bf1306c8251a74f989e4e2", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, true
+    {"f5a92b7a0c00691e04bf1306c8251a74f989e4e2"}, CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_SIZELIMITED_SLICE, false, 1, false, false, true
   },
   {
     "res/Cisco_Absolute_Power_1280x720_30fps.yuv",
-    "a27539982433279faa9975c96eaec28df770223e", CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_FIXEDSLCNUM_SLICE, false, 1, false, false, true
+    {"a27539982433279faa9975c96eaec28df770223e"}, CAMERA_VIDEO_REAL_TIME, 1280, 720, 30.0f, SM_FIXEDSLCNUM_SLICE, false, 1, false, false, true
   },
 };
 

--- a/test/utils/HashFunctions.h
+++ b/test/utils/HashFunctions.h
@@ -6,13 +6,28 @@
 #include <gtest/gtest.h>
 #include "../sha1.h"
 
-static void CompareHash (const unsigned char* digest, const char* hashStr) {
-  char hashStrCmp[SHA_DIGEST_LENGTH * 2 + 1];
-  for (int i = 0; i < SHA_DIGEST_LENGTH; ++i) {
-    sprintf (&hashStrCmp[i * 2], "%.2x", digest[i]);
+static void ToHashStr (char* dst, const unsigned char* src, size_t src_len) {
+  for (size_t i = 0; i < src_len; ++i) {
+    sprintf (&dst[i * 2], "%.2x", src[i]);
   }
-  hashStrCmp[SHA_DIGEST_LENGTH * 2] = '\0';
+  dst[src_len * 2] = '\0';
+}
+
+inline void CompareHash (const unsigned char* digest, const char* hashStr) {
+  char hashStrCmp[SHA_DIGEST_LENGTH * 2 + 1];
+  ToHashStr (hashStrCmp, digest, SHA_DIGEST_LENGTH);
   EXPECT_STREQ (hashStr, hashStrCmp);
+}
+
+inline void CompareHashAnyOf (const unsigned char* digest, const char* const hashStr[], size_t nHashStr) {
+  char hashStrCmp[SHA_DIGEST_LENGTH * 2 + 1];
+  ToHashStr (hashStrCmp, digest, SHA_DIGEST_LENGTH);
+  for (size_t i = 0; i < nHashStr && hashStr[i]; ++i) {
+    if (0 == strcmp (hashStr[i], hashStrCmp))
+      return;
+  }
+  // No match found. Compare to first hash so as to produce a grepable failure.
+  EXPECT_STREQ (hashStr[0], hashStrCmp);
 }
 
 #endif //__HASHFUNCTIONS_H__


### PR DESCRIPTION
Avoid X86_ASM ifdef.

Ideally, we may want to update all routines to average vertically
first, which would make this unnecessary. In the interim, this
enables the tests to run successfully on x86 without SSSE3 support
again.

Reviewed at: https://rbcommons.com/s/OpenH264/r/1640/