### PR TITLE
Use WelsSnprintf instead of direct snprintf in tests

### DIFF
--- a/codec/common/inc/crt_util_safe_x.h
+++ b/codec/common/inc/crt_util_safe_x.h
@@ -48,6 +48,7 @@
 #include <time.h>
 
 #if defined(_WIN32)
+#define NOMINMAX
 #include <windows.h>
 #include <sys/types.h>
 #include <sys/timeb.h>

--- a/test/utils/HashFunctions.h
+++ b/test/utils/HashFunctions.h
@@ -5,10 +5,11 @@
 #include <string.h>
 #include <gtest/gtest.h>
 #include "../sha1.h"
+#include "crt_util_safe_x.h"
 
 static void ToHashStr (char* dst, const unsigned char* src, size_t src_len) {
   for (size_t i = 0; i < src_len; ++i) {
-    snprintf (&dst[i * 2], 3, "%.2x", src[i]);
+    WelsSnprintf (&dst[i * 2], 3, "%.2x", src[i]);
   }
   dst[src_len * 2] = '\0';
 }


### PR DESCRIPTION
Versions of MSVC before 2015 lack snprintf; within the codec codebase itself, this is wrapped into WelsSnprintf. Within the testcases, there were no uses of snprintf previously, only sprintf.

We could of course decide to stop caring about older versions of MSVC, but so far, those versions have still worked just fine. However, that requires changes to the build files for Windows Phone ("make OS=msvc-wp"), which currently expect to be built with MSVC 2013.

Define NOMINMAX before including windows.h, to avoid windows.h breaking std::min in test code.