### PR TITLE
call _set_FMA3_enable only on vs 2013 (avx2 bug)

### DIFF
--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -63,7 +63,7 @@ extern const uint8_t   g_kuiTemporalIdListTable[MAX_TEMPORAL_LEVEL][MAX_GOP_SIZE
 * \return   2 based scaling factor
 */
 static inline uint32_t GetLogFactor (float base, float upper) {
-#if defined(_M_X64)
+#if defined(_M_X64) && _MSC_VER == 1800
   _set_FMA3_enable(0);
 #endif
   const double dLog2factor      = log10 (1.0 * upper / base) / log10 (2.0);


### PR DESCRIPTION
ref link:
http://web.archive.org/web/20150325003447/http://connect.microsoft.com/VisualStudio/feedback/details/811093

this fixes the build on mingw