### PR TITLE
Allow overriding symbol visibility

### DIFF
--- a/codec/common/x86/asm_inc.asm
+++ b/codec/common/x86/asm_inc.asm
@@ -485,12 +485,15 @@ SECTION .note.GNU-stack noalloc noexec nowrite progbits ; Mark the stack as non-
 %endmacro
 
 %macro WELS_EXTERN 1
+    %ifndef WELS_PRIVATE_EXTERN
+        %define WELS_PRIVATE_EXTERN
+    %endif
     ALIGN 16, nop
     %ifdef PREFIX
-        global _%1
+        global _%1 WELS_PRIVATE_EXTERN
         %define %1 _%1
     %else
-        global %1
+        global %1 WELS_PRIVATE_EXTERN
     %endif
     %1:
 %endmacro


### PR DESCRIPTION
This patch adds configurable symbol visibility.  This is useful for projects
that want to do in-tree openh264 builds and not export any symbols, otherwise
they would conflict with the system library's symbols.

Users can pass -DWELS_PRIVATE_EXTERN=:hidden on Linux or
-DWELS_PRIVATE_EXTERN=:private_extern on mac to hide symbols that would have
been exported.