### PR TITLE
API update: support sample aspect ratio in VUI

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -418,6 +418,30 @@ typedef enum {
   CM_NUM_ENUM
 } EColorMatrix;
 
+
+/**
+* @brief Enumerate the type of sample aspect ratio
+*/
+typedef enum {
+  ASP_UNSPECIFIED = 0,
+  ASP_1x1 = 1,
+  ASP_12x11 = 2,
+  ASP_10x11 = 3,
+  ASP_16x11 = 4,
+  ASP_40x33 = 5,
+  ASP_24x11 = 6,
+  ASP_20x11 = 7,
+  ASP_32x11 = 8,
+  ASP_80x33 = 9,
+  ASP_18x11 = 10,
+  ASP_15x11 = 11,
+  ASP_64x33 = 12,
+  ASP_160x99 = 13,
+  
+  ASP_EXT_SAR = 255
+} ESampleAspectRatio;
+
+
 /**
 * @brief  Structure for spatial layer configuration
 */
@@ -444,6 +468,12 @@ typedef struct {
 										    //   smpte240m, linear, log100, log316, iec61966-2-4, bt1361e, iec61966-2-1, bt2020-10, bt2020-12
   unsigned char	uiColorMatrix;				// EColorMatrix; 8 bits in header (corresponds to FFmpeg "colorspace"); 0 - 10 => GBR, bt709,
 										    //   undef, ???, fcc, bt470bg, smpte170m, smpte240m, YCgCo, bt2020nc, bt2020c
+
+  bool bAspectRatioPresent; ///< aspect ratio present in VUI
+  ESampleAspectRatio eAspectRatio; ///< aspect ratio idc
+  unsigned short sAspectRatioExtWidth; ///< use if aspect ratio idc == 255
+  unsigned short sAspectRatioExtHeight; ///< use if aspect ratio idc == 255
+
 } SSpatialLayerConfig;
 
 /**

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -186,6 +186,12 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
       param.sSpatialLayers[iLayer].sSliceArgument.uiSliceMode = SM_SINGLE_SLICE;
       param.sSpatialLayers[iLayer].sSliceArgument.uiSliceNum = 0; //AUTO, using number of CPU cores
       param.sSpatialLayers[iLayer].sSliceArgument.uiSliceSizeConstraint = 1500;
+
+      param.sSpatialLayers[iLayer].bAspectRatioPresent = false; // do not write any of the following information to the header
+      param.sSpatialLayers[iLayer].eAspectRatio = ASP_UNSPECIFIED;
+      param.sSpatialLayers[iLayer].sAspectRatioExtWidth = 0;
+      param.sSpatialLayers[iLayer].sAspectRatioExtHeight = 0;
+
       const int32_t kiLesserSliceNum = ((MAX_SLICES_NUM < MAX_SLICES_NUM_TMP) ? MAX_SLICES_NUM : MAX_SLICES_NUM_TMP);
       for (int32_t idx = 0; idx < kiLesserSliceNum; idx++)
         param.sSpatialLayers[iLayer].sSliceArgument.uiSliceMbNum[idx] = 0; //default, using one row a slice if uiSliceMode is SM_RASTER_MODE
@@ -425,6 +431,11 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
       pSpatialLayer->uiColorPrimaries =          pCodingParam.sSpatialLayers[iIdxSpatial].uiColorPrimaries;
       pSpatialLayer->uiTransferCharacteristics = pCodingParam.sSpatialLayers[iIdxSpatial].uiTransferCharacteristics;
       pSpatialLayer->uiColorMatrix =             pCodingParam.sSpatialLayers[iIdxSpatial].uiColorMatrix;
+
+      pSpatialLayer->bAspectRatioPresent = pCodingParam.sSpatialLayers[iIdxSpatial].bAspectRatioPresent;
+      pSpatialLayer->eAspectRatio = pCodingParam.sSpatialLayers[iIdxSpatial].eAspectRatio;
+      pSpatialLayer->sAspectRatioExtWidth = pCodingParam.sSpatialLayers[iIdxSpatial].sAspectRatioExtWidth;
+      pSpatialLayer->sAspectRatioExtHeight = pCodingParam.sSpatialLayers[iIdxSpatial].sAspectRatioExtHeight;
 
       uiProfileIdc = (!bSimulcastAVC) ? PRO_SCALABLE_BASELINE : PRO_BASELINE;
       ++ pDlp;

--- a/codec/encoder/core/inc/parameter_sets.h
+++ b/codec/encoder/core/inc/parameter_sets.h
@@ -98,6 +98,12 @@ bool            bConstraintSet2Flag;
 bool            bConstraintSet3Flag;
 // bool            bSeparateColorPlaneFlag;  // =false,: only used in decoder, encoder in general_***; it can be removed when removed general up_sample
 
+// aspect ratio in VUI
+bool            bAspectRatioPresent;
+ESampleAspectRatio  eAspectRatio;
+uint16_t            sAspectRatioExtWidth;
+uint16_t            sAspectRatioExtHeight;
+
 } SWelsSPS, *PWelsSPS;
 
 

--- a/codec/encoder/core/src/au_set.cpp
+++ b/codec/encoder/core/src/au_set.cpp
@@ -198,7 +198,14 @@ int32_t WelsWriteVUI (SWelsSPS* pSps, SBitStringAux* pBitStringAux) {
   SBitStringAux* pLocalBitStringAux = pBitStringAux;
   assert (pSps != NULL && pBitStringAux != NULL);
 
-  BsWriteOneBit (pLocalBitStringAux, false); //aspect_ratio_info_present_flag
+  BsWriteOneBit(pLocalBitStringAux, pSps->bAspectRatioPresent); //aspect_ratio_info_present_flag
+  if (pSps->bAspectRatioPresent) {
+    BsWriteBits(pLocalBitStringAux, 8, pSps->eAspectRatio); // aspect_ratio_idc
+    if (pSps->eAspectRatio == ASP_EXT_SAR) {
+      BsWriteBits(pLocalBitStringAux, 16, pSps->sAspectRatioExtWidth); // sar_width
+      BsWriteBits(pLocalBitStringAux, 16, pSps->sAspectRatioExtHeight); // sar_height
+    }
+  }
   BsWriteOneBit (pLocalBitStringAux, false); //overscan_info_present_flag
 
   // See codec_app_def.h and parameter_sets.h for more info about members bVideoSignalTypePresent through uiColorMatrix.
@@ -518,6 +525,11 @@ int32_t WelsInitSps (SWelsSPS* pSps, SSpatialLayerConfig* pLayerParam, SSpatialL
     pSps->bGapsInFrameNumValueAllowedFlag = true;
 
   pSps->bVuiParamPresentFlag = true;
+
+  pSps->bAspectRatioPresent = pLayerParam->bAspectRatioPresent;
+  pSps->eAspectRatio = pLayerParam->eAspectRatio;
+  pSps->sAspectRatioExtWidth = pLayerParam->sAspectRatioExtWidth;
+  pSps->sAspectRatioExtHeight = pLayerParam->sAspectRatioExtHeight;
 
   // See codec_app_def.h and parameter_sets.h for more info about members bVideoSignalTypePresent through uiColorMatrix.
   pSps->bVideoSignalTypePresent =   pLayerParam->bVideoSignalTypePresent;


### PR DESCRIPTION
"BIG_ENDIAN_16(x)" macro in codec/common/inc/macros.h is little bit inappropriate. Please, decide where to move it, and how it should be checked for big/little endian system.