### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ Usage of the .bat script:
     `AutoBuildForWindows.bat ARM64-Release-ASM` for arm64 release build  
 for more usage, please refer to the .bat script help.  
 
+Building openh264 from vcpkg
+-------------------
+The openh264 port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install openh264 using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install openh264
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 For All Platforms
 -------------------
 


### PR DESCRIPTION
OpenH264 is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for openh264 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build openh264, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/openh264/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.