### PR TITLE
DecUT_ParseSyntax.cpp: avoid dangling-else warning in if statements

### DIFF
--- a/test/decoder/DecUT_ParseSyntax.cpp
+++ b/test/decoder/DecUT_ParseSyntax.cpp
@@ -279,10 +279,11 @@ bool DecoderParseSyntaxTest::DecodeBs (const char* sFileName, EDecCase eDecCase)
     iRet |= DecodeFrame (pBuf + iBufPos, iSliceSize, m_pData, &m_sBufferInfo, m_pCtx);
     iBufPos += iSliceSize;
   }
-  if (eDecCase == CorrectDec)
+  if (eDecCase == CorrectDec) {
     EXPECT_TRUE (iRet == dsErrorFree);
-  else if (eDecCase == ErrorDec)
+  } else if (eDecCase == ErrorDec) {
     EXPECT_TRUE ((iRet & (dsBitstreamError | dsRefLost | dsDataErrorConcealed)) != 0) << "iRet = " << iRet;
+  }
 
   fclose (pH264File);
   if (pBuf) {
@@ -347,15 +348,18 @@ bool DecoderParseSyntaxTest::ParseBs (const char* sFileName, EDecCase eDecCase) 
     memset (&m_sParserBsInfo, 0, sizeof (SParserBsInfo));
     iRet |= m_pDec->DecodeParser (pBuf + iBufPos, iSliceSize, &m_sParserBsInfo);
     iRet |= m_pDec->DecodeParser (NULL, 0, &m_sParserBsInfo);
-    if (eDecCase == CorrectParseOnly)
+    if (eDecCase == CorrectParseOnly) {
       EXPECT_TRUE (iRet == dsErrorFree || iRet == dsFramePending);
+    }
+
     iBufPos += iSliceSize;
     ++iSliceIndex;
     if (iSliceIndex == 4)
       break;
   }
-  if (eDecCase == ErrorDec)
+  if (eDecCase == ErrorDec) {
     EXPECT_TRUE ((iRet & (dsBitstreamError | dsRefLost | dsDataErrorConcealed)) != 0) << iRet;
+  }
 
   fclose (pH264File);
   if (pBuf) {


### PR DESCRIPTION
When building with gcc 9.3 or newer it, the following warning is emitted:

```
[141/182] Compiling C++ object 'test/decoder/6757f86@@test_decoder@exe/DecUT_ParseSyntax.cpp.o'
../test/decoder/DecUT_ParseSyntax.cpp: In member function ‘bool DecoderParseSyntaxTest::DecodeBs(const char*, EDecCase)’:
../test/decoder/DecUT_ParseSyntax.cpp:284:11: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
  284 |   else if (eDecCase == ErrorDec)
      |           ^
../test/decoder/DecUT_ParseSyntax.cpp: In member function ‘bool DecoderParseSyntaxTest::ParseBs(const char*, EDecCase)’:
../test/decoder/DecUT_ParseSyntax.cpp:350:8: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
  350 |     if (eDecCase == CorrectParseOnly)
      |        ^
../test/decoder/DecUT_ParseSyntax.cpp:357:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
  357 |   if (eDecCase == ErrorDec)
      |      ^
```

These changes add the braces to make the compiler happy and avoid dangling else.