### PR TITLE
codec/common/inc/asmdefs_mmi.h: fix mips32 build

### DIFF
--- a/codec/common/inc/asmdefs_mmi.h
+++ b/codec/common/inc/asmdefs_mmi.h
@@ -288,9 +288,9 @@
 /**
  * backup register
  */
+#if defined(_ABI64) && _MIPS_SIM == _ABI64
 #define BACKUP_REG \
    double __attribute__((aligned(16))) __back_temp[8];         \
-   if (_MIPS_SIM == _ABI64)                                    \
    __asm__ volatile (                                          \
      "gssqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \
      "gssqc1       $f27,      $f26,       0x10(%[temp])  \n\t" \
@@ -299,8 +299,10 @@
      :                                                         \
      : [temp]"r"(__back_temp)                                  \
      : "memory"                                                \
-   );                                                          \
-  else                                                         \
+   );
+#else
+#define BACKUP_REG \
+   double __attribute__((aligned(16))) __back_temp[8];         \
    __asm__ volatile (                                          \
      "gssqc1       $f22,      $f20,       0x00(%[temp])  \n\t" \
      "gssqc1       $f26,      $f24,       0x10(%[temp])  \n\t" \
@@ -309,12 +311,13 @@
      : [temp]"r"(__back_temp)                                  \
      : "memory"                                                \
    );
+#endif
 
 /**
  * recover register
  */
+#if defined(_ABI64) && _MIPS_SIM == _ABI64
 #define RECOVER_REG \
-   if (_MIPS_SIM == _ABI64)                                    \
    __asm__ volatile (                                          \
      "gslqc1       $f25,      $f24,       0x00(%[temp])  \n\t" \
      "gslqc1       $f27,      $f26,       0x10(%[temp])  \n\t" \
@@ -323,8 +326,9 @@
      :                                                         \
      : [temp]"r"(__back_temp)                                  \
      : "memory"                                                \
-   );                                                          \
-   else                                                        \
+   );
+#else
+#define RECOVER_REG \
    __asm__ volatile (                                          \
      "gslqc1       $f22,      $f20,       0x00(%[temp])  \n\t" \
      "gslqc1       $f26,      $f24,       0x10(%[temp])  \n\t" \
@@ -333,6 +337,7 @@
      : [temp]"r"(__back_temp)                                  \
      : "memory"                                                \
    );
+#endif
 
 # define OK             1
 # define NOTOK          0


### PR DESCRIPTION
Fix the following build failure on mips32 which is raised since version 2.0.0 and https://github.com/cisco/openh264/commit/b13e5bceb18ebb93d0313b46aab4af6f480ca933:

```
codec/common/mips/copy_mb_mmi.c: In function 'WelsCopy16x16_mmi':
./codec/common/inc/asmdefs_mmi.h:293:21: error: '_ABI64' undeclared (first use in this function)
  293 |    if (_MIPS_SIM == _ABI64)                                    \
      |                     ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/cba3e9d0fd061cc3a92cb732bcdc2c7b66dbf6cb

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>