### PR TITLE
add dec option for is_ref_pic

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -165,6 +165,7 @@ typedef enum {
   DECODER_OPTION_PROFILE,               ///< get current AU profile info, only is used in GetOption
   DECODER_OPTION_LEVEL,                 ///< get current AU level info,only is used in GetOption
   DECODER_OPTION_STATISTICS_LOG_INTERVAL,///< set log output interval
+  DECODER_OPTION_IS_REF_PIC,             ///< feedback current frame is ref pic or not
 
 } DECODER_OPTION;
 

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -415,6 +415,7 @@ typedef struct TagWelsDecoderContext {
 //feedback whether or not have VCL in current AU, and the temporal ID
   int32_t iFeedbackVclNalInAu;
   int32_t iFeedbackTidInAu;
+  int32_t iFeedbackNalRefIdc;
 
   bool bAuReadyFlag;   // true: one au is ready for decoding; false: default value
 

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -323,6 +323,8 @@ void WelsDecoderDefaults (PWelsDecoderContext pCtx, SLogContext* pLogCtx) {
   pCtx->iSPSLastInvalidId = -1;
   pCtx->iSubSPSInvalidNum = 0;
   pCtx->iSubSPSLastInvalidId = -1;
+  pCtx->iFeedbackNalRefIdc = -1; //initialize
+
 }
 
 /*
@@ -596,6 +598,7 @@ void GetVclNalTemporalId (PWelsDecoderContext pCtx) {
 
   pCtx->iFeedbackVclNalInAu = FEEDBACK_VCL_NAL;
   pCtx->iFeedbackTidInAu    = pAccessUnit->pNalUnitsList[idx]->sNalHeaderExt.uiTemporalId;
+  pCtx->iFeedbackNalRefIdc  = pAccessUnit->pNalUnitsList[idx]->sNalHeaderExt.sNalUnitHeader.uiNalRefIdc;
 }
 
 /*!

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -403,6 +403,12 @@ long CWelsDecoder::GetOption (DECODER_OPTION eOptID, void* pOption) {
     iVal = m_pDecContext->iFeedbackTidInAu;
     * ((int*)pOption) = iVal;
     return cmResultSuccess;
+  } else if (DECODER_OPTION_IS_REF_PIC == eOptID) {
+    iVal = m_pDecContext->iFeedbackNalRefIdc;
+    if (iVal > 0)
+      iVal = 1;
+    * ((int*)pOption) = iVal;
+    return cmResultSuccess;
   } else if (DECODER_OPTION_ERROR_CON_IDC == eOptID) {
     iVal = (int) m_pDecContext->pParam->eEcActiveIdc;
     * ((int*)pOption) = iVal;
@@ -537,6 +543,7 @@ DECODING_STATE CWelsDecoder::DecodeFrame2 (const unsigned char* kpSrc,
 #endif
 
   m_pDecContext->iFeedbackTidInAu             = -1; //initialize
+  m_pDecContext->iFeedbackNalRefIdc           = -1; //initialize
   if (pDstInfo) {
     pDstInfo->uiOutYuvTimeStamp = 0;
     m_pDecContext->uiTimeStamp = pDstInfo->uiInBsTimeStamp;
@@ -716,6 +723,7 @@ DECODING_STATE CWelsDecoder::DecodeParser (const unsigned char* kpSrc,
 
   m_pDecContext->iErrorCode = dsErrorFree; //initialize at the starting of AU decoding.
   m_pDecContext->pParam->eEcActiveIdc = ERROR_CON_DISABLE; //add protection to disable EC here.
+  m_pDecContext->iFeedbackNalRefIdc = -1; //initialize
   if (!m_pDecContext->bFramePending) { //frame complete
     m_pDecContext->pParserBsInfo->iNalNum = 0;
     memset (m_pDecContext->pParserBsInfo->pNalLenInByte, 0, MAX_NAL_UNITS_IN_LAYER);


### PR DESCRIPTION
add GetOption in Decoder to return if current outputted picture is reference picture or not.
return value:
  -1: no output picture;
   0: is not a reference picture;
   1: is a reference picture.

see:
https://rbcommons.com/s/OpenH264/r/1862/