### PR TITLE
Make sure to return a value for DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER for other profiles

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -473,6 +473,8 @@ long CWelsDecoder::GetOption (DECODER_OPTION eOptID, void* pOption) {
   } else if (DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER == eOptID) {
     if (m_pDecContext->pSps && m_pDecContext->pSps->uiProfileIdc != 66 && m_pDecContext->pPps->bEntropyCodingModeFlag) {
       * ((int*)pOption) = m_iNumOfPicts > 0 ? m_iNumOfPicts : 0;
+    } else {
+      * ((int*)pOption) = 0;
     }
     return cmResultSuccess;
   }


### PR DESCRIPTION
If the profile isn't yet known, return 0 here instead of not returning
anything at all.