### PR TITLE
Fix for out of bounds read issue in CWelsDecoder::ReleaseBufferedReadyPictureReorder

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -1132,9 +1132,13 @@ void CWelsDecoder::ReleaseBufferedReadyPictureReorder (PWelsDecoderContext pCtx,
       ppDst[1] = pDstInfo->pDst[1];
       ppDst[2] = pDstInfo->pDst[2];
       m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
+      int32_t iPicBuffIdx = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx;
       if (pPicBuff != NULL) {
-        PPicture pPic = pPicBuff->ppPic[m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx];
-        --pPic->iRefCount;
+        if (iPicBuffIdx > 0 && iPicBuffIdx < pPicBuff->iCapacity)
+        {
+            PPicture pPic = pPicBuff->ppPic[iPicBuffIdx];
+            --pPic->iRefCount;
+        }
       }
       m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].bLastGOP = false;
       m_sReoderingStatus.iMinPOC = IMinInt32;


### PR DESCRIPTION
A fuzzer found an out of bound read crash in CWelsDecoder::ReleaseBufferedReadyPictureReorder.

The commit in this pull request removes the out of bounds read condition by explicitly checking that iPicBuffIdx is greater than 0 and less than the capacity of the indexed object.
