### PR TITLE
Fix issue 3186 (fuzz 18458). Reset held picture reordering list befor…

### DIFF
--- a/codec/decoder/core/inc/decoder.h
+++ b/codec/decoder/core/inc/decoder.h
@@ -172,7 +172,11 @@ void UpdateDecStatNoFreezingInfo (PWelsDecoderContext pCtx);
 //update decoder statistics information
 void UpdateDecStat (PWelsDecoderContext pCtx, const bool kbOutput);
 //Destroy picutre buffer
-void DestroyPicBuff (PPicBuff* ppPicBuf, CMemoryAlign* pMa);
+void DestroyPicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, CMemoryAlign* pMa);
+//reset picture reodering buffer list
+void ResetReorderingPictureBuffers (PPictReoderingStatus pPictReoderingStatus, PPictInfo pPictInfo,
+                                    const bool& bFullReset);
+
 #ifdef __cplusplus
 }
 #endif//__cplusplus

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -65,6 +65,7 @@ namespace WelsDec {
 #define  WELS_QP_MAX    51
 
 #define LONG_TERM_REF
+#define IMinInt32 -0x7FFFFFFF
 typedef struct SWels_Cabac_Element {
   uint8_t uiState;
   uint8_t uiMPS;
@@ -277,6 +278,24 @@ typedef struct tagSWelsLastDecPicInfo {
   int32_t           iPrevFrameNum;// frame number of previous frame well decoded for non-truncated mode yet
   bool              bLastHasMmco5;
 } SWelsLastDecPicInfo, *PWelsLastDecPicInfo;
+
+typedef struct tagPictInfo {
+  SBufferInfo             sBufferInfo;
+  int32_t                 iPOC;
+  int32_t                 iPicBuffIdx;
+  uint32_t                uiDecodingTimeStamp;
+  bool                    bLastGOP;
+  unsigned char*          pData[3];
+} SPictInfo, *PPictInfo;
+
+typedef struct tagPictReoderingStatus {
+  int32_t iPictInfoIndex;
+  int32_t iMinPOC;
+  int32_t iNumOfPicts;
+  int32_t iLastGOPRemainPicts;
+  int32_t iLastWrittenPOC;
+  int32_t iLargestBufferedPicIndex;
+} SPictReoderingStatus, *PPictReoderingStatus;
 
 /*
  *  SWelsDecoderContext: to maintail all modules data over decoder@framework
@@ -492,6 +511,8 @@ typedef struct TagWelsDecoderContext {
   void* pLastThreadCtx;
   WELS_MUTEX* pCsDecoder;
   int16_t lastReadyHeightOffset[LIST_A][MAX_REF_PIC_COUNT]; //last ready reference MB offset
+  PPictInfo               pPictInfoList;
+  PPictReoderingStatus    pPictReoderingStatus;
 } SWelsDecoderContext, *PWelsDecoderContext;
 
 typedef struct tagSWelsDecThread {

--- a/codec/decoder/core/inc/picture.h
+++ b/codec/decoder/core/inc/picture.h
@@ -88,6 +88,7 @@ struct SPicture {
   unsigned long long uiTimeStamp;
   uint32_t    uiDecodingTimeStamp; //represent relative decoding time stamps
   int32_t     iPicBuffIdx;
+  EWelsSliceType  eSliceType;
   bool bNewSeqBegin;
   int32_t iMbEcedNum;
   int32_t iMbEcedPropNum;

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -62,6 +62,7 @@ extern void FreePicture (PPicture pPic, CMemoryAlign* pMa);
 
 static int32_t CreatePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, const int32_t kiSize,
                               const int32_t kiPicWidth, const int32_t kiPicHeight) {
+
   PPicBuff pPicBuf = NULL;
   int32_t iPicIdx = 0;
   if (kiSize <= 0 || kiPicWidth <= 0 || kiPicHeight <= 0) {
@@ -80,7 +81,7 @@ static int32_t CreatePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, cons
 
   if (NULL == pPicBuf->ppPic) {
     pPicBuf->iCapacity = 0;
-    DestroyPicBuff (&pPicBuf, pMa);
+    DestroyPicBuff (pCtx, &pPicBuf, pMa);
     return ERR_INFO_OUT_OF_MEMORY;
   }
 
@@ -89,7 +90,7 @@ static int32_t CreatePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, cons
     if (NULL == pPic) {
       // init capacity first for free memory
       pPicBuf->iCapacity = iPicIdx;
-      DestroyPicBuff (&pPicBuf, pMa);
+      DestroyPicBuff (pCtx, &pPicBuf, pMa);
       return ERR_INFO_OUT_OF_MEMORY;
     }
     pPicBuf->ppPic[iPicIdx] = pPic;
@@ -123,7 +124,7 @@ static int32_t IncreasePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, co
 
   if (NULL == pPicNewBuf->ppPic) {
     pPicNewBuf->iCapacity = 0;
-    DestroyPicBuff (&pPicNewBuf, pMa);
+    DestroyPicBuff (pCtx, &pPicNewBuf, pMa);
     return ERR_INFO_OUT_OF_MEMORY;
   }
 
@@ -133,7 +134,7 @@ static int32_t IncreasePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, co
     if (NULL == pPic) {
       // Set maximum capacity as the new malloc memory at the tail
       pPicNewBuf->iCapacity = iPicIdx;
-      DestroyPicBuff (&pPicNewBuf, pMa);
+      DestroyPicBuff (pCtx, &pPicNewBuf, pMa);
       return ERR_INFO_OUT_OF_MEMORY;
     }
     pPicNewBuf->ppPic[iPicIdx] = pPic;
@@ -187,7 +188,7 @@ static int32_t DecreasePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, co
 
   if (NULL == pPicNewBuf->ppPic) {
     pPicNewBuf->iCapacity = 0;
-    DestroyPicBuff (&pPicNewBuf, pMa);
+    DestroyPicBuff (pCtx, &pPicNewBuf, pMa);
     return ERR_INFO_OUT_OF_MEMORY;
   }
 
@@ -254,8 +255,10 @@ static int32_t DecreasePicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, co
   return ERR_NONE;
 }
 
-void DestroyPicBuff (PPicBuff* ppPicBuf, CMemoryAlign* pMa) {
+void DestroyPicBuff (PWelsDecoderContext pCtx, PPicBuff* ppPicBuf, CMemoryAlign* pMa) {
   PPicBuff pPicBuf = NULL;
+
+  ResetReorderingPictureBuffers (pCtx->pPictReoderingStatus, pCtx->pPictInfoList, false);
 
   if (NULL == ppPicBuf || NULL == *ppPicBuf)
     return;
@@ -283,6 +286,24 @@ void DestroyPicBuff (PPicBuff* ppPicBuf, CMemoryAlign* pMa) {
 
   pPicBuf = NULL;
   *ppPicBuf = NULL;
+}
+
+//reset picture reodering buffer list
+void ResetReorderingPictureBuffers (PPictReoderingStatus pPictReoderingStatus, PPictInfo pPictInfo,
+                                    const bool& fullReset) {
+  if (pPictReoderingStatus != NULL && pPictInfo != NULL) {
+    int32_t pictInfoListCount = fullReset ? 16 : (pPictReoderingStatus->iLargestBufferedPicIndex + 1);
+    pPictReoderingStatus->iPictInfoIndex = 0;
+    pPictReoderingStatus->iMinPOC = IMinInt32;
+    pPictReoderingStatus->iNumOfPicts = 0;
+    pPictReoderingStatus->iLastGOPRemainPicts = 0;
+    pPictReoderingStatus->iLastWrittenPOC = IMinInt32;
+    pPictReoderingStatus->iLargestBufferedPicIndex = 0;
+    for (int32_t i = 0; i < pictInfoListCount; ++i) {
+      pPictInfo[i].bLastGOP = false;
+      pPictInfo[i].iPOC = IMinInt32;
+    }
+  }
 }
 
 /*
@@ -485,7 +506,7 @@ int32_t WelsRequestMem (PWelsDecoderContext pCtx, const int32_t kiMbWidth, const
     // for Recycled_Pic_Queue
     PPicBuff* ppPic = &pCtx->pPicBuff;
     if (NULL != ppPic && NULL != *ppPic) {
-      DestroyPicBuff (ppPic, pMa);
+      DestroyPicBuff (pCtx, ppPic, pMa);
     }
 
 
@@ -531,7 +552,7 @@ void WelsFreeDynamicMemory (PWelsDecoderContext pCtx) {
 
   PPicBuff* pPicBuff = &pCtx->pPicBuff;
   if (NULL != pPicBuff && NULL != *pPicBuff) {
-    DestroyPicBuff (pPicBuff, pMa);
+    DestroyPicBuff (pCtx, pPicBuff, pMa);
   }
 
   if (pCtx->pTempDec) {

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2555,7 +2555,7 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
       pCtx->pDec->iFrameNum = pSh->iFrameNum;
       pCtx->pDec->iFramePoc = pSh->iPicOrderCntLsb; // still can not obtain correct, because current do not support POCtype 2
       pCtx->pDec->bIdrFlag = pNalCur->sNalHeaderExt.bIdrFlag;
-
+      pCtx->pDec->eSliceType = pSh->eSliceType;
       memcpy (&pLayerInfo.sSliceInLayer.sSliceHeaderExt, pShExt, sizeof (SSliceHeaderExt)); //confirmed_safe_unsafe_usage
       pLayerInfo.sSliceInLayer.bSliceHeaderExtFlag      = pNalCur->sNalData.sVclNal.bSliceHeaderExtFlag;
       pLayerInfo.sSliceInLayer.eSliceType               = pSh->eSliceType;

--- a/codec/decoder/core/src/manage_dec_ref.cpp
+++ b/codec/decoder/core/src/manage_dec_ref.cpp
@@ -80,14 +80,17 @@ static void SetUnRef (PPicture pRef) {
     pRef->uiSpatialId = -1;
     pRef->iSpsId = -1;
     pRef->bIsComplete = false;
+
+    if (pRef->eSliceType == I_SLICE) {
+      return;
+    }
+    int32_t lists = pRef->eSliceType == P_SLICE ? 1 : 2;
     for (int32_t i = 0; i < MAX_DPB_COUNT; ++i) {
-      if (pRef->pRefPic[LIST_0][i] != NULL) {
-        pRef->pRefPic[LIST_0][i]->bAvailableFlag = true;
-        pRef->pRefPic[LIST_0][i] = NULL;
-      }
-      if (pRef->pRefPic[LIST_1][i] != NULL) {
-        pRef->pRefPic[LIST_1][i]->bAvailableFlag = true;
-        pRef->pRefPic[LIST_1][i] = NULL;
+      for (int32_t list = 0; list < lists; ++list) {
+        if (pRef->pRefPic[list][i] != NULL) {
+          pRef->pRefPic[list][i]->bAvailableFlag = true;
+          pRef->pRefPic[list][i] = NULL;
+        }
       }
     }
   }
@@ -189,6 +192,7 @@ static int32_t WelsCheckAndRecoverForFutureDecoding (PWelsDecoderContext pCtx) {
         pRef->iFrameNum = 0;
         pRef->iFramePoc = 0;
         pRef->uiTemporalId = pRef->uiQualityId = 0;
+        pRef->eSliceType = pCtx->eSliceType;
         ExpandReferencingPicture (pRef->pData, pRef->iWidthInPixel, pRef->iHeightInPixel, pRef->iLinesize,
                                   pCtx->sExpandPicFunc.pfExpandLumaPicture, pCtx->sExpandPicFunc.pfExpandChromaPicture);
         AddShortTermToList (&pCtx->sRefPic, pRef);

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -109,25 +109,11 @@ class CWelsDecoder : public ISVCDecoder {
   virtual long EXTAPI SetOption (DECODER_OPTION eOptID, void* pOption);
   virtual long EXTAPI GetOption (DECODER_OPTION eOptID, void* pOption);
 
-  typedef struct tagPictInfo {
-    SBufferInfo             sBufferInfo;
-    int32_t                 iPOC;
-    int32_t                 iPicBuffIdx;
-    uint32_t                uiDecodingTimeStamp;
-    bool                    bLastGOP;
-    unsigned char*          pData[3];
-  } SPictInfo, *PPictInfo;
-
  private:
   PWelsDecoderContext     m_pDecContext;
   welsCodecTrace*         m_pWelsTrace;
   SPictInfo               m_sPictInfoList[16];
-  int32_t                 m_iPictInfoIndex;
-  int32_t                 m_iMinPOC;
-  int32_t                 m_iNumOfPicts;
-  int32_t                 m_iLastGOPRemainPicts;
-  int32_t                 m_LastWrittenPOC;
-  int32_t                 m_iLargestBufferedPicIndex;
+  SPictReoderingStatus    m_sReoderingStatus;
   SVlcTable               m_sVlcTable;
   SWelsLastDecPicInfo     m_sLastDecPicInfo;
   SDecoderStatistics      m_sDecoderStatistics;// For real time debugging
@@ -135,7 +121,6 @@ class CWelsDecoder : public ISVCDecoder {
   int32_t InitDecoder (const SDecodingParam* pParam);
   void UninitDecoder (void);
   int32_t ResetDecoder();
-  void ResetReorderingPictureBuffers();
 
   void OutputStatisticsLog (SDecoderStatistics& sDecoderStatistics);
   DECODING_STATE ReorderPicturesInDisplay (unsigned char** ppDst, SBufferInfo* pDstInfo);


### PR DESCRIPTION
…e calling DestroyPicBuff.

It also fix SetUnRef crashing which should only loop for LIST_1 only if ref pic is B_SLICE in rare case.