### PR TITLE
deblocking: Disambiguate reference pictures

### DIFF
--- a/codec/decoder/core/inc/deblocking.h
+++ b/codec/decoder/core/inc/deblocking.h
@@ -77,7 +77,7 @@ void WelsDeblockingFilterSlice (PWelsDecoderContext pCtx, PDeblockingFilterMbFun
  * \return  NONE
  */
 
-uint32_t DeblockingBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int32_t iNeighMb, int32_t iMbXy);
+uint32_t DeblockingBsMarginalMBAvcbase (PDeblockingFilter  pFilter, PDqLayer pCurDqLayer, int32_t iEdge, int32_t iNeighMb, int32_t iMbXy);
 uint32_t DeblockingBSliceBsMarginalMBAvcbase (PDqLayer pCurDqLayer, int32_t iEdge, int32_t iNeighMb, int32_t iMbXy);
 
 int32_t DeblockingAvailableNoInterlayer (PDqLayer pCurDqLayer, int32_t iFilterIdc);

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -172,6 +172,7 @@ typedef struct tagDeblockingFilter {
   int8_t  iChromaQP[2];
   int8_t  iLumaQP;
   struct TagDeblockingFunc*  pLoopf;
+  PPicture *pRefPics[LIST_A];
 } SDeblockingFilter, *PDeblockingFilter;
 
 typedef void (*PDeblockingFilterMbFunc) (PDqLayer pCurDqLayer, PDeblockingFilter  filter, int32_t boundry_flag);

--- a/test/api/decoder_test.cpp
+++ b/test/api/decoder_test.cpp
@@ -134,12 +134,12 @@ static const FileParam kFileParamArray[] = {
   {"res/Cisco_Men_whisper_640x320_CABAC_Bframe_9.264", "88b8864a69cee7656202bc54d2ffa8b7b6f1f6c5"},
   {"res/Cisco_Men_whisper_640x320_CAVLC_Bframe_9.264", "270a500d2f91c9e2c8ffabc03f62e0dc0b3a24ed"},
   {"res/Cisco_Adobe_PDF_sample_a_1024x768_CAVLC_Bframe_9.264", "d3b2b986178ce3eafa806cd984543d0da830f408"},
-  {"res/VID_1280x544_cabac_temporal_direct.264", "46ec1d702ffef31492f933afdd0b1ea155aac922"},
-  {"res/VID_1280x720_cabac_temporal_direct.264", "449e70d68b2b216d7d1cf3439d80298df3c3d50c"},
-  {"res/VID_1920x1080_cabac_temporal_direct.264", "7da13d15f660c953094e238220fdba29f29465e5"},
-  {"res/VID_1280x544_cavlc_temporal_direct.264", "290b06a9be6a991269d2d2dd42d85bd4ba02783f"},
-  {"res/VID_1280x720_cavlc_temporal_direct.264", "a339f84be1a3268638cc389f611ac4648c8c26c8"},
-  {"res/VID_1920x1080_cavlc_temporal_direct.264", "fbc5a3253180f1e24d9a2d3c4a2ae0d43630c8f9"},
+  {"res/VID_1280x544_cabac_temporal_direct.264", "8d946d46a8cb248269c4294203397daed8dace1d"},
+  {"res/VID_1280x720_cabac_temporal_direct.264", "419faadd8362918e6d908addd3e92fddb925624a"},
+  {"res/VID_1920x1080_cabac_temporal_direct.264", "2c93dc4ea4617636d2554c68896ce3ba16d678e7"},
+  {"res/VID_1280x544_cavlc_temporal_direct.264", "c89756e76e57c6a84cc55146b18845d4d24e4cd5"},
+  {"res/VID_1280x720_cavlc_temporal_direct.264", "be1af190f5eba34102a9de42917c8ec50073c5a0"},
+  {"res/VID_1920x1080_cavlc_temporal_direct.264", "6c58378bc51beb909381e634700706737fd17be2"},
 };
 
 INSTANTIATE_TEST_CASE_P (DecodeFile, DecoderOutputTest,


### PR DESCRIPTION
    Macroblocks can refer to the same reference picture using
    different indices when the same picture appears in multiple
    slots in the current reference picture lists. That leads to
    calculating the wrong loop filter strength for edge processing,
    and small errors in the conformance suite on (for example)
    CVWP5_TOSHIBA_E.264 and others.
    
    Modify the test-suite and checksums for affected test files
    where this situation occurs.

Note that the 6 test files in question still don't produce the same pixel output as the reference decoder, so there's more work to do.