### PR TITLE
meson: add support for android, ios, macos

### DIFF
--- a/codec/common/meson.build
+++ b/codec/common/meson.build
@@ -17,21 +17,41 @@ cpp_sources = [
   'src/WelsThreadPool.cpp',
 ]
 
-asm_sources = [
-  'x86/cpuid.asm',
-  'x86/dct.asm',
-  'x86/deblock.asm',
-  'x86/expand_picture.asm',
-  'x86/intra_pred_com.asm',
-  'x86/mb_copy.asm',
-  'x86/mc_chroma.asm',
-  'x86/mc_luma.asm',
-  'x86/satd_sad.asm',
-  'x86/vaa.asm',
-]
-
-objs_asm = asm_gen.process(asm_sources)
+objs_asm = []
+if ['x86', 'x86_64'].contains(cpu_family)
+  asm_sources = [
+    'x86/cpuid.asm',
+    'x86/dct.asm',
+    'x86/deblock.asm',
+    'x86/expand_picture.asm',
+    'x86/intra_pred_com.asm',
+    'x86/mb_copy.asm',
+    'x86/mc_chroma.asm',
+    'x86/mc_luma.asm',
+    'x86/satd_sad.asm',
+    'x86/vaa.asm',
+  ]
+  objs_asm += asm_gen.process(asm_sources)
+elif cpu_family == 'arm'
+  cpp_sources += [
+    'arm/copy_mb_neon.S',
+    'arm/deblocking_neon.S',
+    'arm/expand_picture_neon.S',
+    'arm/intra_pred_common_neon.S',
+    'arm/mc_neon.S',
+  ]
+elif cpu_family == 'aarch64'
+  cpp_sources += [
+    'arm64/copy_mb_aarch64_neon.S',
+    'arm64/deblocking_aarch64_neon.S',
+    'arm64/expand_picture_aarch64_neon.S',
+    'arm64/intra_pred_common_aarch64_neon.S',
+    'arm64/mc_aarch64_neon.S',
+  ]
+else
+  error('Unsupported cpu_family @0@'.format(cpu_family))
+endif
 
 libcommon = static_library('common', cpp_sources, objs_asm,
-  include_directories: inc,
+  include_directories: [inc, casm_inc],
   dependencies: deps)

--- a/codec/decoder/meson.build
+++ b/codec/decoder/meson.build
@@ -22,13 +22,27 @@ cpp_sources = [
   'core/src/wels_decoder_thread.cpp',
 ]
 
-asm_sources = [
-  'core/x86/dct.asm',
-  'core/x86/intra_pred.asm',
-]
-
-objs_asm = asm_gen.process(asm_sources)
+objs_asm = []
+if ['x86', 'x86_64'].contains(cpu_family)
+  asm_sources = [
+    'core/x86/dct.asm',
+    'core/x86/intra_pred.asm',
+  ]
+  objs_asm = asm_gen.process(asm_sources)
+elif cpu_family == 'arm'
+  cpp_sources += [
+    'core/arm/block_add_neon.S',
+    'core/arm/intra_pred_neon.S',
+  ]
+elif cpu_family == 'aarch64'
+  cpp_sources += [
+    'core/arm64/block_add_aarch64_neon.S',
+    'core/arm64/intra_pred_aarch64_neon.S',
+  ]
+else
+  error('Unsupported cpu family @0@'.format(cpu_family))
+endif
 
 libdecoder = static_library('decoder', cpp_sources, objs_asm,
-  include_directories: [inc, decoder_inc],
+  include_directories: [inc, decoder_inc, casm_inc],
   dependencies: deps)

--- a/codec/encoder/meson.build
+++ b/codec/encoder/meson.build
@@ -33,19 +33,41 @@ cpp_sources = [
   'plus/src/welsEncoderExt.cpp',
 ]
 
-asm_sources = [
-  'core/x86/coeff.asm',
-  'core/x86/dct.asm',
-  'core/x86/intra_pred.asm',
-  'core/x86/matrix_transpose.asm',
-  'core/x86/memzero.asm',
-  'core/x86/quant.asm',
-  'core/x86/sample_sc.asm',
-  'core/x86/score.asm',
-]
-
-objs_asm = asm_gen.process(asm_sources)
+objs_asm = []
+if ['x86', 'x86_64'].contains(cpu_family)
+  asm_sources = [
+    'core/x86/coeff.asm',
+    'core/x86/dct.asm',
+    'core/x86/intra_pred.asm',
+    'core/x86/matrix_transpose.asm',
+    'core/x86/memzero.asm',
+    'core/x86/quant.asm',
+    'core/x86/sample_sc.asm',
+    'core/x86/score.asm',
+  ]
+  objs_asm = asm_gen.process(asm_sources)
+elif cpu_family == 'arm'
+  cpp_sources += [
+    'core/arm/intra_pred_neon.S',
+    'core/arm/intra_pred_sad_3_opt_neon.S',
+    'core/arm/memory_neon.S',
+    'core/arm/pixel_neon.S',
+    'core/arm/reconstruct_neon.S',
+    'core/arm/svc_motion_estimation.S',
+  ]
+elif cpu_family == 'aarch64'
+  cpp_sources += [
+    'core/arm64/intra_pred_aarch64_neon.S',
+    'core/arm64/intra_pred_sad_3_opt_aarch64_neon.S',
+    'core/arm64/memory_aarch64_neon.S',
+    'core/arm64/pixel_aarch64_neon.S',
+    'core/arm64/reconstruct_aarch64_neon.S',
+    'core/arm64/svc_motion_estimation_aarch64_neon.S',
+  ]
+else
+  error('Unsupported cpu family @0@'.format(cpu_family))
+endif
 
 libencoder = static_library('encoder', cpp_sources, objs_asm,
-  include_directories: [inc, processing_inc, encoder_inc],
+  include_directories: [inc, processing_inc, encoder_inc, casm_inc],
   dependencies: deps)

--- a/codec/meson.build
+++ b/codec/meson.build
@@ -2,5 +2,8 @@ subdir('common')
 subdir('decoder')
 subdir('encoder')
 subdir('processing')
-subdir('console')
+if not ['android', 'ios'].contains(system)
+  # also disabled in the Makefile for these platforms
+  subdir('console')
+endif
 subdir('api')

--- a/codec/processing/meson.build
+++ b/codec/processing/meson.build
@@ -18,14 +18,32 @@ cpp_sources = [
   'src/vaacalc/vaacalculation.cpp',
 ]
 
-asm_sources = [
-  'src/x86/denoisefilter.asm',
-  'src/x86/downsample_bilinear.asm',
-  'src/x86/vaa.asm',
-]
-
-objs_asm = asm_gen.process(asm_sources)
+objs_asm = []
+if ['x86', 'x86_64'].contains(cpu_family)
+  asm_sources = [
+    'src/x86/denoisefilter.asm',
+    'src/x86/downsample_bilinear.asm',
+    'src/x86/vaa.asm',
+  ]
+  objs_asm = asm_gen.process(asm_sources)
+elif cpu_family == 'arm'
+  cpp_sources += [
+    'src/arm/adaptive_quantization.S',
+    'src/arm/down_sample_neon.S',
+    'src/arm/pixel_sad_neon.S',
+    'src/arm/vaa_calc_neon.S',
+  ]
+elif cpu_family == 'aarch64'
+  cpp_sources += [
+	'src/arm64/adaptive_quantization_aarch64_neon.S',
+	'src/arm64/down_sample_aarch64_neon.S',
+	'src/arm64/pixel_sad_aarch64_neon.S',
+	'src/arm64/vaa_calc_aarch64_neon.S',
+  ]
+else
+  error('Unsupported cpu family @0@'.format(cpu_family))
+endif
 
 libprocessing = static_library('processing', cpp_sources, objs_asm,
-  include_directories: [inc, processing_inc],
+  include_directories: [inc, processing_inc, casm_inc],
   dependencies: deps)

--- a/meson.build
+++ b/meson.build
@@ -36,8 +36,6 @@ encoder_inc = include_directories([
   join_paths('codec', 'encoder', 'plus', 'inc'),
 ])
 
-asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
-
 nasm = find_program('nasm', 'nasm.exe')
 
 system = host_machine.system()
@@ -54,24 +52,52 @@ deps = [dependency('threads')]
 c_args = []
 cpp_args = []
 asm_args = []
+asm_inc = []
+casm_inc = []
+cpp_lib = '-lstdc++'
 
-if system == 'linux'
+# TODO: should rely on dependency('threads') instead and change the pkg-config
+# generator below
+pthread_dep = cpp.find_library('pthread', required : false)
+libm_dep = cpp.find_library('libm', required : false)
+deps += [libm_dep]
+
+if ['linux', 'android', 'ios', 'darwin'].contains(system)
+  asm_format32 = 'elf'
+  asm_format64 = 'elf64'
+  if ['ios', 'darwin'].contains(system)
+    asm_format32 = 'macho32'
+    asm_format64 = 'macho64'
+  endif
   if cpu_family == 'x86'
-    asm_format = 'elf'
-    asm_args += ['-DX86_32']
-    add_project_arguments('-DX86_32_ASM', language: 'c')
+    asm_format = asm_format32
+    asm_args += ['-DX86_32', '-DHAVE_AVX2']
+    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: 'c')
+    asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'x86_64'
-    asm_format = 'elf64'
-    asm_args += ['-DUNIX64']
+    asm_format = asm_format64
+    asm_args += ['-DUNIX64', '-DHAVE_AVX2']
+    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', language: 'c')
+    asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
+  elif cpu_family == 'arm'
+    asm_format = asm_format32
+    add_project_arguments('-DHAVE_NEON', language: 'c')
+    add_project_arguments('-DHAVE_NEON', language: 'c')
+    casm_inc = include_directories(join_paths('codec', 'common', 'arm'))
+  elif cpu_family == 'aarch64'
+    asm_format = asm_format64
+    add_project_arguments('-DHAVE_NEON_ARM64', language: 'c')
+    add_project_arguments('-DHAVE_NEON_ARM64', language: 'cpp')
+    casm_inc = include_directories(join_paths('codec', 'common', 'arm64'))
   else
-    error ('FIXME: unhandled CPU family @0@ for Linux'.format(cpu_family))
+    error ('FIXME: unhandled CPU family @0@ for @1@'.format(cpu_family, system))
   endif
 
-  deps += [cpp.find_library('libm')]
-
-  asm_args += ['-DHAVE_AVX2']
-  add_project_arguments('-DHAVE_AVX2', language: 'cpp')
-  add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', language: 'c')
+  if ['ios', 'darwin', 'android'].contains(system)
+    cpp_lib = '-lc++'
+  endif
 elif system == 'windows'
   if cpu_family == 'x86'
     asm_format = 'win32'
@@ -82,17 +108,20 @@ elif system == 'windows'
   else
     error ('FIXME: unhandled CPU family @0@ for Windows'.format(cpu_family))
   endif
+  asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
 else
   error ('FIXME: Unhandled system @0@'.format(system))
 endif
 
-asm_gen = generator(nasm,
-  output : '@BASENAME@.o',
-  arguments : [
-    '-f', asm_format,
-    '-i', asm_inc,
-    '@INPUT@',
-    '-o', '@OUTPUT@'] + asm_args)
+if ['x86', 'x86_64'].contains(cpu_family)
+  asm_gen = generator(nasm,
+    output : '@BASENAME@.o',
+    arguments : [
+      '-f', asm_format,
+      '-i', asm_inc,
+      '@INPUT@',
+      '-o', '@OUTPUT@'] + asm_args)
+endif
 
 api_headers = []
 api_header_deps = []
@@ -127,17 +156,20 @@ foreach t : ['', '-static']
   pkgconf.set('prefix', join_paths(get_option('prefix')))
   pkgconf.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
   pkgconf.set('VERSION', meson.project_version())
+  pkglibs = cpp_lib
+  if libm_dep.found()
+    pkglibs += ' -lm'
+  endif
+  if pthread_dep.found()
+    pkglibs += ' -lpthread'
+  endif
   if t == '-static'
-    do_install = false
-    pkgconf.set('LIBS', '-lstdc++ -lpthread -lm')
+    pkgconf.set('LIBS', pkglibs)
     pkgconf.set('LIBS_PRIVATE', '')
   else
-    do_install = true
     pkgconf.set('LIBS', '')
-    pkgconf.set('LIBS_PRIVATE', '-lstdc++ -lpthread -lm')
+    pkgconf.set('LIBS_PRIVATE', pkglibs)
   endif
-
-  message('do_install: @0@'.format(do_install))
 
   configure_file(
     input: 'openh264.pc.in',


### PR DESCRIPTION
Adds support for arm and arm64 in the meson build.

Tested for android, ios, macos by https://gitlab.freedesktop.org/ystreet/cerbero/pipelines/117966