### PR TITLE
meson: Fix generation of import library on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,7 @@ libopenh264_shared = shared_library('openh264',
   install: true,
   soversion: major_version,
   version: meson.project_version(),
+  vs_module_defs: 'openh264.def',
   dependencies: deps)
 
 libopenh264_static = static_library('openh264',


### PR DESCRIPTION
Add the `.def` file when generating the DLL so that the required symbols are exported when building with MSVC and an import library is generated.

Without this, you can't use the openh264 DLL generated with the meson build files.