### PR TITLE
Update WelsThreadLib.cpp

### DIFF
--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -74,9 +74,12 @@
 #ifdef WINAPI_FAMILY
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #define WP80
-using namespace Platform;
-using namespace Windows::Foundation;
-using namespace Windows::System::Threading;
+
+#include "winrt/Windows.Foundation.h"
+#include "winrt/Windows.System.Threading.Core.h"
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::System::Threading;
+
 #define USE_THREADPOOL
 
 #define InitializeCriticalSection(x) InitializeCriticalSectionEx(x, 0, 0)
@@ -204,11 +207,11 @@ WELS_THREAD_ERROR_CODE    WelsThreadCreate (WELS_THREAD_HANDLE* thread,  LPWELS_
   HANDLE h = CreateEvent (NULL, FALSE, FALSE, NULL);
   HANDLE h2;
   DuplicateHandle (GetCurrentProcess(), h, GetCurrentProcess(), &h2, 0, FALSE, DUPLICATE_SAME_ACCESS);
-  ThreadPool::RunAsync (ref new WorkItemHandler ([ = ] (IAsyncAction^) {
+  ThreadPool::RunAsync (WorkItemHandler ([ = ] (IAsyncAction) {
     routine (arg);
     SetEvent (h2);
     CloseHandle (h2);
-  }, CallbackContext::Any), WorkItemPriority::Normal, WorkItemOptions::TimeSliced);
+  }), WorkItemPriority::Normal, WorkItemOptions::TimeSliced);
 #else
   WELS_THREAD_HANDLE   h = CreateThread (NULL, 0, routine, arg, 0, NULL);
 #endif


### PR DESCRIPTION
cppwinrt headers are included in the windows sdk from 17134 onwards. This gets rid of the C++/CX code in this class and hence can be compiled without the ZW flag, which is very helpful when integrating with other build systems. My personal use case here is building webrtc for uwp.