### PR TITLE
Update version number in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('openh264', ['c', 'cpp'],
-  version : '2.0.0',
+  version : '2.1.0',
   meson_version : '>= 0.47',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])


### PR DESCRIPTION
This was forgotten before the 2.1.0 release.

It seems the 2.1.0 release tarballs were not generated with 'meson dist'. Using 'meson dist' to build and validate the tarball would allow immediately noticing such issues.