### PR TITLE
Fix symbol hiding

### DIFF
--- a/codec/common/x86/asm_inc.asm
+++ b/codec/common/x86/asm_inc.asm
@@ -485,15 +485,20 @@ SECTION .note.GNU-stack noalloc noexec nowrite progbits ; Mark the stack as non-
 %endmacro
 
 %macro WELS_EXTERN 1
-    %ifndef WELS_PRIVATE_EXTERN
-        %define WELS_PRIVATE_EXTERN
-    %endif
     ALIGN 16, nop
     %ifdef PREFIX
-        global _%1 WELS_PRIVATE_EXTERN
+        %ifdef WELS_PRIVATE_EXTERN
+            global _%1: WELS_PRIVATE_EXTERN
+        %else
+            global _%1
+        %endif
         %define %1 _%1
     %else
-        global %1 WELS_PRIVATE_EXTERN
+        %ifdef WELS_PRIVATE_EXTERN
+            global %1: WELS_PRIVATE_EXTERN
+        %else
+            global %1
+        %endif
     %endif
     %1:
 %endmacro


### PR DESCRIPTION
The definition of WELS_PRIVATE_EXTERN breaks the compilation, because of the whitespace before it.

The compilation errors are as follows:
```
codec/encoder/core/x86/coeff.asm:522: error: identifier expected after GLOBAL
codec/common/x86/asm_inc.asm:496: ... from macro `WELS_EXTERN' defined here
```
