### PR TITLE
fix macro missing build issue for avx2 in UT

### DIFF
--- a/test/encoder/EncUT_DecodeMbAux.cpp
+++ b/test/encoder/EncUT_DecodeMbAux.cpp
@@ -239,10 +239,12 @@ TEST (DecodeMbAuxTest, WelsIDctT4Rec_mmx) {
 TEST (DecodeMbAuxTest, WelsIDctT4Rec_sse2) {
   TestIDctT4Rec<int16_t> (WelsIDctT4Rec_sse2);
 }
+#if defined(HAVE_AVX2)
 TEST (DecodeMbAuxTest, WelsIDctT4Rec_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestIDctT4Rec<int16_t> (WelsIDctT4Rec_avx2);
 }
+#endif
 #endif
 template<typename clip_t>
 void WelsIDctT8Anchor (uint8_t* p_dst, int16_t dct[4][16]) {
@@ -340,10 +342,12 @@ TEST (DecodeMbAuxTest, WelsIDctRecI16x16Dc_c) {
 TEST (DecodeMbAuxTest, WelsIDctFourT4Rec_sse2) {
   TestIDctFourT4Rec<int16_t> (WelsIDctFourT4Rec_sse2);
 }
+#if defined(HAVE_AVX2)
 TEST (DecodeMbAuxTest, WelsIDctFourT4Rec_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestIDctFourT4Rec<int16_t> (WelsIDctFourT4Rec_avx2);
 }
+#endif
 TEST (DecodeMbAuxTest, WelsIDctRecI16x16Dc_sse2) {
   int32_t iCpuCores = 0;
   uint32_t uiCpuFeatureFlag = WelsCPUFeatureDetect (&iCpuCores);

--- a/test/encoder/EncUT_EncoderMbAux.cpp
+++ b/test/encoder/EncUT_EncoderMbAux.cpp
@@ -210,6 +210,7 @@ TEST (EncodeMbAuxTest, WelsDctFourT4_sse2) {
   TestDctFourT4 (WelsDctFourT4_sse2);
 }
 
+#ifdef HAVE_AVX2
 TEST (EncodeMbAuxTest, WelsDctT4_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestDctT4 (WelsDctT4_avx2);
@@ -219,6 +220,7 @@ TEST (EncodeMbAuxTest, WelsDctFourT4_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestDctFourT4 (WelsDctFourT4_avx2);
 }
+#endif //HAVE_AVX2
 
 TEST (EncodeMbAuxTest, WelsCalculateSingleCtr4x4_sse2) {
   CMemoryAlign cMemoryAlign (0);
@@ -452,6 +454,7 @@ TEST (EncodeMbAuxTest, WelsQuantFour4x4_sse2) {
 TEST (EncodeMbAuxTest, WelsQuantFour4x4Max_sse2) {
   TestWelsQuantFour4x4Max (WelsQuantFour4x4Max_sse2);
 }
+#ifdef HAVE_AVX2
 TEST (EncodeMbAuxTest, WelsQuant4x4_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestWelsQuant4x4 (WelsQuant4x4_avx2);
@@ -468,6 +471,7 @@ TEST (EncodeMbAuxTest, WelsQuantFour4x4Max_avx2) {
   if (WelsCPUFeatureDetect (0) & WELS_CPU_AVX2)
     TestWelsQuantFour4x4Max (WelsQuantFour4x4Max_avx2);
 }
+#endif //HAVE_AVX2
 #endif
 int32_t WelsHadamardQuant2x2SkipAnchor (int16_t* rs, int16_t ff,  int16_t mf) {
   int16_t pDct[4], s[4];

--- a/test/encoder/EncUT_Sample.cpp
+++ b/test/encoder/EncUT_Sample.cpp
@@ -636,10 +636,12 @@ GENERATE_Sad8x16_UT (WelsSampleSatd8x16_sse41, WelsSampleSatd8x16_c, WELS_CPU_SS
 GENERATE_Sad16x8_UT (WelsSampleSatd16x8_sse41, WelsSampleSatd16x8_c, WELS_CPU_SSE41)
 GENERATE_Sad16x16_UT (WelsSampleSatd16x16_sse41, WelsSampleSatd16x16_c, WELS_CPU_SSE41)
 
+#ifdef HAVE_AVX2
 GENERATE_Sad8x8_UT (WelsSampleSatd8x8_avx2, WelsSampleSatd8x8_c, WELS_CPU_AVX2)
 GENERATE_Sad8x16_UT (WelsSampleSatd8x16_avx2, WelsSampleSatd8x16_c, WELS_CPU_AVX2)
 GENERATE_Sad16x8_UT (WelsSampleSatd16x8_avx2, WelsSampleSatd16x8_c, WELS_CPU_AVX2)
 GENERATE_Sad16x16_UT (WelsSampleSatd16x16_avx2, WelsSampleSatd16x16_c, WELS_CPU_AVX2)
+#endif //HAVE_AVX2
 #endif
 
 #ifdef HAVE_NEON

--- a/test/processing/ProcessUT_VaaCalc.cpp
+++ b/test/processing/ProcessUT_VaaCalc.cpp
@@ -839,11 +839,13 @@ GENERATE_VAACalcSadSsdBgd_UT (VAACalcSadSsdBgd_sse2, 1, WELS_CPU_SSE2)
 GENERATE_VAACalcSadSsd_UT (VAACalcSadSsd_sse2, 1, WELS_CPU_SSE2)
 GENERATE_VAACalcSadVar_UT (VAACalcSadVar_sse2, 1, WELS_CPU_SSE2)
 
+#if defined(HAVE_AVX2)
 GENERATE_VAACalcSad_UT (VAACalcSad_avx2, 1, WELS_CPU_AVX2)
 GENERATE_VAACalcSadBgd_UT (VAACalcSadBgd_avx2, 1, WELS_CPU_AVX2)
 GENERATE_VAACalcSadSsdBgd_UT (VAACalcSadSsdBgd_avx2, 1, WELS_CPU_AVX2)
 GENERATE_VAACalcSadSsd_UT (VAACalcSadSsd_avx2, 1, WELS_CPU_AVX2)
 GENERATE_VAACalcSadVar_UT (VAACalcSadVar_avx2, 1, WELS_CPU_AVX2)
+#endif //HAVE_AVX2
 #endif
 
 #if defined(HAVE_NEON)


### PR DESCRIPTION
missing some macros for building UT solution related to AVX2 asm.
review see:
https://rbcommons.com/s/OpenH264/r/1704/