### PR TITLE
Fix Clang compiler error

### DIFF
--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -60,11 +60,17 @@ mov pc, lr
 .arm
 .global \funcName
 .type \funcName, %function
+#ifndef __clang__
+.func \funcName
+#endif
 \funcName:
 .endm
 
 .macro WELS_ASM_FUNC_END
 mov pc, lr
+#ifndef __clang__
+.endfunc
+#endif
 .endm
 #endif
 

--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -60,13 +60,11 @@ mov pc, lr
 .arm
 .global \funcName
 .type \funcName, %function
-.func \funcName
 \funcName:
 .endm
 
 .macro WELS_ASM_FUNC_END
 mov pc, lr
-.endfunc
 .endm
 #endif
 


### PR DESCRIPTION
Clang compiler does not recognize .func and .endFunc.
Removed them.