### PR TITLE
Revert "Makefile, pkg-config: Add INCLUDE_PREFIX variable, use includ…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ CFLAGS_DEBUG=-g
 BUILDTYPE=Release
 V=Yes
 PREFIX=/usr/local
-INCLUDE_PREFIX=$(PREFIX)/include/openh264
 SHARED=-shared
 OBJ=o
 DESTDIR=
@@ -293,8 +292,8 @@ $(PROJECT_NAME)-static.pc: $(PROJECT_NAME).pc.in
 	@sed -e 's;@prefix@;$(PREFIX);' -e 's;@libdir@;$(PREFIX)/lib;' -e 's;@VERSION@;$(FULL_VERSION);' -e 's;@LIBS@;$(STATIC_LDFLAGS);' -e 's;@LIBS_PRIVATE@;;' < $< > $@
 
 install-headers:
-	mkdir -p $(DESTDIR)$(INCLUDE_PREFIX)
-	install -m 644 $(SRC_PATH)/codec/api/svc/codec*.h $(DESTDIR)$(INCLUDE_PREFIX)
+	mkdir -p $(DESTDIR)$(PREFIX)/include/wels
+	install -m 644 $(SRC_PATH)/codec/api/svc/codec*.h $(DESTDIR)$(PREFIX)/include/wels
 
 install-static-lib: $(LIBPREFIX)$(PROJECT_NAME).$(LIBSUFFIX) install-headers
 	mkdir -p $(DESTDIR)$(PREFIX)/$(LIBDIR_NAME)

--- a/openh264.pc.in
+++ b/openh264.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 libdir=@libdir@
-includedir=${prefix}/include/openh264
+includedir=${prefix}/include
 
 Name: OpenH264
 Description: OpenH264 is a codec library which supports H.264 encoding and decoding. It is suitable for use in real time applications such as WebRTC.


### PR DESCRIPTION
…e/openh264 as default, include correct default for pkg-config (#3415)"

This reverts commit ccf65bc7b1eb257980b02528133b3a5a65e1497c.

This change broke the existing official way of including the headers.