### PR TITLE
Thread decoding bug fix

### DIFF
--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -201,6 +201,7 @@ typedef struct TagBufferInfo {
   union {
     SSysMEMBuffer sSystemBuffer; ///<  memory info for one picture
   } UsrData;                     ///<  output buffer info
+  unsigned char* pDst[3];  //point to picture YUV data
 } SBufferInfo;
 
 

--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -145,9 +145,9 @@ void FlushFrames (ISVCDecoder* pDecoder, int64_t& iTotal, FILE* pYuvFile, FILE* 
     sDstBufInfo.iBufferStatus = 1;
     pDecoder->FlushFrame (pData, &sDstBufInfo);
     if (sDstBufInfo.iBufferStatus == 1) {
-      pDst[0] = pData[0];
-      pDst[1] = pData[1];
-      pDst[2] = pData[2];
+      pDst[0] = sDstBufInfo.pDst[0];
+      pDst[1] = sDstBufInfo.pDst[1];
+      pDst[2] = sDstBufInfo.pDst[2];
     }
     int64_t iEnd = WelsTime();
     iTotal += iEnd - iStart;
@@ -346,9 +346,9 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
     }
 
     if (sDstBufInfo.iBufferStatus == 1) {
-      pDst[0] = pData[0];
-      pDst[1] = pData[1];
-      pDst[2] = pData[2];
+      pDst[0] = sDstBufInfo.pDst[0];
+      pDst[1] = sDstBufInfo.pDst[1];
+      pDst[2] = sDstBufInfo.pDst[2];
     }
     iEnd    = WelsTime();
     iTotal += iEnd - iStart;
@@ -378,9 +378,9 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
       sDstBufInfo.uiInBsTimeStamp = uiTimeStamp;
       pDecoder->DecodeFrame2 (NULL, 0, pData, &sDstBufInfo);
       if (sDstBufInfo.iBufferStatus == 1) {
-        pDst[0] = pData[0];
-        pDst[1] = pData[1];
-        pDst[2] = pData[2];
+        pDst[0] = sDstBufInfo.pDst[0];
+        pDst[1] = sDstBufInfo.pDst[1];
+        pDst[2] = sDstBufInfo.pDst[2];
       }
       iEnd    = WelsTime();
       iTotal += iEnd - iStart;

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -286,7 +286,6 @@ typedef struct tagPictInfo {
   int32_t                 iPicBuffIdx;
   uint32_t                uiDecodingTimeStamp;
   bool                    bLastGOP;
-  unsigned char*          pData[3];
 } SPictInfo, *PPictInfo;
 
 typedef struct tagPictReoderingStatus {

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -220,6 +220,9 @@ static inline int32_t DecodeFrameConstruction (PWelsDecoderContext pCtx, uint8_t
   ppDst[0] = ppDst[0] + pCtx->sFrameCrop.iTopOffset * 2 * pPic->iLinesize[0] + pCtx->sFrameCrop.iLeftOffset * 2;
   ppDst[1] = ppDst[1] + pCtx->sFrameCrop.iTopOffset  * pPic->iLinesize[1] + pCtx->sFrameCrop.iLeftOffset;
   ppDst[2] = ppDst[2] + pCtx->sFrameCrop.iTopOffset  * pPic->iLinesize[1] + pCtx->sFrameCrop.iLeftOffset;
+  for (int i = 0; i < 3; ++i) {
+    pDstInfo->pDst[i] = ppDst[i];
+  }
   pDstInfo->iBufferStatus = 1;
   if (GetThreadCount (pCtx) > 1 && pPic->bIsComplete == false) {
     pPic->bIsComplete = true;

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -944,9 +944,9 @@ DECODING_STATE CWelsDecoder::FlushFrame (unsigned char** ppDst,
 #endif
 #endif
     memcpy (pDstInfo, &m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].sBufferInfo, sizeof (SBufferInfo));
-    ppDst[0] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[0];
-    ppDst[1] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[1];
-    ppDst[2] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[2];
+    ppDst[0] = pDstInfo->pDst[0];
+    ppDst[1] = pDstInfo->pDst[1];
+    ppDst[2] = pDstInfo->pDst[2];
     m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
     PPicBuff pPicBuff = m_iThreadCount <= 1 ? m_pDecThrCtx[0].pCtx->pPicBuff : m_pPicBuff;
     if (m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx < pPicBuff->iCapacity) {
@@ -1046,9 +1046,6 @@ void CWelsDecoder::BufferingReadyPicture (PWelsDecoderContext pCtx, unsigned cha
   for (int32_t i = 0; i < 16; ++i) {
     if (m_sPictInfoList[i].iPOC == IMinInt32) {
       memcpy (&m_sPictInfoList[i].sBufferInfo, pDstInfo, sizeof (SBufferInfo));
-      m_sPictInfoList[i].pData[0] = ppDst[0];
-      m_sPictInfoList[i].pData[1] = ppDst[1];
-      m_sPictInfoList[i].pData[2] = ppDst[2];
       m_sPictInfoList[i].iPOC = pCtx->pSliceHeader->iPicOrderCntLsb;
       m_sPictInfoList[i].uiDecodingTimeStamp = pCtx->uiDecodingTimeStamp;
       m_sPictInfoList[i].iPicBuffIdx = pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb->iPicBuffIdx;
@@ -1090,9 +1087,9 @@ void CWelsDecoder::ReleaseBufferedReadyPicture (PWelsDecoderContext pCtx, unsign
 #endif
 #endif
     memcpy (pDstInfo, &m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].sBufferInfo, sizeof (SBufferInfo));
-    ppDst[0] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[0];
-    ppDst[1] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[1];
-    ppDst[2] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[2];
+    ppDst[0] = pDstInfo->pDst[0];
+    ppDst[1] = pDstInfo->pDst[1];
+    ppDst[2] = pDstInfo->pDst[2];
     m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
     PPicture pPic = pPicBuff->ppPic[m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx];
     --pPic->iRefCount;
@@ -1123,9 +1120,9 @@ void CWelsDecoder::ReleaseBufferedReadyPicture (PWelsDecoderContext pCtx, unsign
     }
     if (uiDecodingTimeStamp > 0) {
       memcpy (pDstInfo, &m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].sBufferInfo, sizeof (SBufferInfo));
-      ppDst[0] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[0];
-      ppDst[1] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[1];
-      ppDst[2] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[2];
+      ppDst[0] = pDstInfo->pDst[0];
+      ppDst[1] = pDstInfo->pDst[1];
+      ppDst[2] = pDstInfo->pDst[2];
       m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
       PPicture pPic = pPicBuff->ppPic[m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx];
       --pPic->iRefCount;
@@ -1164,9 +1161,9 @@ void CWelsDecoder::ReleaseBufferedReadyPicture (PWelsDecoderContext pCtx, unsign
 #endif
 #endif
       memcpy (pDstInfo, &m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].sBufferInfo, sizeof (SBufferInfo));
-      ppDst[0] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[0];
-      ppDst[1] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[1];
-      ppDst[2] = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].pData[2];
+      ppDst[0] = pDstInfo->pDst[0];
+      ppDst[1] = pDstInfo->pDst[1];
+      ppDst[2] = pDstInfo->pDst[2];
       m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
       PPicture pPic = pPicBuff->ppPic[m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx];
       --pPic->iRefCount;


### PR DESCRIPTION
Fix a thread buffering bug: a few yuv frames at output can be dropped due to unexpected pDst reset. This is resolved by moving pDst into SBufferInfo data structure.