### PR TITLE
Fix oss-fuzzer 14035. Reset all B-frame's reference's references when…

### DIFF
--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -129,7 +129,7 @@ static int32_t WelsCheckAndRecoverForFutureDecoding (PWelsDecoderContext pCtx) {
         if (pCtx->eSliceType == B_SLICE) {
           //reset reference's references when IDR is lost
           for (int32_t list = LIST_0; list < LIST_A; ++list) {
-            for (int32_t i = 0; i < 17; ++i) {
+            for (int32_t i = 0; i < MAX_DPB_COUNT; ++i) {
               pRef->pRefPic[list][i] = NULL;
             }
           }

--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -126,6 +126,14 @@ static int32_t WelsCheckAndRecoverForFutureDecoding (PWelsDecoderContext pCtx) {
         pRef->bIsComplete = false; // Set complete flag to false for lost IDR ref picture
         pRef->iSpsId = pCtx->pSps->iSpsId;
         pRef->iPpsId = pCtx->pPps->iPpsId;
+        if (pCtx->eSliceType == B_SLICE) {
+          //reset reference's references when IDR is lost
+          for (int32_t list = LIST_0; list < LIST_A; ++list) {
+            for (int32_t i = 0; i < 17; ++i) {
+              pRef->pRefPic[list][i] = NULL;
+            }
+          }
+        }
         pCtx->iErrorCode |= dsDataErrorConcealed;
         bool bCopyPrevious = ((ERROR_CON_FRAME_COPY_CROSS_IDR == pCtx->pParam->eEcActiveIdc)
                               || (ERROR_CON_SLICE_COPY_CROSS_IDR == pCtx->pParam->eEcActiveIdc)


### PR DESCRIPTION
… IDR is lost to prevent temporal prediction from trying to access lost references.