### PR TITLE
Simplify getting the iOS SDK path

### DIFF
--- a/build/platform-ios.mk
+++ b/build/platform-ios.mk
@@ -7,11 +7,9 @@ SDKTYPE = iPhoneSimulator
 else
 SDKTYPE = iPhoneOS
 endif
-SDK = $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-version)
 SDK_MIN = 5.1
 
-XCODE=$(shell xcode-select -p)
-SDKROOT = $(XCODE)/Platforms/$(SDKTYPE).platform/Developer/SDKs/$(SDKTYPE)$(SDK).sdk
+SDKROOT = $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-path)
 CFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN) -DAPPLE_IOS -fembed-bitcode
 LDFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN)
 


### PR DESCRIPTION
Since some time ago, the SDK is actually in a directory named
iPhoneOS.sdk, and the one with a version number (like iPhoneOS10.0.sdk)
is only a symbolic link to the other one. Therefore we don't actually
need to query for the current SDK version.

Additionally, xcrun has got another option for getting the full
SDK path, all in one run, instead of having to manually hardcode
the path within the xcode app bundle, and query xcode-select for the
path to the xcode app bundle.
