### PR TITLE
Remove the duplicated iRandValue from DecodeCrashTestAPI

### DIFF
--- a/test/api/decode_api_test.cpp
+++ b/test/api/decode_api_test.cpp
@@ -506,8 +506,6 @@ TEST_P (EncodeDecodeTestAPI, SetOption_Trace_NULL) {
 
 class DecodeCrashTestAPI : public ::testing::TestWithParam<EncodeDecodeFileParamBase>, public EncodeDecodeTestBase {
  public:
-  uint8_t iRandValue;
- public:
   void SetUp() {
     EncodeDecodeTestBase::SetUp();
     ucBuf_ = NULL;


### PR DESCRIPTION
The base class also has got such a field, which gets initialized
by the base class prepareEncDecParam.

This fixes valgrind errors about uninitialized data, present
since d1c0a93.