### PR TITLE
[Common] for singleton of ThreadPool

### DIFF
--- a/codec/common/inc/WelsList.h
+++ b/codec/common/inc/WelsList.h
@@ -104,6 +104,20 @@ class CWelsList {
     return NULL;
   }
 
+  TNodeType* index (int32_t iIndex) {
+    int32_t iIdx = 0;
+    SNode<TNodeType>* pNode = m_pFirst;
+    while ((pNode != NULL) && (iIdx <= iIndex)) {
+      if (iIdx == iIndex) {
+        return pNode->pPointer;
+      }
+      pNode = pNode->pNextNode;
+      iIdx ++;
+    }
+
+    return NULL;
+  }
+
   void pop_front() {
     if (m_iCurrentNodeCount == 0) {
       return;

--- a/codec/common/inc/WelsThreadPool.h
+++ b/codec/common/inc/WelsThreadPool.h
@@ -60,7 +60,7 @@ class  CWelsThreadPool : public CWelsThread, public IWelsTaskThreadSink {
   static WELS_THREAD_ERROR_CODE SetThreadNum (int32_t iMaxThreadNum);
 
   static CWelsThreadPool& AddReference();
-  void RemoveInstance();
+  void RemoveInstance (IWelsTaskSink* pSink);
 
   static bool IsReferenced();
 
@@ -76,7 +76,6 @@ class  CWelsThreadPool : public CWelsThread, public IWelsTaskThreadSink {
     return m_iMaxThreadNum;
   }
 
-
  protected:
   WELS_THREAD_ERROR_CODE Init();
   WELS_THREAD_ERROR_CODE Uninit();
@@ -84,8 +83,8 @@ class  CWelsThreadPool : public CWelsThread, public IWelsTaskThreadSink {
   WELS_THREAD_ERROR_CODE CreateIdleThread();
   void           DestroyThread (CWelsTaskThread* pThread);
   WELS_THREAD_ERROR_CODE AddThreadToIdleQueue (CWelsTaskThread* pThread);
-  WELS_THREAD_ERROR_CODE AddThreadToBusyList (CWelsTaskThread* pThread);
-  WELS_THREAD_ERROR_CODE RemoveThreadFromBusyList (CWelsTaskThread* pThread);
+  WELS_THREAD_ERROR_CODE AddThreadToBusyList (CWelsTaskThread* pThread, IWelsTask* pTask);
+  WELS_THREAD_ERROR_CODE RemoveThreadFromBusyList (CWelsTaskThread* pThread, IWelsTask* pTask);
   bool           AddTaskToWaitedList (IWelsTask* pTask);
   CWelsTaskThread*   GetIdleThread();
   IWelsTask*         GetWaitedTask();
@@ -93,20 +92,22 @@ class  CWelsThreadPool : public CWelsThread, public IWelsTaskThreadSink {
   int32_t            GetBusyThreadNum();
   int32_t            GetWaitedTaskNum();
   void               ClearWaitedTasks();
-
+  void RemoveWaitedTask (IWelsTaskSink* pTask);
+  void RemoveBusyTask (IWelsTaskSink* pSink);
  private:
   CWelsThreadPool();
   virtual ~CWelsThreadPool();
-  
+
   WELS_THREAD_ERROR_CODE StopAllRunning();
 
   static int32_t   m_iRefCount;
   static CWelsLock m_cInitLock;
   static int32_t   m_iMaxThreadNum;
 
-  CWelsCircleQueue<IWelsTask>* m_cWaitedTasks;
+  CWelsList<IWelsTask>* m_cWaitedTasks;
   CWelsCircleQueue<CWelsTaskThread>* m_cIdleThreads;
   CWelsList<CWelsTaskThread>* m_cBusyThreads;
+  CWelsList<IWelsTask>* m_cBusyTasks;
 
   CWelsLock   m_cLockPool;
   CWelsLock   m_cLockWaitedTasks;

--- a/codec/common/src/WelsThreadPool.cpp
+++ b/codec/common/src/WelsThreadPool.cpp
@@ -48,7 +48,7 @@ CWelsLock CWelsThreadPool::m_cInitLock;
 int32_t CWelsThreadPool::m_iMaxThreadNum = DEFAULT_THREAD_NUM;
 
 CWelsThreadPool::CWelsThreadPool() :
-  m_cWaitedTasks (NULL), m_cIdleThreads (NULL), m_cBusyThreads (NULL) {
+  m_cWaitedTasks (NULL), m_cIdleThreads (NULL), m_cBusyThreads (NULL), m_cBusyTasks (NULL) {
 }
 
 
@@ -75,7 +75,7 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::SetThreadNum (int32_t iMaxThreadNum) {
 }
 
 
-CWelsThreadPool& CWelsThreadPool::AddReference () {
+CWelsThreadPool& CWelsThreadPool::AddReference() {
   CWelsAutoLock  cLock (m_cInitLock);
   static CWelsThreadPool m_cThreadPoolSelf;
   if (m_iRefCount == 0) {
@@ -92,44 +92,51 @@ CWelsThreadPool& CWelsThreadPool::AddReference () {
   return m_cThreadPoolSelf;
 }
 
-void CWelsThreadPool::RemoveInstance() {
+
+void CWelsThreadPool::RemoveInstance (IWelsTaskSink* pSink) {
+  //fprintf (stdout, "RemoveInstance=%x\n", pSink);
+
   CWelsAutoLock  cLock (m_cInitLock);
-  //fprintf(stdout, "m_iRefCount=%d\n", m_iRefCount);
+  //fprintf (stdout, "m_iRefCount=%d GetBusyThreadNum=%d\n", m_iRefCount, GetBusyThreadNum());
+  //note: need to remove WaitedTask first in case that task in WaitedTask is added to running in between RemoveWaitedTask and RemoveBusyTask
+  RemoveWaitedTask (pSink);
+  RemoveBusyTask (pSink);
   -- m_iRefCount;
+
   if (0 == m_iRefCount) {
-    StopAllRunning();
+    //StopAllRunning();
     Uninit();
     //fprintf(stdout, "m_iRefCount=%d, IdleThreadNum=%d, BusyThreadNum=%d, WaitedTask=%d\n", m_iRefCount, GetIdleThreadNum(), GetBusyThreadNum(), GetWaitedTaskNum());
   }
+  //fprintf (stdout, "end RemoveInstance=%x, %d\n", pSink, m_iRefCount);
 }
 
 
 bool CWelsThreadPool::IsReferenced() {
   CWelsAutoLock  cLock (m_cInitLock);
-  return (m_iRefCount>0);
+  return (m_iRefCount > 0);
 }
 
 
 WELS_THREAD_ERROR_CODE CWelsThreadPool::OnTaskStart (CWelsTaskThread* pThread, IWelsTask* pTask) {
-  AddThreadToBusyList (pThread);
+  //AddThreadToBusyList (pThread, pTask);
   //fprintf(stdout, "CWelsThreadPool::AddThreadToBusyList: Task %x at Thread %x\n", pTask, pThread);
   return WELS_THREAD_ERROR_OK;
 }
 
 WELS_THREAD_ERROR_CODE CWelsThreadPool::OnTaskStop (CWelsTaskThread* pThread, IWelsTask* pTask) {
-  //fprintf(stdout, "CWelsThreadPool::OnTaskStop 0: Task %x at Thread %x Finished\n", pTask, pThread);
+  //fprintf (stdout, "CWelsThreadPool::OnTaskStop 0: Task %x at Thread %x Finished\n", pTask, pThread);
 
-  RemoveThreadFromBusyList (pThread);
-  AddThreadToIdleQueue (pThread);
-  //fprintf(stdout, "CWelsThreadPool::OnTaskStop 1: Task %x at Thread %x Finished, m_pSink=%x\n", pTask, pThread, m_pSink);
 
   if (pTask->GetSink()) {
+    //fprintf (stdout, "CWelsThreadPool::OnTaskStop 1: Task %x at Thread %x Finished, sink=%x\n", pTask, pThread, pTask->GetSink());
     pTask->GetSink()->OnTaskExecuted();
   }
-  //if (m_pSink) {
-  //  m_pSink->OnTaskExecuted (pTask);
-  //}
-  //fprintf(stdout, "CWelsThreadPool::OnTaskStop 2: Task %x at Thread %x Finished\n", pTask, pThread);
+  RemoveThreadFromBusyList (pThread, pTask);
+  AddThreadToIdleQueue (pThread);
+  //fprintf (stdout, "CWelsThreadPool::OnTaskStop 2: Task %x at Thread %x Finished\n", pTask, pThread);
+
+  //fprintf (stdout, "CWelsThreadPool::OnTaskStop 3: Task %x at Thread %x Finished\n", pTask, pThread);
 
   SignalThread();
 
@@ -137,15 +144,16 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::OnTaskStop (CWelsTaskThread* pThread, IW
   return WELS_THREAD_ERROR_OK;
 }
 
-WELS_THREAD_ERROR_CODE CWelsThreadPool::Init () {
+WELS_THREAD_ERROR_CODE CWelsThreadPool::Init() {
   //fprintf(stdout, "Enter WelsThreadPool Init\n");
 
   CWelsAutoLock  cLock (m_cLockPool);
 
-  m_cWaitedTasks = new CWelsCircleQueue<IWelsTask>();
+  m_cWaitedTasks = new CWelsList<IWelsTask>();
   m_cIdleThreads = new CWelsCircleQueue<CWelsTaskThread>();
   m_cBusyThreads = new CWelsList<CWelsTaskThread>();
-  if (NULL == m_cWaitedTasks || NULL == m_cIdleThreads || NULL == m_cBusyThreads) {
+  m_cBusyTasks = new CWelsList<IWelsTask>();
+  if (NULL == m_cWaitedTasks || NULL == m_cIdleThreads || NULL == m_cBusyThreads || NULL == m_cBusyTasks) {
     return WELS_THREAD_ERROR_GENERAL;
   }
 
@@ -165,13 +173,16 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::Init () {
 WELS_THREAD_ERROR_CODE CWelsThreadPool::StopAllRunning() {
   WELS_THREAD_ERROR_CODE iReturn = WELS_THREAD_ERROR_OK;
 
+  //fprintf (stdout, "CWelsThreadPool::Uninit ClearWaitedTasks\n");
   ClearWaitedTasks();
 
+  //fprintf (stdout, "CWelsThreadPool::Uninit GetBusyThreadNum %d\n", GetBusyThreadNum());
   while (GetBusyThreadNum() > 0) {
-    //WELS_INFO_TRACE ("CWelsThreadPool::Uninit - Waiting all thread to exit");
+    //fprintf (stdout, "CWelsThreadPool::Uninit - Waiting all thread to exit\n");
     WelsSleep (10);
   }
 
+  //fprintf (stdout, "StopAllRunning:  GetIdleThreadNum %d %d\n", GetIdleThreadNum(), m_iMaxThreadNum);
   if (GetIdleThreadNum() != m_iMaxThreadNum) {
     iReturn = WELS_THREAD_ERROR_GENERAL;
   }
@@ -197,37 +208,45 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::Uninit() {
 
   Kill();
 
-  WELS_DELETE_OP(m_cWaitedTasks);
-  WELS_DELETE_OP(m_cIdleThreads);
-  WELS_DELETE_OP(m_cBusyThreads);
+  WELS_DELETE_OP (m_cWaitedTasks);
+  WELS_DELETE_OP (m_cIdleThreads);
+  WELS_DELETE_OP (m_cBusyThreads);
+  WELS_DELETE_OP (m_cBusyTasks);
 
   return iReturn;
 }
 
 void CWelsThreadPool::ExecuteTask() {
-  //fprintf(stdout, "ThreadPool: scheduled tasks: ExecuteTask\n");
+  //fprintf (stdout, "ThreadPool: scheduled tasks: ExecuteTask\n");
   CWelsTaskThread* pThread = NULL;
   IWelsTask*    pTask = NULL;
   while (GetWaitedTaskNum() > 0) {
+    //fprintf (stdout, "CWelsThreadPool::ExecuteTask: GetIdleThread00\n");
     pThread = GetIdleThread();
+    //fprintf (stdout, "CWelsThreadPool::ExecuteTask: GetIdleThread01 %x\n", pThread);
     if (pThread == NULL) {
       break;
     }
     pTask = GetWaitedTask();
-    //fprintf(stdout, "ThreadPool:  ExecuteTask = %x at thread %x\n", pTask, pThread);
-    pThread->SetTask (pTask);
+    if (pTask) {
+      //fprintf (stdout, "ThreadPool:  ExecuteTask = %x at thread %x\n", pTask, pThread);
+      AddThreadToBusyList (pThread, pTask);
+      pThread->SetTask (pTask);
+    }
   }
 }
 
 WELS_THREAD_ERROR_CODE CWelsThreadPool::QueueTask (IWelsTask* pTask) {
   CWelsAutoLock  cLock (m_cLockPool);
 
-  //fprintf(stdout, "CWelsThreadPool::QueueTask: %d, pTask=%x\n", m_iRefCount, pTask);
+  //fprintf (stdout, "CWelsThreadPool::QueueTask: %d, pTask=%x\n", m_iRefCount, pTask);
   if (GetWaitedTaskNum() == 0) {
+    //fprintf (stdout, "CWelsThreadPool::QueueTask: GetIdleThread11\n");
     CWelsTaskThread* pThread = GetIdleThread();
-
+    //fprintf (stdout, "CWelsThreadPool::ExecuteTask: GetIdleThread12\n");
     if (pThread != NULL) {
-      //fprintf(stdout, "ThreadPool:  ExecuteTask = %x at thread %x\n", pTask, pThread);
+      //fprintf (stdout, "ThreadPool:  QueueTask = %x at thread %x\n", pTask, pThread);
+      AddThreadToBusyList (pThread, pTask);
       pThread->SetTask (pTask);
 
       return WELS_THREAD_ERROR_OK;
@@ -261,7 +280,7 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::CreateIdleThread() {
 
 void  CWelsThreadPool::DestroyThread (CWelsTaskThread* pThread) {
   pThread->Kill();
-  WELS_DELETE_OP(pThread);
+  WELS_DELETE_OP (pThread);
 
   return;
 }
@@ -272,15 +291,16 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::AddThreadToIdleQueue (CWelsTaskThread* p
   return WELS_THREAD_ERROR_OK;
 }
 
-WELS_THREAD_ERROR_CODE CWelsThreadPool::AddThreadToBusyList (CWelsTaskThread* pThread) {
+WELS_THREAD_ERROR_CODE CWelsThreadPool::AddThreadToBusyList (CWelsTaskThread* pThread, IWelsTask* pTask) {
   CWelsAutoLock cLock (m_cLockBusyTasks);
   m_cBusyThreads->push_back (pThread);
+  m_cBusyTasks->push_back (pTask);
   return WELS_THREAD_ERROR_OK;
 }
 
-WELS_THREAD_ERROR_CODE CWelsThreadPool::RemoveThreadFromBusyList (CWelsTaskThread* pThread) {
+WELS_THREAD_ERROR_CODE CWelsThreadPool::RemoveThreadFromBusyList (CWelsTaskThread* pThread, IWelsTask* pTask) {
   CWelsAutoLock cLock (m_cLockBusyTasks);
-  if (m_cBusyThreads->erase (pThread)) {
+  if (m_cBusyThreads->erase (pThread) && m_cBusyTasks->erase (pTask)) {
     return WELS_THREAD_ERROR_OK;
   } else {
     return WELS_THREAD_ERROR_GENERAL;
@@ -291,14 +311,14 @@ bool  CWelsThreadPool::AddTaskToWaitedList (IWelsTask* pTask) {
   CWelsAutoLock  cLock (m_cLockWaitedTasks);
 
   int32_t nRet = m_cWaitedTasks->push_back (pTask);
-  //fprintf(stdout, "CWelsThreadPool::AddTaskToWaitedList=%d, pTask=%x\n", m_cWaitedTasks->size(), pTask);
+  //fprintf(stdout, "CWelsThreadPool::AddTaskToWaitedList=%d, pTask=%x %x\n", m_cWaitedTasks->size(), pTask, pTask->GetSink());
   return (0==nRet ? true : false);
 }
 
 CWelsTaskThread*   CWelsThreadPool::GetIdleThread() {
   CWelsAutoLock cLock (m_cLockIdleTasks);
 
-  //fprintf(stdout, "CWelsThreadPool::GetIdleThread=%d\n", m_cIdleThreads->size());
+  //fprintf (stdout, "CWelsThreadPool::GetIdleThread=%d\n", m_cIdleThreads->size());
   if (m_cIdleThreads->size() == 0) {
     return NULL;
   }
@@ -309,16 +329,21 @@ CWelsTaskThread*   CWelsThreadPool::GetIdleThread() {
 }
 
 int32_t  CWelsThreadPool::GetBusyThreadNum() {
-  return m_cBusyThreads->size();
+  //CWelsAutoLock cLock (m_cLockBusyTasks);
+  return (m_cBusyThreads) ? (m_cBusyThreads->size()) : (-1);
 }
 
 int32_t  CWelsThreadPool::GetIdleThreadNum() {
-  return m_cIdleThreads->size();
+  // CWelsAutoLock cLock (m_cLockIdleTasks);
+  return (m_cIdleThreads) ? (m_cIdleThreads->size()) : (-1);
 }
 
 int32_t  CWelsThreadPool::GetWaitedTaskNum() {
-  //fprintf(stdout, "CWelsThreadPool::m_cWaitedTasks=%d\n", m_cWaitedTasks->size());
-  return m_cWaitedTasks->size();
+  //fprintf (stdout, "CWelsThreadPool::GetWaitedTaskNum\n");
+  //CWelsAutoLock cLock (m_cLockWaitedTasks);
+  //fprintf (stdout, "CWelsThreadPool::GetWaitedTaskNum m_cWaitedTasks=%x\n", m_cWaitedTasks);
+  //fprintf (stdout, "CWelsThreadPool::GetWaitedTaskNum m_cWaitedTasks=%d\n", m_cWaitedTasks->size());
+  return (m_cWaitedTasks) ? (m_cWaitedTasks->size()) : (-1);
 }
 
 IWelsTask* CWelsThreadPool::GetWaitedTask() {
@@ -331,19 +356,71 @@ IWelsTask* CWelsThreadPool::GetWaitedTask() {
   IWelsTask* pTask = m_cWaitedTasks->begin();
 
   m_cWaitedTasks->pop_front();
-
+  //fprintf (stdout, "CWelsThreadPool::GetWaitedTask=%x %d\n", pTask, m_cWaitedTasks->size());
   return pTask;
 }
 
 void  CWelsThreadPool::ClearWaitedTasks() {
   CWelsAutoLock cLock (m_cLockWaitedTasks);
   IWelsTask* pTask = NULL;
+  //fprintf (stdout, "CWelsThreadPool::ClearWaitedTasks m_cWaitedTasks=%d\n", m_cWaitedTasks->size());
   while (0 != m_cWaitedTasks->size()) {
+    //fprintf (stdout, "CWelsThreadPool::ClearWaitedTasks m_cWaitedTasks=%d\n", m_cWaitedTasks->size());
     pTask = m_cWaitedTasks->begin();
     if (pTask->GetSink()) {
       pTask->GetSink()->OnTaskCancelled();
+      //fprintf (stdout, "CWelsThreadPool::ClearWaitedTasks pTask=%x pSink=%d\n", pTask, pTask->GetSink());
     }
     m_cWaitedTasks->pop_front();
+  }
+}
+
+IWelsTask* FindTaskWithSink (CWelsList<IWelsTask>* pTaskList, IWelsTaskSink* pSink) {
+  //fprintf (stdout, "CWelsThreadPool::FindTaskWithSink\n");
+  int32_t iTaskNum = pTaskList->size();
+  //fprintf (stdout, "CWelsThreadPool::FindTaskWithSink %d %x %x\n", iTaskNum, pTaskList, pSink);
+  for (int32_t iIdx = 0; iIdx < iTaskNum; iIdx++) {
+    IWelsTask* pTask = pTaskList->index (iIdx);
+    if (pTask->GetSink() == pSink) {
+      //fprintf (stdout, "CWelsThreadPool::FindTaskWithSink %d %x %x\n", iIdx, pTask, pSink);
+      return pTask;
+    }
+  }
+  return NULL;
+}
+
+void CWelsThreadPool::RemoveWaitedTask (IWelsTaskSink* pSink) {
+  CWelsAutoLock cLock (m_cLockWaitedTasks);
+  //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask %x %x\n", m_cWaitedTasks, pSink);
+  if ((0 == m_cWaitedTasks->size()) || (NULL == pSink)) {
+    //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask m_cWaitedTasks %d or Sink==NULL\n", m_cWaitedTasks->size());
+    return;
+  }
+  //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask %d\n", m_cWaitedTasks->size());
+  IWelsTask* pTask = FindTaskWithSink (m_cWaitedTasks, pSink);
+  //fprintf (stdout, "CWelsThreadPool::RemoveWaitedsTask0 %x\n", pTask);
+  while (pTask) {
+    //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask1 %x\n", pTask);
+    pTask->GetSink()->OnTaskCancelled();
+    m_cWaitedTasks->erase (pTask);
+    //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask2 %x\n", pTask);
+    pTask = FindTaskWithSink (m_cWaitedTasks, pSink);
+  }
+  //fprintf (stdout, "CWelsThreadPool::RemoveWaitedTask %x %x\n", pSink, pTask);
+}
+
+void CWelsThreadPool::RemoveBusyTask (IWelsTaskSink* pSink) {
+  while (GetBusyThreadNum() > 0) {
+    //fprintf (stdout, "CWelsThreadPool::RemoveBusyTask %d %x\n", GetBusyThreadNum(), pSink);
+    m_cLockBusyTasks.Lock();
+    IWelsTask* pTask = FindTaskWithSink (m_cBusyTasks, pSink);
+    m_cLockBusyTasks.Unlock();
+    if (pTask) {
+      //fprintf (stdout, "CWelsThreadPool::RemoveBusyTask waiting %x to finish\n", pTask);
+      WelsSleep (10);
+    } else {
+      break;
+    }
   }
 }
 

--- a/codec/encoder/core/src/wels_task_management.cpp
+++ b/codec/encoder/core/src/wels_task_management.cpp
@@ -65,9 +65,9 @@ IWelsTaskManage*   IWelsTaskManage::CreateTaskManage (sWelsEncCtx* pCtx, const i
   pTaskManage = WELS_NEW_OP (CWelsTaskManageBase(), CWelsTaskManageBase);
   WELS_VERIFY_RETURN_IF (NULL, NULL == pTaskManage)
 
-  if ( ENC_RETURN_SUCCESS != pTaskManage->Init (pCtx) ) {
+  if (ENC_RETURN_SUCCESS != pTaskManage->Init (pCtx)) {
     pTaskManage->Uninit();
-    WELS_DELETE_OP(pTaskManage);
+    WELS_DELETE_OP (pTaskManage);
   }
   return pTaskManage;
 }
@@ -100,8 +100,8 @@ WelsErrorType CWelsTaskManageBase::Init (sWelsEncCtx* pEncCtx) {
   int32_t iReturn = ENC_RETURN_SUCCESS;
   //fprintf(stdout, "m_pThreadPool = &(CWelsThreadPool::GetInstance, this=%x\n", this);
   iReturn = CWelsThreadPool::SetThreadNum (m_iThreadNum);
-  m_pThreadPool = & (CWelsThreadPool::AddReference ());
-  if ( (iReturn != ENC_RETURN_SUCCESS) && pEncCtx ) {
+  m_pThreadPool = & (CWelsThreadPool::AddReference());
+  if ((iReturn != ENC_RETURN_SUCCESS) && pEncCtx) {
     WelsLog (& (pEncCtx->sLogCtx), WELS_LOG_WARNING, "Set Thread Num to %d did not succeed, current thread num in use: %d",
              m_iThreadNum, m_pThreadPool->GetThreadNum());
   }
@@ -120,16 +120,19 @@ WelsErrorType CWelsTaskManageBase::Init (sWelsEncCtx* pEncCtx) {
 }
 
 void   CWelsTaskManageBase::Uninit() {
-  DestroyTasks();
-  //fprintf(stdout, "m_pThreadPool = m_pThreadPool->RemoveInstance\n");
-  m_pThreadPool->RemoveInstance();
+
+  m_pThreadPool->RemoveInstance (this);
+  m_pThreadPool = NULL;
   //WELS_DELETE_OP (m_pThreadPool);
 
-  //fprintf(stdout, "m_pThreadPool = m_pThreadPool->RemoveInstance2\n");
+  //fprintf (stdout, "m_pThreadPool = m_pThreadPool->RemoveInstance\n");
+
+  DestroyTasks();
+  //fprintf (stdout, "DestroyTasks\n");
 
   for (int32_t iDid = 0; iDid < MAX_DEPENDENCY_LAYER; iDid++) {
-    WELS_DELETE_OP(m_cEncodingTaskList[iDid]);
-    WELS_DELETE_OP(m_cPreEncodingTaskList[iDid]);
+    WELS_DELETE_OP (m_cEncodingTaskList[iDid]);
+    WELS_DELETE_OP (m_cPreEncodingTaskList[iDid]);
   }
   WelsEventClose (&m_hTaskEvent);
   WelsMutexDestroy(&m_hEventMutex);

--- a/test/common/CWelsListTest.cpp
+++ b/test/common/CWelsListTest.cpp
@@ -137,6 +137,10 @@ TEST (CWelsList, CWelsListEraseAll) {
   }
   EXPECT_TRUE (cTestList.size() == TEST_LEN);
 
+  for (int i = 0; i < TEST_LEN; i++) {
+    EXPECT_TRUE (* (cTestList.index (i)) == data[i]);
+  }
+
   int iCurrentLen = TEST_LEN;
   do {
     int iEraseIdx = rand() % TEST_LEN;

--- a/test/common/WelsThreadPoolTest.h
+++ b/test/common/WelsThreadPoolTest.h
@@ -13,11 +13,11 @@ class CThreadPoolTest : public IWelsTaskSink {
   }
 
   ~CThreadPoolTest() {}
-
+/*
   virtual int32_t OnTaskExecuted (IWelsTask* pTask) {
     WelsCommon::CWelsAutoLock cAutoLock (m_cTaskCountLock);
     m_iTaskCount ++;
-    //fprintf(stdout, "Task execute over count is %d\n", m_iTaskCount);
+    fprintf(stdout, "Task execute over count is %d\n", m_iTaskCount);
     return cmResultSuccess;
   }
 
@@ -26,9 +26,10 @@ class CThreadPoolTest : public IWelsTaskSink {
     m_iTaskCount ++;
     //fprintf(stdout, "Task execute cancelled count is %d\n", m_iTaskCount);
     return cmResultSuccess;
-  }
+  }*/
 
   virtual int32_t OnTaskExecuted() {
+    //fprintf(stdout, "OnTaskExecuted %x\n", this);
     WelsCommon::CWelsAutoLock cAutoLock (m_cTaskCountLock);
     m_iTaskCount ++;
     //fprintf(stdout, "Task execute over count is %d\n", m_iTaskCount);


### PR DESCRIPTION
After threadpool becomes a singleton, we may need protection to ensure that, even if upper calling did not remove reference correctly, the thread pool itself will be able to terminate unneeded threads

main essential changes:
1, AddThreadToBusyList
2, RemoveBusyTask, RemoveWaitedTask

https://rbcommons.com/s/OpenH264/r/1585/
