### PR TITLE
Add user level malloc/free support

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -537,6 +537,8 @@ long (*GetOption) (ISVCDecoder*, DECODER_OPTION eOptionId, void* pOption);
 #endif
 
 typedef void (*WelsTraceCallback) (void* ctx, int level, const char* string);
+typedef void*(*WelsMallocCallback)(unsigned int size);
+typedef void(*WelsFreeCallback)(void* p);
 
 /** @brief   Create encoder
  *  @param   ppEncoder encoder

--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -166,7 +166,10 @@ typedef enum {
   DECODER_OPTION_LEVEL,                 ///< get current AU level info,only is used in GetOption
   DECODER_OPTION_STATISTICS_LOG_INTERVAL,///< set log output interval
   DECODER_OPTION_IS_REF_PIC,             ///< feedback current frame is ref pic or not
-  DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER  ///< number of frames remaining in decoder buffer when pictures are required to re-ordered into display-order.
+  DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER, ///< number of frames remaining in decoder buffer when pictures are required to re-ordered into display-order.
+
+  DECODER_OPTION_MALLOC,                ///< a void* (*)(unsigned int) function which allocates memory
+  DECODER_OPTION_FREE                   ///< a void (*)(void*) function which deallocates memory
 
 } DECODER_OPTION;
 

--- a/codec/common/inc/memory_align.h
+++ b/codec/common/inc/memory_align.h
@@ -49,11 +49,16 @@
 #include <stdio.h>
 #endif//MEMORY_CHECK
 
+#include <stdlib.h>
+
 namespace WelsCommon {
+
+typedef void*(*MALLOC_FP)(uint32_t);
+typedef void(*FREE_FP)(void*);
 
 class CMemoryAlign {
  public:
-CMemoryAlign (const uint32_t kuiCacheLineSize);
+CMemoryAlign (const uint32_t kuiCacheLineSize, MALLOC_FP fpMalloc = CMemoryAlign::malloc, FREE_FP fpFree = CMemoryAlign::free);
 virtual ~CMemoryAlign();
 
 void* WelsMallocz (const uint32_t kuiSize, const char* kpTag);
@@ -62,6 +67,9 @@ void WelsFree (void* pPointer, const char* kpTag);
 const uint32_t WelsGetCacheLineSize() const;
 const uint32_t WelsGetMemoryUsage() const;
 
+static void * malloc(const uint32_t kuiSize) { return ::malloc(kuiSize); }
+static void free(void * pP) { return ::free(pP); }
+
  private:
 // private copy & assign constructors adding to fix klocwork scan issues
 CMemoryAlign (const CMemoryAlign& kcMa);
@@ -69,6 +77,8 @@ CMemoryAlign& operator= (const CMemoryAlign& kcMa);
 
  protected:
 uint32_t        m_nCacheLineSize;
+MALLOC_FP       m_fpMalloc;
+FREE_FP         m_fpFree;
 
 #ifdef MEMORY_MONITOR
 uint32_t        m_nMemoryUsageInBytes;
@@ -86,7 +96,7 @@ uint32_t        m_nMemoryUsageInBytes;
 * \note N/A
 *************************************************************************************
 */
-void* WelsMallocz (const uint32_t kuiSize, const char* kpTag);
+void* WelsMallocz (const uint32_t kuiSize, const char* kpTag, MALLOC_FP fpMalloc = CMemoryAlign::malloc);
 
 /*!
 *************************************************************************************
@@ -100,7 +110,7 @@ void* WelsMallocz (const uint32_t kuiSize, const char* kpTag);
 * \note N/A
 *************************************************************************************
 */
-void WelsFree (void* pPtr, const char* kpTag);
+void WelsFree (void* pPtr, const char* kpTag, FREE_FP fpFree = CMemoryAlign::free);
 
 #define WELS_SAFE_FREE(pPtr, pTag)              if (pPtr) { WelsFree(pPtr, pTag); pPtr = NULL; }
 

--- a/codec/common/src/memory_align.cpp
+++ b/codec/common/src/memory_align.cpp
@@ -44,9 +44,11 @@ static int32_t  g_iMemoryLength;
 #endif
 
 
-CMemoryAlign::CMemoryAlign (const uint32_t kuiCacheLineSize)
+CMemoryAlign::CMemoryAlign (const uint32_t kuiCacheLineSize, MALLOC_FP fpMalloc, FREE_FP fpFree)
+  :   m_fpMalloc(fpMalloc)
+    , m_fpFree(fpFree)
 #ifdef MEMORY_MONITOR
-  : m_nMemoryUsageInBytes (0)
+    , m_nMemoryUsageInBytes (0)
 #endif//MEMORY_MONITOR
 {
   if ((kuiCacheLineSize == 0) || (kuiCacheLineSize & 0x0f))
@@ -61,7 +63,7 @@ CMemoryAlign::~CMemoryAlign() {
 #endif//MEMORY_MONITOR
 }
 
-void* WelsMalloc (const uint32_t kuiSize, const char* kpTag, const uint32_t kiAlign) {
+static void* WelsMalloc (const uint32_t kuiSize, const char* kpTag, const uint32_t kiAlign, MALLOC_FP fpMalloc) {
   const int32_t kiSizeOfVoidPointer     = sizeof (void**);
   const int32_t kiSizeOfInt             = sizeof (int32_t);
   const int32_t kiAlignedBytes          = kiAlign - 1;
@@ -69,7 +71,7 @@ void* WelsMalloc (const uint32_t kuiSize, const char* kpTag, const uint32_t kiAl
   const int32_t kiActualRequestedSize   = kiTrialRequestedSize;
   const uint32_t kiPayloadSize          = kuiSize;
 
-  uint8_t* pBuf = (uint8_t*) malloc (kiActualRequestedSize);
+  uint8_t* pBuf = (uint8_t*) (*fpMalloc) (kiActualRequestedSize);
   if (NULL == pBuf)
     return NULL;
 
@@ -98,7 +100,7 @@ void* WelsMalloc (const uint32_t kuiSize, const char* kpTag, const uint32_t kiAl
   return pAlignedBuffer;
 }
 
-void WelsFree (void* pPointer, const char* kpTag) {
+void WelsFree (void* pPointer, const char* kpTag, FREE_FP fpFree) {
   if (pPointer) {
 #ifdef MEMORY_CHECK
     if (fpMemChkPoint != NULL) {
@@ -110,7 +112,7 @@ void WelsFree (void* pPointer, const char* kpTag) {
       fflush (fpMemChkPoint);
     }
 #endif
-    free (* (((void**) pPointer) - 1));
+    (*fpFree) (* (((void**) pPointer) - 1));
   }
 }
 
@@ -126,7 +128,7 @@ void* CMemoryAlign::WelsMallocz (const uint32_t kuiSize, const char* kpTag) {
 }
 
 void* CMemoryAlign::WelsMalloc (const uint32_t kuiSize, const char* kpTag) {
-  void* pPointer = WelsCommon::WelsMalloc (kuiSize, kpTag, m_nCacheLineSize);
+  void* pPointer = WelsCommon::WelsMalloc (kuiSize, kpTag, m_nCacheLineSize, m_fpMalloc);
 #ifdef MEMORY_MONITOR
   if (pPointer != NULL) {
     const int32_t kiMemoryLength = * ((int32_t*) ((uint8_t*)pPointer - sizeof (void**) - sizeof (
@@ -151,11 +153,11 @@ void CMemoryAlign::WelsFree (void* pPointer, const char* kpTag) {
 #endif
   }
 #endif//MEMORY_MONITOR
-  WelsCommon::WelsFree (pPointer, kpTag);
+  WelsCommon::WelsFree (pPointer, kpTag, m_fpFree);
 }
 
-void* WelsMallocz (const uint32_t kuiSize, const char* kpTag) {
-  void* pPointer = WelsMalloc (kuiSize, kpTag, 16);
+void* WelsMallocz (const uint32_t kuiSize, const char* kpTag, MALLOC_FP fpMalloc) {
+  void* pPointer = WelsMalloc (kuiSize, kpTag, 16, fpMalloc);
   if (NULL == pPointer) {
     return NULL;
   }

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -120,6 +120,8 @@ class CWelsDecoder : public ISVCDecoder {
  private:
   PWelsDecoderContext     m_pDecContext;
   welsCodecTrace*         m_pWelsTrace;
+  WelsMallocCallback      m_pMalloc;
+  WelsFreeCallback        m_pFree;
   SPictInfo               m_sPictInfoList[16];
   int32_t                 m_iPictInfoIndex;
   int32_t                 m_iMinPOC;


### PR DESCRIPTION
Added a way via ISVCDecoder::SetOption to register user provided malloc/free.   The signature differs from void(*)(size_t) since it looks like current practice at this API level is to not use size_t and other typedefs.  Additionally, internal malloc equivalents WelsMalloc/WelsMallocz take a uint32_t instead of size_t so the signature is consistent across levels.

This allows application writers to hook into memory allocation without modifying prebuilt binaries.