### PR TITLE
Fix building for arm/aarch64 with mingw (using clang)

### DIFF
--- a/build/platform-mingw_nt.mk
+++ b/build/platform-mingw_nt.mk
@@ -1,4 +1,4 @@
-include $(SRC_PATH)build/x86-common.mk
+include $(SRC_PATH)build/arch.mk
 SHAREDLIB_DIR = $(PREFIX)/bin
 SHAREDLIBSUFFIX = dll
 SHAREDLIBSUFFIXFULLVER=$(SHAREDLIBSUFFIX)
@@ -7,6 +7,7 @@ EXTRA_LIBRARY=$(LIBPREFIX)$(PROJECT_NAME).dll.a
 SHLDFLAGS = -Wl,--out-implib,$(EXTRA_LIBRARY)
 CFLAGS += -MMD -MP
 LDFLAGS +=
+ifeq ($(ASM_ARCH), x86)
 ifeq ($(ARCH), x86_64)
 ASMFLAGS += -f win64
 ASMFLAGS_PLATFORM = -DWIN64
@@ -15,6 +16,11 @@ CXX = x86_64-w64-mingw32-g++
 AR = x86_64-w64-mingw32-ar
 else
 ASMFLAGS += -f win32 -DPREFIX
+endif
+endif
+ifeq ($(ASM_ARCH), arm)
+CCAS = gas-preprocessor.pl -as-type clang -force-thumb -- $(CC)
+CCASFLAGS = -DHAVE_NEON -mimplicit-it=always
 endif
 EXEEXT = .exe
 

--- a/codec/common/arm/arm_arch_common_macro.S
+++ b/codec/common/arm/arm_arch_common_macro.S
@@ -50,16 +50,22 @@ mov pc, lr
 .endm
 #else
 
+#ifdef __ELF__
 .section .note.GNU-stack,"",%progbits // Mark stack as non-executable
+#endif
 .text
+#ifdef __ELF__
 .arch armv7-a
 .fpu neon
+#endif
 
 .macro WELS_ASM_FUNC_BEGIN funcName
 .align 2
 .arm
 .global \funcName
+#ifdef __ELF__
 .type \funcName, %function
+#endif
 #ifndef __clang__
 .func \funcName
 #endif

--- a/codec/common/arm64/arm_arch64_common_macro.S
+++ b/codec/common/arm64/arm_arch64_common_macro.S
@@ -45,13 +45,17 @@ ret
 .endm
 #else
 
+#ifdef __ELF__
 .section .note.GNU-stack,"",%progbits // Mark stack as non-executable
+#endif
 .text
 
 .macro WELS_ASM_AARCH64_FUNC_BEGIN funcName
 .align 2
 .global \funcName
+#ifdef __ELF__
 .type \funcName, %function
+#endif
 #ifndef __clang__
 .func \funcName
 #endif

--- a/codec/common/meson.build
+++ b/codec/common/meson.build
@@ -40,7 +40,7 @@ elif cpu_family == 'arm'
     'arm/intra_pred_common_neon.S',
     'arm/mc_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources
@@ -53,7 +53,7 @@ elif cpu_family == 'aarch64'
     'arm64/intra_pred_common_aarch64_neon.S',
     'arm64/mc_aarch64_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources

--- a/codec/decoder/meson.build
+++ b/codec/decoder/meson.build
@@ -34,7 +34,7 @@ elif cpu_family == 'arm'
     'core/arm/block_add_neon.S',
     'core/arm/intra_pred_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources
@@ -44,7 +44,7 @@ elif cpu_family == 'aarch64'
     'core/arm64/block_add_aarch64_neon.S',
     'core/arm64/intra_pred_aarch64_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources

--- a/codec/encoder/meson.build
+++ b/codec/encoder/meson.build
@@ -55,7 +55,7 @@ elif cpu_family == 'arm'
     'core/arm/reconstruct_neon.S',
     'core/arm/svc_motion_estimation.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources
@@ -69,7 +69,7 @@ elif cpu_family == 'aarch64'
     'core/arm64/reconstruct_aarch64_neon.S',
     'core/arm64/svc_motion_estimation_aarch64_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources

--- a/codec/processing/meson.build
+++ b/codec/processing/meson.build
@@ -33,7 +33,7 @@ elif cpu_family == 'arm'
     'src/arm/pixel_sad_neon.S',
     'src/arm/vaa_calc_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources
@@ -45,7 +45,7 @@ elif cpu_family == 'aarch64'
 	'src/arm64/pixel_sad_aarch64_neon.S',
 	'src/arm64/vaa_calc_aarch64_neon.S',
   ]
-  if system == 'windows'
+  if use_asm_gen
     objs_asm = asm_gen.process(asm_sources)
   else
     cpp_sources += asm_sources

--- a/meson.build
+++ b/meson.build
@@ -106,16 +106,17 @@ elif system == 'windows'
     asm_args += ['-DWIN64']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'arm'
-    if cpp.get_argument_syntax() != 'msvc'
-      error('Windows ARM is currently only supported with Visual Studio-like compilers')
+    if cpp.get_argument_syntax() == 'msvc'
+      asm_format = 'armasm'
+      asm_args += ['-nologo', '-DHAVE_NEON', '-ignore', '4509']
+      asm_cmds = ['armasm']
+    else
+      asm_format = 'clang'
+      asm_args += ['-DHAVE_NEON', '-mimplicit-it=always']
+      asm_cmds = cpp.cmd_array()
     endif
-    asm_format = 'armasm'
-    asm_args += ['-nologo', '-DHAVE_NEON', '-ignore', '4509']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'arm', '')
   elif cpu_family == 'aarch64'
-    if cpp.get_argument_syntax() != 'msvc'
-      error('Windows ARM64 is currently only supported with Visual Studio-like compilers')
-    endif
     asm_format = 'armasm'
     asm_args += ['-nologo', '-DHAVE_NEON_AARCH64']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'arm64', '')
@@ -126,9 +127,11 @@ else
   error('FIXME: Unhandled system @0@'.format(system))
 endif
 
+use_asm_gen = false
 if cpu_family in ['x86', 'x86_64']
   nasm = find_program('nasm')
 
+  use_asm_gen = true
   asm_gen = generator(nasm,
     output : '@BASENAME@.o',
     arguments : [
@@ -137,29 +140,38 @@ if cpu_family in ['x86', 'x86_64']
       '@INPUT@',
       '-o', '@OUTPUT@'] + asm_args)
 elif system == 'windows'
-  gasprep = find_program('gas-preprocessor.pl')
   if  cpu_family == 'arm'
+    # For ARM, gas-preprocessor is needed for converting the asm to be
+    # buildable as thumb even with Clang.
+    use_asm_gen = true
+    gasprep = find_program('gas-preprocessor.pl')
     asm_gen = generator(gasprep,
       output : '@BASENAME@.obj',
       arguments : [
         '-as-type', asm_format,
         '-force-thumb',
-        '--',
-        'armasm',
+        '--'
+        ] + asm_cmds + [
         '-I' + asm_inc] + asm_args + [
         '@INPUT@',
         '-c', '-o', '@OUTPUT@'])
   elif cpu_family == 'aarch64'
-    asm_gen = generator(gasprep,
-      output : '@BASENAME@.obj',
-      arguments : [
-        '-as-type', asm_format,
-        '-arch', 'aarch64',
-        '--',
-        'armasm64',
-        '-I' + asm_inc] + asm_args + [
-        '@INPUT@',
-        '-c', '-o', '@OUTPUT@'])
+    # For ARM64, Clang can build the assembly as-is without needing to use
+    # either gas-preprocessor or armasm64.
+    if cpp.get_argument_syntax() == 'msvc'
+      use_asm_gen = true
+      gasprep = find_program('gas-preprocessor.pl')
+      asm_gen = generator(gasprep,
+        output : '@BASENAME@.obj',
+        arguments : [
+          '-as-type', asm_format,
+          '-arch', 'aarch64',
+          '--',
+          'armasm64',
+          '-I' + asm_inc] + asm_args + [
+          '@INPUT@',
+          '-c', '-o', '@OUTPUT@'])
+    endif
   else
     # Windows only supports x86, x86_64, arm, arm64
     error('unreachable code')


### PR DESCRIPTION
@nirbheek If you have feedback on the meson changes, I'd appreciate it. Instead of hardcoding the condition where asm_gen is needed, it'd be neater if there were a construct like `if defined(asm_gen)`. I tried setting `asm_gen = false` or similar things, for cases where it's not needed, but any comparison operator, where `asm_gen` can either be a generator or another type, seems to produce warnings/errors in some case. 