### PR TITLE
Clean up MSVC build after c256ae3b2774030966913e47a9088ec47d053535

### DIFF
--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -24,9 +24,6 @@ CXX = clang-cl
 CCAS = clang-cl
 CFLAGS += -DHAVE_NEON_AARCH64 --target=arm64-windows
 CCASFLAGS = -nologo -DHAVE_NEON_AARCH64 --target=arm64-windows
-LDFLAGS += -link
-else
-LDFLAGS += -link -cetcompat
 endif
 
 
@@ -54,10 +51,14 @@ SHAREDLIBSUFFIXFULLVER=$(SHAREDLIBSUFFIX)
 SHAREDLIBSUFFIXMAJORVER=$(SHAREDLIBSUFFIX)
 SHARED=-LD
 EXTRA_LIBRARY=$(PROJECT_NAME)_dll.lib
-
+LDFLAGS += -link
 SHLDFLAGS=-debug -map -opt:ref -opt:icf -def:$(SRC_PATH)openh264.def -implib:$(EXTRA_LIBRARY)
 STATIC_LDFLAGS=
 CODEC_UNITTEST_CFLAGS+=-D_CRT_SECURE_NO_WARNINGS
+
+ifneq ($(filter %86 x86_64, $(ARCH)),)
+LDFLAGS += -cetcompat
+endif
 
 %.res: %.rc
 	$(QUIET_RC)rc -fo $@ $<

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -2,15 +2,9 @@ include $(SRC_PATH)build/arch.mk
 ifeq ($(ASM_ARCH), x86)
 ifeq ($(ARCH), x86_64)
 ASMFLAGS += -f win64
-ASMFLAGS_PLATFORM = -DWIN64 -D_WIN64
-CFLAGS += -D_WIN64
-CXXFLAGS += -D_WIN64
-COMMON_CFLAGS += -D_WIN64
+ASMFLAGS_PLATFORM = -DWIN64
 else
 ASMFLAGS += -f win32 -DPREFIX
-CFLAGS += -DWIN32
-CXXFLAGS += -DWIN32
-COMMON_CFLAGS += -DWIN32
 endif
 else
 endif
@@ -28,7 +22,7 @@ ifeq ($(ASM_ARCH), arm64)
 CC = clang-cl
 CXX = clang-cl
 CCAS = clang-cl
-CFLAGS += -DWIN32 -nologo -DHAVE_NEON_AARCH64 --target=arm64-windows
+CFLAGS += -DHAVE_NEON_AARCH64 --target=arm64-windows
 CCASFLAGS = -nologo -DHAVE_NEON_AARCH64 --target=arm64-windows
 LDFLAGS += -link
 else

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -22,7 +22,7 @@ ifeq ($(ASM_ARCH), arm64)
 CC = clang-cl
 CXX = clang-cl
 CCAS = clang-cl
-CFLAGS += -DHAVE_NEON_AARCH64 --target=arm64-windows
+CFLAGS += --target=arm64-windows
 CCASFLAGS = -nologo -DHAVE_NEON_AARCH64 --target=arm64-windows
 endif
 

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -35,7 +35,7 @@ endif
 # it unconditionally. The same issue can also be worked around by adding
 # -DGTEST_HAS_TR1_TUPLE=0 instead, but we prefer this version since it
 # matches what gtest itself does.
-CFLAGS += -nologo -W3 -WX -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -D_VARIADIC_MAX=10
+CFLAGS += -nologo -W3 -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -D_VARIADIC_MAX=10
 CXX_LINK_O=-nologo -Fe$@
 AR_OPTS=-nologo -out:$@
 CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -GF -GS -Gy -DNDEBUG

--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -19,10 +19,7 @@ AR=lib
 CXX_O=-Fo$@
 
 ifeq ($(ASM_ARCH), arm64)
-CC = clang-cl
-CXX = clang-cl
 CCAS = clang-cl
-CFLAGS += --target=arm64-windows
 CCASFLAGS = -nologo -DHAVE_NEON_AARCH64 --target=arm64-windows
 endif
 


### PR DESCRIPTION
c256ae3b2774030966913e47a9088ec47d053535 contained lots of unnecessary changes to the MSVC build configuration. This removes the unnecessary/redundant changes that were part of that commit.

When merging, please use "create merge commit" or "rebase and merge". Please DO NOT use "squash and merge" for this PR. The changes are split up into individual changes that each explain exactly what's changed and why, which is important information to keep in the commit log for posteriority, while "squash and merge" would lose all that information. (If it's possible to merge in any other way than "squash and merge", I can make one separate PR for each change, but that's a bit more overhead for everybody.)