### PR TITLE
Use getauxval to detect cpu capabilities

### DIFF
--- a/codec/common/src/cpu.cpp
+++ b/codec/common/src/cpu.cpp
@@ -320,73 +320,63 @@ uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
 /* Get cpu features from cpuinfo. */
 static uint32_t get_cpu_flags_from_cpuinfo(void)
 {
-    uint32_t flags = 0;
-
-# ifdef __linux__
-    FILE* fp = fopen("/proc/cpuinfo", "r");
-    if (!fp)
-        return flags;
-
-    char buf[200];
-    memset(buf, 0, sizeof(buf));
-    while (fgets(buf, sizeof(buf), fp)) {
-        if (!strncmp(buf, "model name", strlen("model name"))) {
-            if (strstr(buf, "Loongson-3A") || strstr(buf, "Loongson-3B") ||
-                strstr(buf, "Loongson-2K")) {
-                flags |= WELS_CPU_MMI;
-            }
-            break;
-        }
-    }
-    while (fgets(buf, sizeof(buf), fp)) {
-        if(!strncmp(buf, "ASEs implemented", strlen("ASEs implemented"))) {
-            if (strstr(buf, "loongson-mmi") && strstr(buf, "loongson-ext")) {
-                flags |= WELS_CPU_MMI;
-            }
-            if (strstr(buf, "msa")) {
-                flags |= WELS_CPU_MSA;
-            }
-            break;
-        }
-    }
-    fclose(fp);
-# endif
-
-    return flags;
-}
-
-uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
-    return get_cpu_flags_from_cpuinfo();
-}
-
-#elif defined(__loongarch__) && defined(__linux__)
-/* The CPUCFG instruction is used to dynamically identify the characteristics
- * of the loongarch in the running processor during software execution. */
-#define LOONGARCH_CFG2 0x02
-#define LOONGARCH_CFG2_LSX  (1<<6)
-#define LOONGARCH_CFG2_LASX (1<<7)
-
-static uint32_t get_cpu_flags_from_cpucfg(void) {
-  uint32_t reg = 0;
   uint32_t flags = 0;
 
-  __asm__ volatile(
-    "cpucfg %0, %1 \n\t"
-    : "+&r"(reg)
-    : "r"(LOONGARCH_CFG2)
-  );
-  if (reg & LOONGARCH_CFG2_LSX)
-      flags |= WELS_CPU_LSX;
-  if (reg & LOONGARCH_CFG2_LASX)
-      flags |= WELS_CPU_LASX;
+# ifdef __linux__
+  FILE* fp = fopen("/proc/cpuinfo", "r");
+  if (!fp)
+    return flags;
+
+  char buf[200];
+  memset(buf, 0, sizeof(buf));
+  while (fgets(buf, sizeof(buf), fp)) {
+    if (!strncmp(buf, "model name", strlen("model name"))) {
+      if (strstr(buf, "Loongson-3A") || strstr(buf, "Loongson-3B") ||
+        strstr(buf, "Loongson-2K")) {
+        flags |= WELS_CPU_MMI;
+      }
+      break;
+    }
+  }
+  while (fgets(buf, sizeof(buf), fp)) {
+    if(!strncmp(buf, "ASEs implemented", strlen("ASEs implemented"))) {
+      if (strstr(buf, "loongson-mmi") && strstr(buf, "loongson-ext")) {
+        flags |= WELS_CPU_MMI;
+      }
+      if (strstr(buf, "msa")) {
+        flags |= WELS_CPU_MSA;
+      }
+      break;
+    }
+  }
+  fclose(fp);
+# endif
+
   return flags;
 }
 
 uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
-    return get_cpu_flags_from_cpucfg();
+  return get_cpu_flags_from_cpuinfo();
 }
 
-#else /* Neither X86_ASM, HAVE_NEON, HAVE_NEON_AARCH64 nor mips */
+#elif defined(__loongarch__) && defined(__linux__)
+/* The getauxval is used to dynamically identify the characteristics
+ * of the loongarch in the running processor during software execution. */
+#include <sys/auxv.h>
+#define LA_HWCAP_LSX    (1 << 4)
+#define LA_HWCAP_LASX   (1 << 5)
+
+uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
+  uint32_t flags = 0;
+  uint32_t flag  = (uint32_t)getauxval(AT_HWCAP);
+  if (flag & LA_HWCAP_LSX)
+    flags |= WELS_CPU_LSX;
+  if (flag & LA_HWCAP_LASX)
+    flags |= WELS_CPU_LASX;
+  return flags;
+}
+
+#else /* Neither X86_ASM, HAVE_NEON, HAVE_NEON_AARCH64, loongarch nor mips */
 
 uint32_t WelsCPUFeatureDetect (int32_t* pNumberOfLogicProcessors) {
   return 0;


### PR DESCRIPTION
Will crash if cpucfg instruction is not supported.