### PR TITLE
Avoid implicit conversions from double to int32_t

### DIFF
--- a/codec/encoder/core/src/ratectl.cpp
+++ b/codec/encoder/core/src/ratectl.cpp
@@ -580,8 +580,7 @@ void RcDecideTargetBitsTimestamp (sWelsEncCtx* pEncCtx) {
       pWelsSvcRc->iTargetBits = pTOverRc->iMinBitsTl;
     } else {
       int32_t iMaxTh = iBufferTh * 3 / 4;
-      int32_t iMinTh = (pDLayerParam->fFrameRate < 8) ? iBufferTh * 1.0 / 4 : static_cast<int32_t>
-                       (iBufferTh * 2 / pDLayerParam->fFrameRate);
+      int32_t iMinTh = static_cast<int32_t>((pDLayerParam->fFrameRate < 8) ? iBufferTh * 1.0 / 4 : iBufferTh * 2 / pDLayerParam->fFrameRate);
       if (pDLayerParam->fFrameRate < (IDR_BITRATE_RATIO + 1))
         pWelsSvcRc->iTargetBits = static_cast<int32_t> (((double) (pDLayerParam->iSpatialBitrate) / (double) (
                                     pDLayerParam->fFrameRate)));
@@ -612,8 +611,7 @@ void RcDecideTargetBitsTimestamp (sWelsEncCtx* pEncCtx) {
       pWelsSvcRc->iTargetBits = WELS_DIV_ROUND (pTOverRc->iTlayerWeight * kiGopBits, INT_MULTIPLY * 10 * 2);
 
       int32_t iMaxTh = iBufferTh / 2;
-      int32_t iMinTh = (pDLayerParam->fFrameRate < 8) ? iBufferTh * 1.0 / 4 : static_cast<int32_t>
-                       (iBufferTh * 2 / pDLayerParam->fFrameRate);
+      int32_t iMinTh = static_cast<int32_t>((pDLayerParam->fFrameRate < 8) ? iBufferTh * 1.0 / 4 : iBufferTh * 2 / pDLayerParam->fFrameRate);
       WelsLog (& (pEncCtx->sLogCtx), WELS_LOG_DEBUG,
                "iMaxTh = %d,iMinTh = %d,pWelsSvcRc->iTargetBits = %d,pWelsSvcRc->iBufferSizeSkip = %d, pWelsSvcRc->iBufferFullnessSkip= % "
                PRId64,


### PR DESCRIPTION
This fixes warnings when building with MSVC.