### PR TITLE
meson: fix warnings when copying headers into the builddir

### DIFF
--- a/include/wels/meson.build
+++ b/include/wels/meson.build
@@ -4,5 +4,5 @@ foreach header : api_headers
   api_header_deps += configure_file(
     input : header[1],
     output : header[0],
-    configuration : configuration_data())
+    copy : true)
 endforeach


### PR DESCRIPTION
Use 'copy' kwarg instead of passing empty configuration_data().

Fixes the following warnings:
```
include/wels/meson.build:4: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'codec_api.h'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
include/wels/meson.build:4: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'codec_app_def.h'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
include/wels/meson.build:4: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'codec_def.h'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
include/wels/meson.build:4: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'codec_ver.h'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
```