### PR TITLE
bug fixes:reallocate UT pointer null memory issue

### DIFF
--- a/test/encoder/EncUT_SliceBufferReallocate.cpp
+++ b/test/encoder/EncUT_SliceBufferReallocate.cpp
@@ -164,8 +164,8 @@ void SetParamForReallocateTest (sWelsEncCtx* pCtx, int32_t iLayerIdx,
 
 void CSliceBufferReallocatTest::InitParamForTestCase (int32_t iLayerIdx) {
   InitParam();
-  InitLayerSliceBuffer (iLayerIdx);
   InitFrameBsBuffer();
+  InitLayerSliceBuffer (iLayerIdx);
 
   //param validation
   int32_t iRet = m_pEncoder->InitializeExt ((SEncParamExt*)m_EncContext.pSvcParam);
@@ -177,6 +177,7 @@ void CSliceBufferReallocatTest::InitParamForSizeLimitSlcModeCase (int32_t iLayer
   int32_t iRet = 0;
 
   InitParam();
+  InitFrameBsBuffer();
   InitLayerSliceBuffer (iLayerIdx);
 
   if (SM_SIZELIMITED_SLICE != pSliceArgument->uiSliceMode && NULL != m_EncContext.ppDqLayerList[iLayerIdx]) {
@@ -186,7 +187,6 @@ void CSliceBufferReallocatTest::InitParamForSizeLimitSlcModeCase (int32_t iLayer
     EXPECT_TRUE (ENC_RETURN_SUCCESS == iRet);
     EXPECT_TRUE (NULL != m_EncContext.ppDqLayerList[iLayerIdx]);
   }
-  InitFrameBsBuffer();
 
   //param validation
   iRet = m_pEncoder->InitializeExt ((SEncParamExt*)m_EncContext.pSvcParam);


### PR DESCRIPTION
memory null pointer issue check by UBSan setting.
codec/encoder/core/src/svc_encode_slice.cpp:1057:40:
 runtime error: member access within null pointer of type 'SWelsEncoderOutput'

cause by initial order not right