### PR TITLE
replace gtest master branch with a stable branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ gmp-bootstrap:
 	cd gmp-api && git fetch origin && git checkout $(GMP_API_BRANCH)
 
 gtest-bootstrap:
-	if [ ! -d gtest ] ; then git clone https://github.com/google/googletest.git gtest ; fi
+	if [ ! -d gtest ] ; then git clone https://github.com/google/googletest.git gtest && \
+       cd gtest && git checkout -b release-1.8.1 release-1.8.1 ; fi
 
 ifeq ($(HAVE_GTEST),Yes)
 


### PR DESCRIPTION
as the title.

test:
./codec_unittest