### PR TITLE
remove too many log for IDR loss under EC is off

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -1208,8 +1208,9 @@ int32_t UpdateAccessUnit (PWelsDecoderContext pCtx) {
         pCurAu->uiActualUnitsNum) { // no found IDR nal within incoming AU, need exit to avoid mosaic issue, 11/19/2009
 
       pCtx->sDecoderStatistics.uiIDRLostNum++;
-      WelsLog (& (pCtx->sLogCtx), WELS_LOG_WARNING,
-               "UpdateAccessUnit():::::Key frame lost.....CAN NOT find IDR from current AU.");
+      if (!pCtx->bParamSetsLostFlag)
+        WelsLog (& (pCtx->sLogCtx), WELS_LOG_WARNING,
+                 "UpdateAccessUnit():::::Key frame lost.....CAN NOT find IDR from current AU.");
       pCtx->iErrorCode |= dsRefLost;
       if (pCtx->eErrorConMethod == ERROR_CON_DISABLE) {
 #ifdef LONG_TERM_REF


### PR DESCRIPTION
when EC is off, the log "CAN NOT find..." exists for succeeding slices. Modify so that only the first input slice would print this log.

code review at:
https://rbcommons.com/s/OpenH264/r/1699/