### PR TITLE
Fix WelsThreadLib.cpp to build under Fuchsia.

### DIFF
--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -259,7 +259,7 @@ WELS_THREAD_ERROR_CODE    WelsThreadCreate (WELS_THREAD_HANDLE* thread,  LPWELS_
   err = pthread_attr_init (&at);
   if (err)
     return err;
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__Fuchsia__)
   err = pthread_attr_setscope (&at, PTHREAD_SCOPE_SYSTEM);
   if (err)
     return err;
@@ -560,5 +560,3 @@ WELS_THREAD_ERROR_CODE    WelsQueryLogicalProcessInfo (WelsLogicalProcessInfo* p
 }
 
 #endif
-
-


### PR DESCRIPTION
Fuchsia's POSIX compatibility layer does not provide the two pthread calls used here.