### PR TITLE
Fix another test reference

### DIFF
--- a/test/api/decode_api_test.cpp
+++ b/test/api/decode_api_test.cpp
@@ -782,7 +782,7 @@ const char* const pHashStr[][2] = { //DO NOT CHANGE!
   // Allow for different output depending on whether averaging is done
   // vertically or horizontally first when downsampling.
   { "d5fb6d72f8cc0ea4b037e883598c162fd32b475d", "0fc7e06d0d766ac911730da2aa9e953bc858a161" },
-  { "2dc97661e94515d9947a344127062f82814afc2a", "1d47de674c9c44d8292ee00fa053a42bb9383614" },
+  { "17203f07486e895aef7c1bf94133fd731caba572", "1d47de674c9c44d8292ee00fa053a42bb9383614" },
   { "86bf890aef2abe24abe40ebe3d9ec76a25ddebe7", "43eaac708413c109ca120c5d570176f1c9b4036c" }
 };
 


### PR DESCRIPTION
The DecodeParseAPI.ParseOnly_General test doesn't test all layers
in each test round, but only one, so all of these references weren't
fixed properly at once.