### PR TITLE
Switch building of the unittest from Ant to Gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,11 +364,13 @@ endif
 ifeq (android,$(OS))
 ifeq (./,$(SRC_PATH))
 codec_unittest$(EXEEXT):
-	cd ./test/build/android && $(NDKROOT)/ndk-build -B APP_ABI=$(APP_ABI) && android update project -t $(TARGET) -p . && ant debug
+	$(NDK_BUILD) -C test/build/android -B
+	./gradlew unittest:assembleDebug
 
 clean_Android: clean_Android_ut
 clean_Android_ut:
-	-cd ./test/build/android && $(NDKROOT)/ndk-build APP_ABI=$(APP_ABI) clean && ant clean
+	-$(NDK_BUILD) -C test/build/android -B clean
+	-./gradlew unittest:clean
 endif
 endif
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
-include ':test-dec', ':test-enc'
+include ':test-dec', ':test-enc', ':unittest'
 project(':test-dec').projectDir = new File('codec/build/android/dec')
 project(':test-enc').projectDir = new File('codec/build/android/enc')
+project(':unittest').projectDir = new File('test/build/android')

--- a/test/build/android/.gitignore
+++ b/test/build/android/.gitignore
@@ -4,3 +4,4 @@ proguard-project.txt
 gen
 bin
 project.properties
+build

--- a/test/build/android/build.gradle
+++ b/test/build/android/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 29
+
+    sourceSets.main {
+        manifest.srcFile "AndroidManifest.xml"
+        res.srcDir "res"
+        java.srcDir "src"
+        jniLibs.srcDir "libs"
+    }
+}


### PR DESCRIPTION
This was missed in b16f0c23213237c7957f47d605df4e2f4c4357a1 where the other targets were switched from Ant to Gradle.

This fixes building after switching to a newer version of the Android SDK (suppporting Gradle) where Ant no longer is supported.

CC @alexcohn 