### PR TITLE
Fix NOMINMAX macro redefined issue

### DIFF
--- a/codec/common/inc/crt_util_safe_x.h
+++ b/codec/common/inc/crt_util_safe_x.h
@@ -48,7 +48,9 @@
 #include <time.h>
 
 #if defined(_WIN32)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <sys/types.h>
 #include <sys/timeb.h>

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -203,7 +203,9 @@ int32_t InitFunctionPointers (sWelsEncCtx* pEncCtx, SWelsSvcCodingParam* pParam,
 
   //
   WelsInitBGDFunc (pFuncList, pParam->bEnableBackgroundDetection);
-  WelsInitSCDPskipFunc (pFuncList, bScreenContent && (pParam->bEnableSceneChangeDetect));
+	WelsInitSCDPskipFunc (pFuncList, bScreenContent &&
+                        (pParam->bEnableSceneChangeDetect) &&
+                        (pEncCtx->pSvcParam->iComplexityMode < HIGH_COMPLEXITY));
 
   // for pfGetVarianceFromIntraVaa function ptr adaptive by CPU features, 6/7/2010
   InitIntraAnalysisVaaInfo (pFuncList, uiCpuFlag);


### PR DESCRIPTION
When we update openh264 version to Chrome, ( https://chromium-review.googlesource.com/c/chromium/src/+/4368477 )

we got a compile error on Chrome: https://logs.chromium.org/logs/chromium/buildbucket/cr-buildbucket/8785448579561379729/+/u/compile/stdout

The error is about NOMINMAX macro redefine. 
The issue is because:
1. #define NOMINMAX in crt_util_safe_x.h was added in  https://github.com/cisco/openh264/pull/3608/files  
2. However,  it's set by compiler flag for Windows: https://source.chromium.org/chromium/chromium/src/+/main:third_party/perl/c/lib/gcc/i686-w64-mingw32/8.3.0/include/c++/i686-w64-mingw32/bits/os_defines.h?q=%22%23define%20NOMINMAX%201%22&ss=chromium

This pull request add macro checking to fix the issue. 
