### PR TITLE
Using and operation when detecting Loongson mmi instructions

### DIFF
--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -331,7 +331,7 @@ static uint32_t get_cpu_flags_from_cpuinfo(void)
     }
     while (fgets(buf, sizeof(buf), fp)) {
         if(!strncmp(buf, "ASEs implemented", strlen("ASEs implemented"))) {
-            if (strstr(buf, "loongson-mmi") || strstr(buf, "loongson-ext")) {
+            if (strstr(buf, "loongson-mmi") && strstr(buf, "loongson-ext")) {
                 flags |= WELS_CPU_MMI;
             }
             if (strstr(buf, "msa")) {


### PR DESCRIPTION
The Loongson 64-bit simd optimizations has used LEXT1(LoongISA general EXTensions 1),
so we must make sure loongson-mmi and loongson-ext exist at the same time.