### PR TITLE
[UT] fix the filling of testing data

### DIFF
--- a/test/api/encode_decode_api_test.cpp
+++ b/test/api/encode_decode_api_test.cpp
@@ -82,8 +82,9 @@ void EncodeDecodeTestAPIBase::prepareParamDefault (int iLayers, int iSlices, int
 
 void EncodeDecodeTestAPIBase::EncodeOneFrame (int iCheckTypeIndex) {
     int frameSize = EncPic.iPicWidth * EncPic.iPicHeight * 3 / 2;
-    memset (buf_.data(), iRandValue, (frameSize >> 2));
-    memset (buf_.data() + (frameSize >> 2), rand() % 256, (frameSize - (frameSize >> 2)));
+    int lumaSize = EncPic.iPicWidth * EncPic.iPicHeight;
+    memset (buf_.data(), iRandValue, lumaSize);
+    memset (buf_.data() + lumaSize, rand() % 256, (frameSize - lumaSize));
     int rv = encoder_->EncodeFrame (&EncPic, &info);
     if (0 == iCheckTypeIndex)
       ASSERT_TRUE (rv == cmResultSuccess);


### PR DESCRIPTION
https://rbcommons.com/s/OpenH264/r/1763/
fix the filling of testing data, previously it is not that the whole frame is filed with a same content