### PR TITLE
Remove check for working compiler in NDK

### DIFF
--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -73,6 +73,14 @@ ifeq ($(NDK_TOOLCHAIN_VERSION), clang)
   LDFLAGS += -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libunwind.a
 endif
 
+ifneq ($(findstring /,$(CXX)),$(findstring \,$(CXX)))
+ifneq ($(CXX),$(wildcard $(CXX)))
+ifneq ($(CXX).exe,$(wildcard $(CXX).exe))
+$(error Compiler not found, bad NDKROOT or ARCH?)
+endif
+endif
+endif
+
 STL_INCLUDES = \
     -I$(NDKROOT)/sources/cxx-stl/stlport/stlport
 STL_LIB = \

--- a/build/platform-android.mk
+++ b/build/platform-android.mk
@@ -73,12 +73,6 @@ ifeq ($(NDK_TOOLCHAIN_VERSION), clang)
   LDFLAGS += -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libunwind.a
 endif
 
-ifneq ($(CXX),$(wildcard $(CXX)))
-ifneq ($(CXX).exe,$(wildcard $(CXX).exe))
-$(error Compiler not found, bad NDKROOT or ARCH?)
-endif
-endif
-
 STL_INCLUDES = \
     -I$(NDKROOT)/sources/cxx-stl/stlport/stlport
 STL_LIB = \


### PR DESCRIPTION
For Firefox, we use our own build of clang for Android builds. The version of clang shipped in the Android NDK will not run on our build machines because it uses an incompatible version of glibc. Removing this check allows us to compile the plugin on our build machines. If there is no working compiler available, we'll just hit errors further along in the build, so I don't think there's any harm in removing this check.