### PR TITLE
Add a missing stdlib.h include

### DIFF
--- a/codec/common/inc/WelsList.h
+++ b/codec/common/inc/WelsList.h
@@ -43,6 +43,7 @@
 #define _WELS_LIST_H_
 
 #include "typedefs.h"
+#include <stdlib.h>
 
 namespace WelsCommon {
 


### PR DESCRIPTION
This fixes building for windows phone.

Prior to 8d444f5 this wasn't an issue, since WelsCircleQueue.h, which
included stdlib.h, was included before.