### PR TITLE
Remove static initializer in WelsThreadPool

### DIFF
--- a/codec/common/inc/WelsThreadPool.h
+++ b/codec/common/inc/WelsThreadPool.h
@@ -100,7 +100,6 @@ class  CWelsThreadPool : public CWelsThread, public IWelsTaskThreadSink {
   WELS_THREAD_ERROR_CODE StopAllRunning();
 
   static int32_t   m_iRefCount;
-  static CWelsLock m_cInitLock;
   static int32_t   m_iMaxThreadNum;
   static CWelsThreadPool* m_pThreadPoolSelf;
 

--- a/codec/common/src/WelsThreadPool.cpp
+++ b/codec/common/src/WelsThreadPool.cpp
@@ -46,8 +46,8 @@ namespace WelsCommon {
 namespace {
 
 CWelsLock& GetInitLock() {
-  static CWelsLock initLock;
-  return initLock;
+  static CWelsLock *initLock = new CWelsLock;
+  return *initLock;
 }
 
 }

--- a/codec/common/src/WelsThreadPool.cpp
+++ b/codec/common/src/WelsThreadPool.cpp
@@ -43,8 +43,16 @@
 
 namespace WelsCommon {
 
+namespace {
+
+CWelsLock& GetInitLock() {
+  static CWelsLock initLock;
+  return initLock;
+}
+
+}
+
 int32_t CWelsThreadPool::m_iRefCount = 0;
-CWelsLock CWelsThreadPool::m_cInitLock;
 int32_t CWelsThreadPool::m_iMaxThreadNum = DEFAULT_THREAD_NUM;
 CWelsThreadPool* CWelsThreadPool::m_pThreadPoolSelf = NULL;
 
@@ -62,7 +70,7 @@ CWelsThreadPool::~CWelsThreadPool() {
 }
 
 WELS_THREAD_ERROR_CODE CWelsThreadPool::SetThreadNum (int32_t iMaxThreadNum) {
-  CWelsAutoLock  cLock (m_cInitLock);
+  CWelsAutoLock  cLock (GetInitLock());
 
   if (m_iRefCount != 0) {
     return WELS_THREAD_ERROR_GENERAL;
@@ -77,7 +85,7 @@ WELS_THREAD_ERROR_CODE CWelsThreadPool::SetThreadNum (int32_t iMaxThreadNum) {
 
 
 CWelsThreadPool* CWelsThreadPool::AddReference() {
-  CWelsAutoLock  cLock (m_cInitLock);
+  CWelsAutoLock  cLock (GetInitLock());
   if (m_pThreadPoolSelf == NULL) {
     m_pThreadPoolSelf = new CWelsThreadPool();
     if (!m_pThreadPoolSelf) {
@@ -102,7 +110,7 @@ CWelsThreadPool* CWelsThreadPool::AddReference() {
 }
 
 void CWelsThreadPool::RemoveInstance() {
-  CWelsAutoLock  cLock (m_cInitLock);
+  CWelsAutoLock  cLock (GetInitLock());
   //fprintf(stdout, "m_iRefCount=%d\n", m_iRefCount);
   -- m_iRefCount;
   if (0 == m_iRefCount) {
@@ -118,7 +126,7 @@ void CWelsThreadPool::RemoveInstance() {
 
 
 bool CWelsThreadPool::IsReferenced() {
-  CWelsAutoLock  cLock (m_cInitLock);
+  CWelsAutoLock  cLock (GetInitLock());
   return (m_iRefCount > 0);
 }
 
@@ -370,5 +378,3 @@ void  CWelsThreadPool::ClearWaitedTasks() {
 }
 
 }
-
-


### PR DESCRIPTION
This change fixes a static initializer that was introduced in the Chromium build
[1] on Mac and Linux.  For Mac in particular, Chromium does not allow any SIs.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=893594