### PR TITLE
Fix building for android

### DIFF
--- a/codec/decoder/core/src/wels_decoder_thread.cpp
+++ b/codec/decoder/core/src/wels_decoder_thread.cpp
@@ -57,12 +57,6 @@
 #define HW_NCPU_NAME "hw.ncpu"
 #endif
 #endif
-#ifdef ANDROID_NDK
-#include <cpu-features.h>
-#endif
-#ifdef __ANDROID__
-#include <android/api-level.h>
-#endif
 
 #include "wels_decoder_thread.h"
 #include <stdio.h>


### PR DESCRIPTION
Remove unused includes from wels_decoder_thread.cpp.

The include path to cpu-features.h is only added to COMMON_INCLUDES,
as only files in codec/common/src included it - before the newly added
wels_decoder_thread.cpp, which didn't really need it.