### PR TITLE
build: Quote the SDKROOT variable when passed as -isysroot

### DIFF
--- a/build/platform-ios.mk
+++ b/build/platform-ios.mk
@@ -10,6 +10,6 @@ endif
 SDK_MIN = 5.1
 
 SDKROOT := $(shell xcrun --sdk $(shell echo $(SDKTYPE) | tr A-Z a-z) --show-sdk-path)
-CFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN) -DAPPLE_IOS -fembed-bitcode
-LDFLAGS += -arch $(ARCH) -isysroot $(SDKROOT) -miphoneos-version-min=$(SDK_MIN)
+CFLAGS += -arch $(ARCH) -isysroot "$(SDKROOT)" -miphoneos-version-min=$(SDK_MIN) -DAPPLE_IOS -fembed-bitcode
+LDFLAGS += -arch $(ARCH) -isysroot "$(SDKROOT)" -miphoneos-version-min=$(SDK_MIN)
 


### PR DESCRIPTION
This makes building work, if there are spaces in the path to the Xcode used for building (in particular, the user may point to a nondefault version of Xcode by setting DEVELOPER_DIR to point to it when building).