### PR TITLE
Fix out of bound read in WelsDec::NeedErrorCon

### DIFF
--- a/codec/decoder/core/src/error_concealment.cpp
+++ b/codec/decoder/core/src/error_concealment.cpp
@@ -452,7 +452,7 @@ int32_t MarkECFrameAsRef (PWelsDecoderContext pCtx) {
 
 bool NeedErrorCon (PWelsDecoderContext pCtx) {
   bool bNeedEC = false;
-  int32_t iMbNum = pCtx->pSps->iMbWidth * pCtx->pSps->iMbHeight;
+  int32_t iMbNum = pCtx->sMb.iMbWidth * pCtx->sMb.iMbHeight;
   for (int32_t i = 0; i < iMbNum; ++i) {
     if (!pCtx->pCurDqLayer->pMbCorrectlyDecodedFlag[i]) {
       bNeedEC = true;


### PR DESCRIPTION
A fuzzer found an out of bounds read in WelsDec::NeedErrorCon.

This pull request fixes the issue by ensuring that iMbNum in WelsDec::NeedErrorCon stays within bounds of pCtx->pCurDqLayer->pMbCorrectlyDecodedFlag