### PR TITLE
A few more fixes found during creating thread unit tests.

### DIFF
--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -142,7 +142,6 @@ void FlushFrames (ISVCDecoder* pDecoder, int64_t& iTotal, FILE* pYuvFile, FILE* 
     pData[2] = NULL;
     memset (&sDstBufInfo, 0, sizeof (SBufferInfo));
     sDstBufInfo.uiInBsTimeStamp = uiTimeStamp;
-    sDstBufInfo.iBufferStatus = 1;
     pDecoder->FlushFrame (pData, &sDstBufInfo);
     if (sDstBufInfo.iBufferStatus == 1) {
       pDst[0] = sDstBufInfo.pDst[0];

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -538,7 +538,7 @@ typedef struct tagSWelsDecThreadCtx {
   PPicture pDec;
   SWelsDecEvent sImageReady;
   SWelsDecEvent sSliceDecodeStart;
-  SWelsDecEvent sSliceDecodeFinsh;
+  SWelsDecEvent sSliceDecodeFinish;
   int32_t       iPicBuffIdx; //picBuff Index
 } SWelsDecoderThreadCTX, *PWelsDecoderThreadCTX;
 

--- a/codec/decoder/core/src/decode_slice.cpp
+++ b/codec/decoder/core/src/decode_slice.cpp
@@ -1719,7 +1719,16 @@ int32_t WelsDecodeAndConstructSlice (PWelsDecoderContext pCtx) {
 
       return ERR_INFO_MB_RECON_FAIL;
     }
+    int8_t pNzc[24];
+    if (pCtx->eSliceType != I_SLICE) {
+      memcpy (pNzc, pCurDqLayer->pNzc[pCurDqLayer->iMbXyIndex], 24);
+      pCtx->sBlockFunc.pWelsSetNonZeroCountFunc (
+        pCurDqLayer->pNzc[pCurDqLayer->iMbXyIndex]); // set all none-zero nzc to 1; dbk can be opti!
+    }
     WelsDeblockingFilterMB (pCurDqLayer, pFilter, iFilterIdc, pDeblockMb);
+    if (pCtx->eSliceType != I_SLICE) {
+      memcpy (pCurDqLayer->pNzc[pCurDqLayer->iMbXyIndex], pNzc, 24);
+    }
     if (pCtx->uiNalRefIdc > 0) {
       if (pCurDqLayer->iMbX == 0 || pCurDqLayer->iMbX == pCurDqLayer->iMbWidth - 1 || pCurDqLayer->iMbY == 0
           || pCurDqLayer->iMbY == pCurDqLayer->iMbHeight - 1) {

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2530,14 +2530,14 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
       pSh = &pNalCur->sNalData.sVclNal.sSliceHeaderExt.sSliceHeader;
       if (pSh->iFirstMbInSlice == 0) {
         if (pLastThreadCtx->pCtx->pDec != NULL && pLastThreadCtx->pCtx->pDec->bIsUngroupedMultiSlice) {
-          WAIT_EVENT (&pLastThreadCtx->sSliceDecodeFinsh, WELS_DEC_THREAD_WAIT_INFINITE);
+          WAIT_EVENT (&pLastThreadCtx->sSliceDecodeFinish, WELS_DEC_THREAD_WAIT_INFINITE);
         }
         pCtx->pDec = NULL;
         pCtx->iTotalNumMbRec = 0;
       } else if (pLastThreadCtx->pCtx->pDec != NULL) {
         if (pSh->iFrameNum == pLastThreadCtx->pCtx->pDec->iFrameNum
             && pSh->iPicOrderCntLsb == pLastThreadCtx->pCtx->pDec->iFramePoc) {
-          WAIT_EVENT (&pLastThreadCtx->sSliceDecodeFinsh, WELS_DEC_THREAD_WAIT_INFINITE);
+          WAIT_EVENT (&pLastThreadCtx->sSliceDecodeFinish, WELS_DEC_THREAD_WAIT_INFINITE);
           pCtx->pDec = pLastThreadCtx->pCtx->pDec;
           pCtx->pDec->bIsUngroupedMultiSlice = true;
           pCtx->sRefPic = pLastThreadCtx->pCtx->sRefPic;
@@ -2822,12 +2822,9 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
       if (iThreadCount >= 1) {
         int32_t  id = pThreadCtx->sThreadInfo.uiThrNum;
         for (int32_t i = 0; i < iThreadCount; ++i) {
-          if (i != id) {
-            if (pThreadCtx[i - id].sSliceDecodeStart.isSignaled) {
-              while (pThreadCtx[i - id].pCtx->uiDecodingTimeStamp < pCtx->uiDecodingTimeStamp) {
-                WelsSleep (1);
-              }
-            }
+          if (i == id || pThreadCtx[i - id].pCtx->uiDecodingTimeStamp == 0) continue;
+          if (pThreadCtx[i - id].pCtx->uiDecodingTimeStamp < pCtx->uiDecodingTimeStamp) {
+            WAIT_EVENT (&pThreadCtx[i - id].sSliceDecodeFinish, WELS_DEC_THREAD_WAIT_INFINITE);
           }
         }
         pCtx->pLastDecPicInfo->uiDecodingTimeStamp = pCtx->uiDecodingTimeStamp;
@@ -2835,7 +2832,7 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
       iRet = DecodeFrameConstruction (pCtx, ppDst, pDstInfo);
       if (iRet) {
         if (iThreadCount > 1) {
-          SET_EVENT (&pThreadCtx->sSliceDecodeFinsh);
+          SET_EVENT (&pThreadCtx->sSliceDecodeFinish);
         }
         return iRet;
       }
@@ -2892,9 +2889,9 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
         }
       }
     }
-  }
-  if (iThreadCount > 1) {
-    SET_EVENT (&pThreadCtx->sSliceDecodeFinsh);
+    if (iThreadCount > 1) {
+      SET_EVENT (&pThreadCtx->sSliceDecodeFinish);
+    }
   }
   return ERR_NONE;
 }

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -127,6 +127,7 @@ class CWelsDecoder : public ISVCDecoder {
   int32_t                 m_DecCtxActiveCount;
   PWelsDecoderThreadCTX   m_pDecThrCtx;
   PWelsDecoderThreadCTX   m_pLastDecThrCtx;
+  int32_t                 m_iLastBufferedIdx;
   WELS_MUTEX              m_csDecoder;
   SWelsDecEvent           m_sBufferingEvent;
   SWelsDecEvent           m_sReleaseBufferEvent;


### PR DESCRIPTION
1. set all none-zero pCurDqLayer->pNzc to 1 before a MB deblocking.
2. make ReleaseBufferedReadyPicture to behaviour to be more close between thread and non-thread.
3. Fix a typo "sSliceDecodeFinsh"