### PR TITLE
Makefile, pkg-config: Add INCLUDE_PREFIX variable, use include/openh2…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CFLAGS_DEBUG=-g
 BUILDTYPE=Release
 V=Yes
 PREFIX=/usr/local
+INCLUDE_PREFIX=$(PREFIX)/include/openh264
 SHARED=-shared
 OBJ=o
 DESTDIR=
@@ -292,8 +293,8 @@ $(PROJECT_NAME)-static.pc: $(PROJECT_NAME).pc.in
 	@sed -e 's;@prefix@;$(PREFIX);' -e 's;@libdir@;$(PREFIX)/lib;' -e 's;@VERSION@;$(FULL_VERSION);' -e 's;@LIBS@;$(STATIC_LDFLAGS);' -e 's;@LIBS_PRIVATE@;;' < $< > $@
 
 install-headers:
-	mkdir -p $(DESTDIR)$(PREFIX)/include/wels
-	install -m 644 $(SRC_PATH)/codec/api/svc/codec*.h $(DESTDIR)$(PREFIX)/include/wels
+	mkdir -p $(DESTDIR)$(INCLUDE_PREFIX)
+	install -m 644 $(SRC_PATH)/codec/api/svc/codec*.h $(DESTDIR)$(INCLUDE_PREFIX)
 
 install-static-lib: $(LIBPREFIX)$(PROJECT_NAME).$(LIBSUFFIX) install-headers
 	mkdir -p $(DESTDIR)$(PREFIX)/$(LIBDIR_NAME)

--- a/openh264.pc.in
+++ b/openh264.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 libdir=@libdir@
-includedir=${prefix}/include
+includedir=${prefix}/include/openh264
 
 Name: OpenH264
 Description: OpenH264 is a codec library which supports H.264 encoding and decoding. It is suitable for use in real time applications such as WebRTC.


### PR DESCRIPTION
Makefile, pkg-config:

Add ```INCLUDE_PREFIX``` variable,
use ```$(PREFIX)/include/openh264``` as default,
include correct default in the ```pkg-config``` file

People who use the ```pkg-config``` mechanism will benefit from this immediately and may not have to make any local changes to their own code.

People who hardcoded the paths may need to start using ```pkg-config``` or tweak their paths as they prefer.