### PR TITLE
Initialize the frame buffer in EncodeDecodeTestAPIBase::InitialEncDec

### DIFF
--- a/test/api/encode_options_test.cpp
+++ b/test/api/encode_options_test.cpp
@@ -36,6 +36,7 @@ bool EncodeDecodeTestAPIBase::InitialEncDec (int iWidth, int iHeight) {
 
   //set a fixed random value
   iRandValue = rand() % 256;
+  memset (buf_.data(), iRandValue, frameSize);
   return true;
 }
 
@@ -2157,11 +2158,6 @@ TEST_F (EncodeDecodeTestAPI, UnsupportedVideoSizeInput) {
   iSrcHeight = iHeight;
 
   ASSERT_TRUE (InitialEncDec (iSrcWidth, iSrcHeight));
-
-  int frameSize = EncPic.iPicWidth * EncPic.iPicHeight * 3 / 2;
-  int lumaSize = EncPic.iPicWidth * EncPic.iPicHeight;
-  memset (buf_.data(), iRandValue, lumaSize);
-  memset (buf_.data() + lumaSize, rand() % 256, (frameSize - lumaSize));
 
   iRet = encoder_->EncodeFrame (&EncPic, &info);
 


### PR DESCRIPTION
This avoids use of uninitialized data (valgrind errors) in
EncodeDecodeTestAPI.ScreenContent_LosslessLink0_EnableLongTermReference.

Normally the buffer is initialized separately for each encoded frame
if using EncodeDecodeTestAPIBase::EncodeOneFrame, but for tests
that use encoder_->EncodeFrame directly, make sure the data always
is initialized.