### PR TITLE
Clip fFrameRate locally in EncoderInterfaceTest.EncoderOptionSetTest

### DIFF
--- a/test/encoder/EncUT_EncoderExt.cpp
+++ b/test/encoder/EncUT_EncoderExt.cpp
@@ -205,9 +205,10 @@ TEST_F (EncoderInterfaceTest, EncoderOptionSetTest) {
   else {
     EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
 
+    fFrameRate = WELS_CLIP3 (fFrameRate, 1, 60);
     iResult = pPtrEnc->GetOption (eOptionId, &fReturn);
     EXPECT_EQ (iResult, static_cast<int> (cmResultSuccess));
-    EXPECT_EQ (WELS_CLIP3 (fFrameRate, 1, 60), fReturn);
+    EXPECT_EQ (fFrameRate, fReturn);
   }
   PrepareOneSrcFrame();
   iResult = pPtrEnc->EncodeFrame (pSrcPic, &sFbi);


### PR DESCRIPTION
For the cases where we pass an out of range framerate
to the encoder in the test, we already did test that the
encoder internally clipped the value to 60. Clip the local
variable as well, to make sure that later code in the test
does the right decisions based on fFrameRate.

This fixes a case where the check
    static_cast<float> (pParamExt->sSpatialLayers[sInfo.iLayer].iSpatialBitrate) <= fFrameRate
would indicate a failure, when the surrounding test used a
value of fFrameRate different than the encoder used internally.