### PR TITLE
meson: fix libdir in openh264.pc.in

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,7 @@ pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
 foreach t : ['', '-static']
   pkgconf = configuration_data()
   pkgconf.set('prefix', join_paths(get_option('prefix')))
+  pkgconf.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
   pkgconf.set('VERSION', meson.project_version())
   if t == '-static'
     do_install = false

--- a/openh264.pc.in
+++ b/openh264.pc.in
@@ -1,5 +1,5 @@
 prefix=@prefix@
-libdir=${prefix}/lib
+libdir=@libdir@
 includedir=${prefix}/include
 
 Name: OpenH264


### PR DESCRIPTION
Parse --libdir option passed to meson and reflect
that into the openh264.pc file.

Useful when libopenh264.so is installed in the
directory /usr/lib/x86_64-linux-gnu/. Otherwise
programs that link with openh264 might fail with
error: "/usr/bin/ld: cannot find -lopenh264"