### PR TITLE
Enable NEON for ChromeOS devices

### DIFF
--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -258,13 +258,18 @@ uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
 
 /* Generic arm/linux cpu feature detection */
 uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
+  int flags = 0;
   FILE* f = fopen ("/proc/cpuinfo", "r");
 
-  if (!f)
-    return 0;
+#if defined(__chromeos__)
+  flags |= WELS_CPU_NEON;
+#endif
+
+  if (!f) {
+    return flags;
+  }
 
   char buf[200];
-  int flags = 0;
   while (fgets (buf, sizeof (buf), f)) {
     if (!strncmp (buf, "Features", strlen ("Features"))) {
       // The asimd and fp features are listed on 64 bit ARMv8 kernels


### PR DESCRIPTION
Chrome uses openh264 to encode video frames for MediaRecorder APIs.
However, on ChromeOS, the encoding procedure is run in renderer process,
which can not access /proc/cpuinfo, making openH264 think that NEON is
not available.

Since all arm-based ChromeOS devices have NEON, it can be marked as
enabled anyway.