### PR TITLE
Use a constructor to initialize SFilesSet

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -111,6 +111,13 @@ typedef struct tagFilesSet {
   char   sRecFileName[MAX_DEPENDENCY_LAYER][MAX_FNAME_LEN];
   uint32_t uiFrameToBeCoded;
   bool     bEnableMultiBsFile;
+
+  tagFilesSet() {
+    uiFrameToBeCoded = 0;
+    bEnableMultiBsFile = false;
+    for (int i = 0; i < MAX_DEPENDENCY_LAYER; i++)
+      sRecFileName[i][0] = '\0';
+  }
 } SFilesSet;
 
 
@@ -763,14 +770,13 @@ int ProcessEncoding (ISVCEncoder* pPtrEnc, int argc, char** argv, bool bConfigFi
 #if defined ( STICK_STREAM_SIZE )
   FILE* fTrackStream = fopen ("coding_size.stream", "wb");
 #endif
-  SFilesSet fs = {};
+  SFilesSet fs;
   // for configuration file
   CReadConfig cRdCfg;
   int iParsedNum = 1;
 
   memset (&sFbi, 0, sizeof (SFrameBSInfo));
   pPtrEnc->GetDefaultParams (&sSvcParam);
-  memset (&fs.sRecFileName[0][0], 0, sizeof (fs.sRecFileName));
   fs.bEnableMultiBsFile = false;
 
   FillSpecificParameters (sSvcParam);


### PR DESCRIPTION
Using a constructor to initialize the struct members, instead of
an empty initializer list (where the other members are implicitly
initialized to zero) probably is more idiomatic C++.

This fixes compilation with STLPort with GCC 4.9 from Android NDK r10
(broken since cebf5916dfe433).

The fact that this only is an issue there could indicate that it
actually was a compiler bug though, but the workaround shouldn't
hurt in this case either. The issue seems to come from the array of
string in the struct, with compiler errors like these:

welsenc.cpp:766:19: error: converting to 'std::string {aka std::basic_string<char, std::char_traits<char>, std::allocator<char> >}' from initializer list would use explicit constructor 'std::basic_string<_CharT, _Traits, _Alloc>::basic_string(const allocator_type&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::basic_string<_CharT, _Traits, _Alloc>::allocator_type = std::allocator<char>]'
   SFilesSet fs = {};
                   ^