### PR TITLE
Add support for building with ARCH=arm64 with MSVC

### DIFF
--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -12,6 +12,10 @@ ifeq ($(ASM_ARCH), arm)
 CCAS = gas-preprocessor.pl -as-type armasm -force-thumb -- armasm
 CCASFLAGS = -nologo -DHAVE_NEON -ignore 4509
 endif
+ifeq ($(ASM_ARCH), arm64)
+CCAS = gas-preprocessor.pl -as-type armasm -arch aarch64 -- armasm64
+CCASFLAGS = -nologo -DHAVE_NEON_AARCH64
+endif
 
 CC=cl
 CXX=cl


### PR DESCRIPTION
This requires the absolute latest version of gas-preprocessor though.