### PR TITLE
meson: Don't use gas-preprocessor and armasm when building for arm64 with clang-cl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,7 @@ elif system == 'windows'
   elif cpu_family == 'aarch64'
     # For ARM64, Clang can build the assembly as-is without needing to use
     # either gas-preprocessor or armasm64.
-    if cpp.get_argument_syntax() == 'msvc'
+    if cpp.get_argument_syntax() == 'msvc' and (cpp.get_id() != 'clang-cl' or meson.version().version_compare('<0.58.0'))
       use_asm_gen = true
       gasprep = find_program('gas-preprocessor.pl')
       asm_gen = generator(gasprep,


### PR DESCRIPTION
Since meson 0.58.0, meson accepts adding '.S' assembly files as source files to the clang-cl compiler.

For arm, gas-preprocessor is still required when building clang-cl, for rewriting the assembly into a thumb-compatible form on the fly.