### PR TITLE
Avoid using C++/CX code for threads for Windows Phone/Windows Store/UWP

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ If building for Windows Phone with MSVC 2013, there's no included bat file that 
 
 This is only necessary for building the DLL; the static library can be built without setting this.
 
+Note, only Windows Phone 8.1 or newer is supported, 8.0 is no longer supported.
+
 For All Platforms
 -------------------
 

--- a/build/msvc-app.mk
+++ b/build/msvc-app.mk
@@ -2,14 +2,3 @@ include $(SRC_PATH)build/msvc-common.mk
 CFLAGS_OPT += -MD
 CFLAGS_DEBUG += -MDd
 CFLAGS += -DUNICODE
-# Ignore warnings about the main function prototype when building with -ZW
-CXXFLAGS += -ZW -wd4447
-# Ignore warnings about code built with -ZW in .lib files
-AR_OPTS += -ignore:4264
-
-# WelsThreadLib requires building with -ZW, since it uses new Windows Runtime
-# classes for creating threads.
-# If linking an .exe that contains Windows Runtime code, the first object
-# file linked into the exe also needs to be built with -ZW (otherwise the build
-# fails with "vccorlib_lib_should_be_specified_before_msvcrt_lib_to_linker",
-# so set it on all files.

--- a/codec/common/src/WelsThreadLib.cpp
+++ b/codec/common/src/WelsThreadLib.cpp
@@ -74,10 +74,6 @@
 #ifdef WINAPI_FAMILY
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #define WP80
-using namespace Platform;
-using namespace Windows::Foundation;
-using namespace Windows::System::Threading;
-#define USE_THREADPOOL
 
 #define InitializeCriticalSection(x) InitializeCriticalSectionEx(x, 0, 0)
 #define GetSystemInfo(x) GetNativeSystemInfo(x)
@@ -200,18 +196,7 @@ void WelsSleep (uint32_t dwMilliSecond) {
 
 WELS_THREAD_ERROR_CODE    WelsThreadCreate (WELS_THREAD_HANDLE* thread,  LPWELS_THREAD_ROUTINE  routine,
     void* arg, WELS_THREAD_ATTR attr) {
-#ifdef USE_THREADPOOL
-  HANDLE h = CreateEvent (NULL, FALSE, FALSE, NULL);
-  HANDLE h2;
-  DuplicateHandle (GetCurrentProcess(), h, GetCurrentProcess(), &h2, 0, FALSE, DUPLICATE_SAME_ACCESS);
-  ThreadPool::RunAsync (ref new WorkItemHandler ([ = ] (IAsyncAction^) {
-    routine (arg);
-    SetEvent (h2);
-    CloseHandle (h2);
-  }, CallbackContext::Any), WorkItemPriority::Normal, WorkItemOptions::TimeSliced);
-#else
   WELS_THREAD_HANDLE   h = CreateThread (NULL, 0, routine, arg, 0, NULL);
-#endif
 
   if (h == NULL) {
     return WELS_THREAD_ERROR_GENERAL;


### PR DESCRIPTION
The CreateThread function was only unavailable in Windows (Phone) 8.0,
but became available again in Windows Phone 8.1 and for Store apps
in Windows 8.1.

This avoids building source files with the /ZW flag for C++/CX mode,
simplifying integration with other projects and build systems.

This is a better suggestion instead of #2980 by @ashikns.