### PR TITLE
External allocator and configurable bitstream buffer

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -603,11 +603,11 @@ typedef struct {
 /**
 * @brief Optional external allocator to use.
 */
-typedef struct SMemoryAllocator {
+struct SMemoryAllocator {
   virtual ~SMemoryAllocator() {}
   virtual void* allocate(unsigned int) = 0; ///< Allocator
   virtual void  deallocate(void *) = 0; ///< Deallocator
-} SMemoryAllocator;
+};
 
 /**
 * @brief SVC Decoding Parameters, reserved here and potential applicable in the future

--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -599,6 +599,15 @@ typedef struct {
   VIDEO_BITSTREAM_TYPE  eVideoBsType;  ///< video stream type (AVC/SVC)
 } SVideoProperty;
 
+
+/**
+* @brief Optional external allocator to use.
+*/
+typedef struct {
+  virtual void* allocate(unsigned int) = 0; ///< Allocator
+  virtual void  deallocate(void *) = 0; ///< Deallocator
+} SMemoryAllocator;
+
 /**
 * @brief SVC Decoding Parameters, reserved here and potential applicable in the future
 */
@@ -611,11 +620,14 @@ typedef struct TagSVCDecodingParam {
   ERROR_CON_IDC eEcActiveIdc;          ///< whether active error concealment feature in decoder
   bool bParseOnly;                     ///< decoder for parse only, no reconstruction. When it is true, SPS/PPS size should not exceed SPS_PPS_BS_SIZE (128). Otherwise, it will return error info
 
+  SMemoryAllocator* pSAllocator;     ///< external memory allocator to use
+  unsigned int  uiMaxBitstreamSize;    ///< bitstream buffer size to allocate in bytes. default MIN_ACCESS_UNIT_CAPACITY * MAX_BUFFERED_NUM
+
   SVideoProperty   sVideoProperty;    ///< video stream property
 } SDecodingParam, *PDecodingParam;
 
 /**
-* @brief Bitstream inforamtion of a layer being encoded
+* @brief Bitstream information of a layer being encoded
 */
 typedef struct {
   unsigned char uiTemporalId;

--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -603,7 +603,8 @@ typedef struct {
 /**
 * @brief Optional external allocator to use.
 */
-typedef struct {
+typedef struct SMemoryAllocator {
+  virtual ~SMemoryAllocator() {}
   virtual void* allocate(unsigned int) = 0; ///< Allocator
   virtual void  deallocate(void *) = 0; ///< Deallocator
 } SMemoryAllocator;

--- a/codec/common/inc/memory_align.h
+++ b/codec/common/inc/memory_align.h
@@ -37,7 +37,7 @@
 #include "codec_app_def.h"
 
 // NOTE: please do not clean below lines even comment, turn on for potential memory leak verify and memory usage monitor etc.
-#define MEMORY_CHECK
+//#define MEMORY_CHECK
 #define MEMORY_MONITOR
 #ifdef MEMORY_CHECK
 #ifndef MEMORY_MONITOR
@@ -49,7 +49,6 @@
 #ifdef MEMORY_CHECK
 #include <stdio.h>
 #endif//MEMORY_CHECK
-
 
 namespace WelsCommon {
 

--- a/codec/common/inc/memory_align.h
+++ b/codec/common/inc/memory_align.h
@@ -34,9 +34,10 @@
 #define WELS_COMMON_MEMORY_ALIGN_H__
 
 #include "typedefs.h"
+#include "codec_app_def.h"
 
 // NOTE: please do not clean below lines even comment, turn on for potential memory leak verify and memory usage monitor etc.
-//#define MEMORY_CHECK
+#define MEMORY_CHECK
 #define MEMORY_MONITOR
 #ifdef MEMORY_CHECK
 #ifndef MEMORY_MONITOR
@@ -49,15 +50,17 @@
 #include <stdio.h>
 #endif//MEMORY_CHECK
 
+
 namespace WelsCommon {
 
 class CMemoryAlign {
  public:
-CMemoryAlign (const uint32_t kuiCacheLineSize);
+CMemoryAlign (const uint32_t kuiCacheLineSize, SMemoryAllocator * pSExtAllocator);
 virtual ~CMemoryAlign();
 
 void* WelsMallocz (const uint32_t kuiSize, const char* kpTag);
 void* WelsMalloc (const uint32_t kuiSize, const char* kpTag);
+
 void WelsFree (void* pPointer, const char* kpTag);
 const uint32_t WelsGetCacheLineSize() const;
 const uint32_t WelsGetMemoryUsage() const;
@@ -67,26 +70,17 @@ const uint32_t WelsGetMemoryUsage() const;
 CMemoryAlign (const CMemoryAlign& kcMa);
 CMemoryAlign& operator= (const CMemoryAlign& kcMa);
 
+void* WelsMalloc (const uint32_t kuiSize, const char* kpTag, const uint32_t kiAlign);
+
  protected:
 uint32_t        m_nCacheLineSize;
+bool            m_bExternalAllocator;
+SMemoryAllocator *m_pSMemoryAllocator;
 
 #ifdef MEMORY_MONITOR
 uint32_t        m_nMemoryUsageInBytes;
 #endif//MEMORY_MONITOR
 };
-
-/*!
-*************************************************************************************
-* \brief        malloc with zero filled utilization in Wels
-*
-* \param        kuiSize     size of memory block required
-*
-* \return       allocated memory pointer exactly, failed in case of NULL return
-*
-* \note N/A
-*************************************************************************************
-*/
-void* WelsMallocz (const uint32_t kuiSize, const char* kpTag);
 
 /*!
 *************************************************************************************

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -369,7 +369,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
 
   sDecParam.sVideoProperty.size = sizeof (sDecParam.sVideoProperty);
   sDecParam.eEcActiveIdc = ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE;
-
+  
   if (iArgC < 2) {
     printf ("usage 1: h264dec.exe welsdec.cfg\n");
     printf ("usage 2: h264dec.exe welsdec.264 out.yuv\n");
@@ -477,8 +477,6 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
     printf ("No input file specified in configuration file.\n");
     return 1;
   }
-
-
 
 
   if (WelsCreateDecoder (&pDecoder)  || (NULL == pDecoder)) {

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -369,7 +369,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
 
   sDecParam.sVideoProperty.size = sizeof (sDecParam.sVideoProperty);
   sDecParam.eEcActiveIdc = ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE;
-  
+
   if (iArgC < 2) {
     printf ("usage 1: h264dec.exe welsdec.cfg\n");
     printf ("usage 2: h264dec.exe welsdec.264 out.yuv\n");

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -479,6 +479,8 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
   }
 
 
+
+
   if (WelsCreateDecoder (&pDecoder)  || (NULL == pDecoder)) {
     printf ("Create Decoder failed.\n");
     return 1;

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -582,7 +582,8 @@ int32_t InitBsBuffer (PWelsDecoderContext pCtx) {
 
   CMemoryAlign* pMa = pCtx->pMemAlign;
 
-  pCtx->iMaxBsBufferSizeInByte = MIN_ACCESS_UNIT_CAPACITY * MAX_BUFFERED_NUM;
+  pCtx->iMaxBsBufferSizeInByte = pCtx->pParam->uiMaxBitstreamSize?pCtx->pParam->uiMaxBitstreamSize:MIN_ACCESS_UNIT_CAPACITY * MAX_BUFFERED_NUM;
+
   if ((pCtx->sRawData.pHead = static_cast<uint8_t*> (pMa->WelsMallocz (pCtx->iMaxBsBufferSizeInByte,
                               "pCtx->sRawData.pHead"))) == NULL) {
     return ERR_INFO_OUT_OF_MEMORY;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -246,6 +246,7 @@ void CWelsDecoder::UninitDecoder (void) {
              "CWelsDecoder::UninitDecoder(), verify memory usage (%d bytes) after free..",
              pSMemAllocator->WelsGetMemoryUsage());
     delete pSMemAllocator;
+    pSMemAllocator = NULL;
   }
 }
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2321,7 +2321,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
 
   pCtx->sLogCtx = *pLogCtx;
 
-  pCtx->pMemAlign = new CMemoryAlign (iCacheLineSize);
+  pCtx->pMemAlign = new CMemoryAlign (iCacheLineSize, NULL);
   WELS_VERIFY_RETURN_PROC_IF (1, (NULL == pCtx->pMemAlign), WelsUninitEncoderExt (&pCtx))
 
   iRet = AllocCodingParam (&pCtx->pSvcParam, pCtx->pMemAlign);


### PR DESCRIPTION
Update SDecodingParam to accept a pointer to an external memory allocator.

Also allow the bitstream buffer to be configurable instead of being fixed to 3 MB. 