### PR TITLE
arm: Align constants that are used with the vldr instruction

### DIFF
--- a/codec/decoder/core/arm/intra_pred_neon.S
+++ b/codec/decoder/core/arm/intra_pred_neon.S
@@ -126,6 +126,7 @@ WELS_ASM_FUNC_END
 
 
 
+.align 3
 //The table for SIMD instruction {(8,7,6,5,4,3,2,1) * 5}
 CONST0_GET_I16X16_LUMA_PRED_PLANE: .long 0x191e2328, 0x050a0f14
 

--- a/codec/encoder/core/arm/intra_pred_neon.S
+++ b/codec/encoder/core/arm/intra_pred_neon.S
@@ -83,6 +83,7 @@ loop_0_get_i16x16_luma_pred_dc_both:
 WELS_ASM_FUNC_END
 
 
+.align 3
 //The table for SIMD instruction {(8,7,6,5,4,3,2,1) * 5}
 CONST0_GET_I16X16_LUMA_PRED_PLANE: .long 0x191e2328, 0x050a0f14
 


### PR DESCRIPTION
The vldr instruction requires the data to be properly aligned.