### PR TITLE
Fix off by one regression in decoder

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -1136,7 +1136,7 @@ void CWelsDecoder::ReleaseBufferedReadyPictureReorder (PWelsDecoderContext pCtx,
       m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPOC = IMinInt32;
       int32_t iPicBuffIdx = m_sPictInfoList[m_sReoderingStatus.iPictInfoIndex].iPicBuffIdx;
       if (pPicBuff != NULL) {
-        if (iPicBuffIdx > 0 && iPicBuffIdx < pPicBuff->iCapacity)
+        if (iPicBuffIdx >= 0 && iPicBuffIdx < pPicBuff->iCapacity)
         {
             PPicture pPic = pPicBuff->ppPic[iPicBuffIdx];
             --pPic->iRefCount;


### PR DESCRIPTION
Fix iPicBuffIdx bounds check introduced in commit
986bd65b711191d4883c54ace32a9879e17729c2 and allow 0 as an index value.

This fixes Big_Buck_Bunny_720_10s_30MB.mp4 playback with gst-play-1.0.