### PR TITLE
Revert an accidental use of snprintf

### DIFF
--- a/test/utils/HashFunctions.h
+++ b/test/utils/HashFunctions.h
@@ -8,7 +8,7 @@
 
 static void ToHashStr (char* dst, const unsigned char* src, size_t src_len) {
   for (size_t i = 0; i < src_len; ++i) {
-    snprintf (&dst[i * 2], 3, "%.2x", src[i]);
+    sprintf (&dst[i * 2], "%.2x", src[i]);
   }
   dst[src_len * 2] = '\0';
 }


### PR DESCRIPTION
This was changed from sprintf to snprintf (seemingly unintentionally) in 9003acbdab8214090e2ffc9576f1a58d0a7e0c22.

Versions of MSVC before 2015 lack snprintf; within the codec codebase itself, this is wrapped into WelsSnprintf. Within the testcases, there were no uses of snprintf previously, only sprintf.

Revert to the old behaviour, as openh264 otherwise still builds fine with e.g. MSVC 2010, 2012 and 2013.

If this isn't desired, we can of course decide to stop caring about older versions of MSVC, but so far, those versions have still worked just fine. However, that requires changes to the build files for Windows Phone ("make OS=msvc-wp"), which currently expect to be built with MSVC 2013.