### PR TITLE
Save xmm7 in DyadicBilinearQuarterDownsampler_sse

### DIFF
--- a/codec/processing/src/x86/downsample_bilinear.asm
+++ b/codec/processing/src/x86/downsample_bilinear.asm
@@ -1948,6 +1948,7 @@ WELS_EXTERN DyadicBilinearQuarterDownsampler_sse
     %assign push_num 0
 %endif
     LOAD_6_PARA
+    PUSH_XMM 8
     SIGN_EXTENSION r1, r1d
     SIGN_EXTENSION r3, r3d
     SIGN_EXTENSION r4, r4d
@@ -2087,6 +2088,7 @@ WELS_EXTERN DyadicBilinearQuarterDownsampler_sse
 %ifndef X86_32
     pop r12
 %endif
+    POP_XMM
     LOAD_6_PARA_POP
 %ifdef X86_32
     pop r6


### PR DESCRIPTION
Static analysis of chrome.dll showed that xmm7 was being used but not preserved in this function. The Windows calling convention requires that xmm7 be preserved so this change adds the necessary "PUSH_XMM 8" and POP_XMM directives to fix this.

This fixes issue #3585. This may fix a bug in Chrome but that is unknown.