### PR TITLE
avoid 0 in random number generating

### DIFF
--- a/test/api/encode_options_test.cpp
+++ b/test/api/encode_options_test.cpp
@@ -2140,8 +2140,8 @@ TEST_F (EncodeDecodeTestAPI, UnsupportedVideoSizeInput) {
   int iSliceNum    = 1;
   int iRet;
 
-  int iSrcWidth = rand() % 16;
-  int iSrcHeight = rand() % 16;
+  int iSrcWidth = rand() % 15 + 1;
+  int iSrcHeight = rand() % 15 + 1;
 
   SEncParamExt sParam;
   encoder_->GetDefaultParams (&sParam);


### PR DESCRIPTION
as the title.