### PR TITLE
Fix PSkip fast algorithm from screen-sharing

### DIFF
--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -203,7 +203,9 @@ int32_t InitFunctionPointers (sWelsEncCtx* pEncCtx, SWelsSvcCodingParam* pParam,
 
   //
   WelsInitBGDFunc (pFuncList, pParam->bEnableBackgroundDetection);
-  WelsInitSCDPskipFunc (pFuncList, bScreenContent && (pParam->bEnableSceneChangeDetect));
+	WelsInitSCDPskipFunc (pFuncList, bScreenContent &&
+                        (pParam->bEnableSceneChangeDetect) &&
+                        (pEncCtx->pSvcParam->iComplexityMode < HIGH_COMPLEXITY));
 
   // for pfGetVarianceFromIntraVaa function ptr adaptive by CPU features, 6/7/2010
   InitIntraAnalysisVaaInfo (pFuncList, uiCpuFlag);


### PR DESCRIPTION
We observed blurry screen-sharing issue when user share screen from messenger on Chrome. The issue is because of a fast algorithm for screen sharing. We proposed to introduce a control on this fast algorithm and turn the option off by default.

Details:
There is a fast mode decision algorithm in Openh264: if the encoder finds that the source pixels of the current block are exactly the same as those of the reference block, it would directly encode it with the PSKIP mode. This usually happens when the shared screen is stable.

However, this algorithm introduces a problem. When the bandwidth is limited, the key frame is usually encoded by large QP, which is associated with poor quality. Ideally, we should refine the quality in the frames that follow. Unfortunately, the fast algorithm identifies all subsequent frames as stable and encodes all the blocks with the PSKIP mode. This is problematic because some reference blocks may have poor quality and should be encoded with the inter mode. As a result, we will never have good screen-sharing quality unless we scroll up/down the screen. 

This pull request introduces a control on this fast algorithm and turn the option off by default.
