### PR TITLE
fix bug with ihadamard to correct place with qmatrix on

### DIFF
--- a/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
+++ b/codec/decoder/core/src/parse_mb_syn_cavlc.cpp
@@ -40,6 +40,7 @@
 
 
 #include "parse_mb_syn_cavlc.h"
+#include "decode_slice.h"
 #include "error_code.h"
 #include "mv_pred.h"
 
@@ -880,7 +881,18 @@ int32_t WelsResidualBlockCavlc (SVlcTable* pVlcTable, uint8_t* pNonZeroCountCach
       int32_t j;
       iCoeffNum += iRun[i] + 1; //FIXME add 1 earlier ?
       j          = kpZigzagTable[ iCoeffNum ];
-      pTCoeff[j] = pCtx->bUseScalingList ? (iLevel[i] * kpDequantCoeff[0]) >> 4 : (iLevel[i] * kpDequantCoeff[0]);
+      pTCoeff[j] = iLevel[i];
+    }
+    WelsChromaDcIdct (pTCoeff);
+    //scaling
+    if (!pCtx->bUseScalingList) {
+      for (int j = 0; j < 4; ++j) {
+        pTCoeff[kpZigzagTable[j]] = (pTCoeff[kpZigzagTable[j]] * kpDequantCoeff[0]) >> 1;
+      }
+    } else {
+      for (int j = 0; j < 4; ++j) {
+        pTCoeff[kpZigzagTable[j]] = ((int64_t) pTCoeff[kpZigzagTable[j]] * (int64_t) kpDequantCoeff[0]) >> 5;
+      }
     }
   } else if (iResidualProperty == I16_LUMA_DC) { //DC coefficent, only call in Intra_16x16, base_mode_flag = 0
     for (i = uiTotalCoeff - 1; i >= 0; --i) { //FIXME merge into rundecode?
@@ -889,12 +901,17 @@ int32_t WelsResidualBlockCavlc (SVlcTable* pVlcTable, uint8_t* pNonZeroCountCach
       j          = kpZigzagTable[ iCoeffNum ];
       pTCoeff[j] = iLevel[i];
     }
+    WelsLumaDcDequantIdct (pTCoeff, uiQp, pCtx);
   } else {
     for (i = uiTotalCoeff - 1; i >= 0; --i) { //FIXME merge into  rundecode?
       int32_t j;
       iCoeffNum += iRun[i] + 1; //FIXME add 1 earlier ?
       j          = kpZigzagTable[ iCoeffNum ];
-      pTCoeff[j] = pCtx->bUseScalingList ? (iLevel[i] * kpDequantCoeff[j]) >> 4 : (iLevel[i] * kpDequantCoeff[j & 0x07]);
+      if (!pCtx->bUseScalingList) {
+        pTCoeff[j] = (iLevel[i] * kpDequantCoeff[j & 0x07]);
+      } else {
+        pTCoeff[j] = (iLevel[i] * kpDequantCoeff[j] + 8) >> 4;
+      }
     }
   }
 

--- a/codec/decoder/core/src/rec_mb.cpp
+++ b/codec/decoder/core/src/rec_mb.cpp
@@ -237,8 +237,10 @@ void BaseMC (sMCRefMember* pMCRefMem, int32_t iXOffset, int32_t iYOffset, SMcFun
              int32_t iBlkWidth, int32_t iBlkHeight, int16_t iMVs[2]) {
   int32_t iFullMVx = (iXOffset << 2) + iMVs[0]; //quarter pixel
   int32_t iFullMVy = (iYOffset << 2) + iMVs[1];
-  iFullMVx = WELS_CLIP3 (iFullMVx, ((-PADDING_LENGTH + 2) * (1 << 2)), ((pMCRefMem->iPicWidth + PADDING_LENGTH - 19) * (1 << 2)));
-  iFullMVy = WELS_CLIP3 (iFullMVy, ((-PADDING_LENGTH + 2) * (1 << 2)), ((pMCRefMem->iPicHeight + PADDING_LENGTH - 19) * (1 << 2)));
+  iFullMVx = WELS_CLIP3 (iFullMVx, ((-PADDING_LENGTH + 2) * (1 << 2)),
+                         ((pMCRefMem->iPicWidth + PADDING_LENGTH - 19) * (1 << 2)));
+  iFullMVy = WELS_CLIP3 (iFullMVy, ((-PADDING_LENGTH + 2) * (1 << 2)),
+                         ((pMCRefMem->iPicHeight + PADDING_LENGTH - 19) * (1 << 2)));
 
   int32_t iSrcPixOffsetLuma = (iFullMVx >> 2) + (iFullMVy >> 2) * pMCRefMem->iSrcLineLuma;
   int32_t iSrcPixOffsetChroma = (iFullMVx >> 3) + (iFullMVy >> 3) * pMCRefMem->iSrcLineChroma;
@@ -541,8 +543,6 @@ int32_t RecChroma (int32_t iMBXY, PWelsDecoderContext pCtx, int16_t* pScoeffLeve
   uint8_t uiCbpC = pDqLayer->pCbp[iMBXY] >> 4;
 
   if (1 == uiCbpC || 2 == uiCbpC) {
-    WelsChromaDcIdct (pScoeffLevel + 256);      // 256 = 16*16
-    WelsChromaDcIdct (pScoeffLevel + 320);      // 256 = 16*16
     for (i = 0; i < 2; i++) {
       int16_t* pRS = pScoeffLevel + 256 + (i << 6);
       uint8_t* pPred = pDqLayer->pPred[i + 1];


### PR DESCRIPTION
In Decoder, Hadamard transform should be prior to scaling process in Rec.
Previously it was combined with DCT process for baseline profile. It does not work for high profile.
Fix the bug and re-position it to proper place.
see:
https://rbcommons.com/s/OpenH264/r/1819/