### PR TITLE
msvc: Fix parallel building when creating PDB debug info

### DIFF
--- a/build/msvc-common.mk
+++ b/build/msvc-common.mk
@@ -32,8 +32,8 @@ endif
 CFLAGS += -nologo -W3 -EHsc -fp:precise -Zc:wchar_t -Zc:forScope -D_VARIADIC_MAX=10
 CXX_LINK_O=-nologo -Fe$@
 AR_OPTS=-nologo -out:$@
-CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -GF -GS -Gy -DNDEBUG
-CFLAGS_DEBUG=-Od -Oy- -Zi -RTC1 -D_DEBUG
+CFLAGS_OPT=-O2 -Ob1 -Oy- -Zi -FS -GF -GS -Gy -DNDEBUG
+CFLAGS_DEBUG=-Od -Oy- -Zi -FS -RTC1 -D_DEBUG
 CFLAGS_M32=
 CFLAGS_M64=
 LINK_LOCAL_DIR=


### PR DESCRIPTION
The current way of creating debug info, using the -Zi option,
writes all debug info to one central file. This doesn't work
if building with multiple compiler invocations in parallel. By adding
the -FS option, writing of the PDB file is passed via mspdbsrv.exe,
allowing multiple concurrent compiler processes.

Alternatively, the debug info could be created using the -Z7 flag
instead, which stores the debug info within the object files until
the linking stage, which also works for parallel compilation.