### PR TITLE
Fix errors and warnings when building with msvc and for android with stlport

### DIFF
--- a/test/api/encode_options_test.cpp
+++ b/test/api/encode_options_test.cpp
@@ -2302,7 +2302,7 @@ TEST_F (EncodeDecodeTestAPI,  TemporalLayerChangeDuringEncoding_Specific) {
       if ( (iStepIdx < 3) && (iFrameNum == ((iTotalFrame / 3) * (iStepIdx + 1)))) {
         sParam.iTemporalLayerNum = originalTemporalLayerNum * iSteps[iStepIdx];
         sParam.iTargetBitrate = sParam.sSpatialLayers[0].iSpatialBitrate = originalBR * iSteps[iStepIdx];
-        sParam.fMaxFrameRate = sParam.sSpatialLayers[0].fFrameRate = originalFR * pow (2, iSteps[iStepIdx]);
+        sParam.fMaxFrameRate = sParam.sSpatialLayers[0].fFrameRate = originalFR * pow (2.0f, iSteps[iStepIdx]);
         encoder_->SetOption (ENCODER_OPTION_SVC_ENCODE_PARAM_EXT, &sParam);
 
         bSetOption = true;


### PR DESCRIPTION
This fixes the following two kinds of errors and warnings:
encode_options_test.cpp(2305) : error C2668: 'pow' : ambiguous call to overloaded function
        math.h(583): could be 'long double pow(long double,int)'
        math.h(535): or       'float pow(float,int)'
        math.h(497): or       'double pow(double,int)'
        while trying to match the argument list '(int, int)'

encode_options_test.cpp(2305) : warning C4244: '=' : conversion from 'double' to 'float', possible loss of data