### PR TITLE
Update meson build files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt-get update -qq
       - run: sudo apt-get install -qq nasm g++-multilib gcc-multilib libc6-dev-i386 python3-pip python3-setuptools
-      - run: sudo python3 -m pip install meson==0.50.1 ninja
+      - run: sudo python3 -m pip install meson==0.52.1 ninja
       - run: nasm -v 
       - run: c++ --version
       - run: make gmp-bootstrap

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('openh264', ['c', 'cpp'],
   version : '2.1.1',
-  meson_version : '>= 0.50',
+  meson_version : '>= 0.52',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])
 
@@ -184,15 +184,8 @@ api_header_deps = []
 subdir ('codec')
 subdir ('test')
 
-all_objects = [
-  libcommon.extract_all_objects(),
-  libprocessing.extract_all_objects(),
-  libencoder.extract_all_objects(),
-  libdecoder.extract_all_objects()
-]
-
 libopenh264_shared = library('openh264',
-  objects: all_objects,
+  link_with: [libcommon, libprocessing, libencoder, libdecoder],
   install: true,
   soversion: major_version,
   version: meson.project_version(),

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,2 @@
+/googletest-release-1.8.0/
+/packagecache/


### PR DESCRIPTION
```
build: Update version numbers to 2.1.1

This was forgotten when doing the release.
```

```
meson: Fix warning about extract_all_objects usage

We use this because of a meson bug that was fixed in 0.52:
```
https://mesonbuild.com/Release-notes-for-0-52-0.html#improved-support-for-static-libraries
```
Bump the requirement and remove the extract_all_objects workaround.
This gets rid of a meson warning:

WARNING: extract_all_objects called without setting recursive
keyword argument. Meson currently defaults to
non-recursive to maintain backward compatibility but
the default will be changed in the future.
```
