### PR TITLE
encoder_ext: modify the verbosity level for QP changing

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -374,12 +374,12 @@ int32_t ParamValidation (SLogContext* pLogCtx, SWelsSvcCodingParam* pCfg) {
                  pCfg->bEnableFrameSkip);
     if ((pCfg->iMaxQp <= 0) || (pCfg->iMinQp <= 0)) {
       if (pCfg->iUsageType == SCREEN_CONTENT_REAL_TIME) {
-        WelsLog (pLogCtx, WELS_LOG_WARNING, "Change QP Range from(%d,%d) to (%d,%d)", pCfg->iMinQp, pCfg->iMaxQp, MIN_SCREEN_QP,
+        WelsLog (pLogCtx, WELS_LOG_INFO, "Change QP Range from(%d,%d) to (%d,%d)", pCfg->iMinQp, pCfg->iMaxQp, MIN_SCREEN_QP,
                  MAX_SCREEN_QP);
         pCfg->iMinQp = MIN_SCREEN_QP;
         pCfg->iMaxQp = MAX_SCREEN_QP;
       } else {
-        WelsLog (pLogCtx, WELS_LOG_WARNING, "Change QP Range from(%d,%d) to (%d,%d)", pCfg->iMinQp, pCfg->iMaxQp,
+        WelsLog (pLogCtx, WELS_LOG_INFO, "Change QP Range from(%d,%d) to (%d,%d)", pCfg->iMinQp, pCfg->iMaxQp,
                  GOM_MIN_QP_MODE, MAX_LOW_BR_QP);
         pCfg->iMinQp = GOM_MIN_QP_MODE;
         pCfg->iMaxQp = MAX_LOW_BR_QP;


### PR DESCRIPTION
Change the verbosity level of qp changing message from warning
to info.

Setting QP<=0 means "use the defaults", and that's an intended
usecase, so change to info.

Discussed in:
https://patchwork.ffmpeg.org/project/ffmpeg/patch/1588065363-7104-2-git-send-email-linjie.fu@intel.com/

Suggested-by: Martin Storsjö <martin@martin.st>
Signed-off-by: Linjie Fu <linjie.fu@intel.com>