### PR TITLE
re-fix oss-buzz bug 14423.

### DIFF
--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -210,22 +210,12 @@ static int32_t DecreasePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, co
   }
 
   //update references due to allocation changes
+  //all references' references have to be reset oss-buzz 14423
   for (int32_t i = 0; i < kiNewSize; i++) {
     for (int32_t listIdx = LIST_0; listIdx < LIST_A; ++listIdx) {
       int32_t j = -1;
       while (++j < MAX_DPB_COUNT && pPicNewBuf->ppPic[i]->pRefPic[listIdx][j] != NULL) {
-        unsigned long long uiTimeStamp = pPicNewBuf->ppPic[i]->pRefPic[listIdx][j]->uiTimeStamp;
-        bool foundThePic = false;
-        for (int32_t k = 0; k < kiNewSize; k++) {
-          if (pPicNewBuf->ppPic[k]->uiTimeStamp == uiTimeStamp) {
-            pPicNewBuf->ppPic[i]->pRefPic[listIdx][j] = pPicNewBuf->ppPic[k];
-            foundThePic = true;
-            break;
-          }
-        }
-        if (!foundThePic) {
-          pPicNewBuf->ppPic[i]->pRefPic[listIdx][j] = NULL;
-        }
+        pPicNewBuf->ppPic[i]->pRefPic[listIdx][j] = NULL;
       }
     }
   }


### PR DESCRIPTION
removed all reference pictures' references when decreasing buffs to be safe.