### PR TITLE
Improve checking for GCC >= 8 and Clang for passing -Wno-class-memaccess

### DIFF
--- a/build/platform-gnu-chain.mk
+++ b/build/platform-gnu-chain.mk
@@ -28,13 +28,15 @@ CFLAGS += -march=armv8-a
 ASMFLAGS += -march=armv8-a
 endif
 
-ifeq ($(CXX), clang++)
+ifneq ($(filter %clang++,$(CXX)),)
 CXXFLAGS += -Wc++11-compat-reserved-user-defined-literal
 endif
 
-ifeq ($(patsubst %g++,,$(CXX)),)
+ifneq ($(filter %g++,$(CXX)),)
+ifeq ($(filter %clang++,$(CXX)),)
 GCCVER_GTEQ8 = $(shell echo $$(($$($(CXX) -dumpversion | awk -F "." '{print $$1}') >= 8)))
 ifeq ($(GCCVER_GTEQ8), 1)
 CXXFLAGS += -Wno-class-memaccess
+endif
 endif
 endif


### PR DESCRIPTION
Don't pass -Wno-class-memaccess to Clang, which doesn't support that option name. (When inspecting $(CXX) with a pattern, "clang++" also matches the pattern "%g++".)

Simplify the pattern checking; use $(filter %g++,$(CXX)) instead of $(patsubst %g++,,$(CXX)) making it less obscure. (This requires changing the ifeq ($(),) into ifneq.)

Check for %clang++ in addition to %g++.

Also use a similar pattern for checking for clang++ instead of plain exact matches for "clang++", for passing the option -Wc++11-compat-reserved-user-defined-literal - this allows applying the option when CXX contains a path, or if "clang++" is prefixed by a cross triple.