### PR TITLE
Makefile: Use tr in a POSIX-conform way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ vpath %.S $(SRC_PATH)
 vpath %.rc $(SRC_PATH)
 vpath %.pc.in $(SRC_PATH)
 
-OS=$(shell uname | tr A-Z a-z | tr -d \\-[:digit:]. | sed -E 's/^(net|open|free)bsd/bsd/')
+OS=$(shell uname | tr A-Z a-z | tr -d \\-0-9. | sed -E 's/^(net|open|free)bsd/bsd/')
 ARCH=$(shell uname -m)
 LIBPREFIX=lib
 LIBSUFFIX=a


### PR DESCRIPTION
I stumbled upon this issue when trying to build on Alpine Linux, where busybox provides tools like 'tr'.
Busybox' tr doesn't interpret the :digit: character class, and instead literally removes the characters :digit from the input, resulting in the OS string "lnux"

0-9 should be a compatible and more standard-conform way.