### PR TITLE
meson: disable tests automatically if gtest is not found

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -1,13 +1,15 @@
-if not get_option('tests').disabled()
-  gtest_main_dep = dependency('gtest', main : true, fallback: ['gtest', 'gtest_main_dep'], required: true)
-  gtest_dep = dependency('gtest', fallback: ['gtest', 'gtest_dep'], required: true)
+build_tests = get_option('tests')
+
+if not build_tests.disabled()
+  gtest_main_dep = dependency('gtest', main : true, fallback: ['gtest', 'gtest_main_dep'], required: build_tests)
+  gtest_dep = dependency('gtest', fallback: ['gtest', 'gtest_dep'], required: build_tests)
 
   test_inc = include_directories('.')
 
   test_data_generator_sources = files('api/DataGenerator.cpp')
   test_base_encoder_sources = files('api/BaseEncoderTest.cpp')
 
-  if gtest_dep.found()
+  if gtest_dep.found() and gtest_main_dep.found()
     subdir('api')
     subdir('common')
     subdir('decoder')


### PR DESCRIPTION
There's not much point in the tri-state feature option if we don't
correctly use the 'auto' state to disable tests when dependencies are
not found and subproject downloads have been disabled.