### PR TITLE
Make SDKROOT immediately assigned

### DIFF
--- a/build/platform-ios.mk
+++ b/build/platform-ios.mk
@@ -9,7 +9,7 @@ SDKTYPE = iPhoneOS
 endif
 SDK_MIN = 5.1
 
-SDKROOT = $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-path)
+SDKROOT := $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-path)
 CFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN) -DAPPLE_IOS -fembed-bitcode
 LDFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN)
 


### PR DESCRIPTION
This avoids re-expanding and rerunning the xcrun command for each time
the SDKROOT variable is used (i.e. once per file built).