### PR TITLE
meson: fix broken shared library with no contents

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -185,7 +185,7 @@ subdir ('codec')
 subdir ('test')
 
 libopenh264_shared = library('openh264',
-  link_with: [libcommon, libprocessing, libencoder, libdecoder],
+  link_whole: [libcommon, libprocessing, libencoder, libdecoder],
   install: true,
   soversion: major_version,
   version: meson.project_version(),


### PR DESCRIPTION
In #3351, some project cleanups were done, which included migrating from a workaround for a bug that used extract_all_objects, to using link_whole + modern meson instead.

The bug fix was supposed to fix building libopenh264 as a static library, since link_whole (and link_with) never correctly linked the actual objects from another static library.

Sadly this never got merged. Instead #3458 (via commit ce3f53a1337fe183186233fd3c867b9c80e5f879) was merged, which changed to link_with instead. This is not supposed to work, because shared libraries created by converting a static library (or 3) into a shared library *need* -Wl,--whole-archive.

(It did work for building libopenh264 as a static library, because part of the meson bug fix to link actual objects ensured that linking one static library into another behaves the same whether you use link_with or link_whole. This is needed since static libraries aren't pre-linked.)

As a result, libopenh264.so was created with zero original objects, and linked to static libraries that provided many symbols, none of which were required for original symbols, and thus none of which were actually included in the final shared library.

Fix by using link_whole as originally intended.

Fixes #3475