### PR TITLE
Null pointer dereference fix for CWelsDecoder::BufferingReadyPicture

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -1028,8 +1028,10 @@ void CWelsDecoder::BufferingReadyPicture (PWelsDecoderContext pCtx, unsigned cha
       memcpy (&m_sPictInfoList[i].sBufferInfo, pDstInfo, sizeof (SBufferInfo));
       m_sPictInfoList[i].iPOC = pCtx->pSliceHeader->iPicOrderCntLsb;
       m_sPictInfoList[i].uiDecodingTimeStamp = pCtx->uiDecodingTimeStamp;
-      m_sPictInfoList[i].iPicBuffIdx = pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb->iPicBuffIdx;
-      if (GetThreadCount (pCtx) <= 1) ++pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb->iRefCount;
+      if (pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb != NULL) {
+        m_sPictInfoList[i].iPicBuffIdx = pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb->iPicBuffIdx;
+        if (GetThreadCount (pCtx) <= 1) ++pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb->iRefCount;
+      }
       m_sPictInfoList[i].bLastGOP = false;
       m_iLastBufferedIdx = i;
       pDstInfo->iBufferStatus = 0;


### PR DESCRIPTION
A fuzzer identified a null pointer dereference in CWelsDecoder::BufferingReadyPicture.

This commit adds a NULL check before the pCtx->pLastDecPicInfo->pPreviousDecodedPictureInDpb object is dereferenced in CWelsDecoder::BufferingReadyPicture