### PR TITLE
Submit two patches for loongson platform.

### DIFF
--- a/codec/common/inc/asmdefs_mmi.h
+++ b/codec/common/inc/asmdefs_mmi.h
@@ -289,7 +289,7 @@
  * backup register
  */
 #define BACKUP_REG \
-   double __back_temp[8];                                      \
+   double __attribute__((aligned(16))) __back_temp[8];         \
    if (_MIPS_SIM == _ABI64)                                    \
    __asm__ volatile (                                          \
      "gssqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \

--- a/codec/processing/src/scenechangedetection/SceneChangeDetection.h
+++ b/codec/processing/src/scenechangedetection/SceneChangeDetection.h
@@ -89,6 +89,12 @@ class CSceneChangeDetectorVideo {
     }
 #endif
 
+#ifdef HAVE_MMI
+    if (iCpuFlag & WELS_CPU_MMI) {
+      m_pfSad = WelsSampleSad8x8_mmi;
+    }
+#endif
+
     m_fSceneChangeMotionRatioLarge = SCENE_CHANGE_MOTION_RATIO_LARGE_VIDEO;
     m_fSceneChangeMotionRatioMedium = SCENE_CHANGE_MOTION_RATIO_MEDIUM;
   }


### PR DESCRIPTION
patch 1:  add initialization of mmi for m_pfSad.
patch 2:  when testing the latest code on loongaon 3a3000,  the performance of encoder/decoder is poor. The reason is unaligned access in BACKUP_REG. Fix it in this patch.