### PR TITLE
Minor typo update.

### DIFF
--- a/codec/api/svc/codec_api.h
+++ b/codec/api/svc/codec_api.h
@@ -191,7 +191,7 @@ typedef unsigned char bool;
   *  SFrameBSInfo info;
   *  memset (&info, 0, sizeof (SFrameBSInfo));
   *  SSourcePicture pic;
-  *  memset (&pic, 0, sizeof (SsourcePicture));
+  *  memset (&pic, 0, sizeof (SSourcePicture));
   *  pic.iPicWidth = width;
   *  pic.iPicHeight = height;
   *  pic.iColorFormat = videoFormatI420;


### PR DESCRIPTION
Fixing a typo in the `code_api.h` file comments where `SSourcePicture` does not match the capitalization of the second `S` in the previous line.