### PR TITLE
 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send a [private vulnerability report](https://github.com/cisco/openh264/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+please give us 90 days to work on a fix before public exposure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ used before a patch is released.
 
 You may submit the report in the following ways:
 
-- send an email to ???@???; and/or
+- send an email to benzzhan@cisco.com; and/or
 - send a [private vulnerability report](https://github.com/cisco/openh264/security/advisories/new)
 
 Please provide the following information in your report:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,7 @@ privately. **Do not disclose it as a public issue.** This gives us time to work 
 to fix the issue before public exposure, reducing the chance that the exploit will be
 used before a patch is released.
 
-You may submit the report in the following ways:
-
-- send an email to benzzhan@cisco.com; and/or
-- send a [private vulnerability report](https://github.com/cisco/openh264/security/advisories/new)
+You may submit the report as an email to benzzhan@cisco.com.
 
 Please provide the following information in your report:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,5 +15,5 @@ Please provide the following information in your report:
 - A description of the vulnerability and its impact
 - How to reproduce the issue
 
-This project is maintained by volunteers on a reasonable-effort basis. As such,
-please give us 90 days to work on a fix before public exposure.
+This project is maintained on a reasonable-effort basis. As such, please give us 90 days to
+work on a fix before public exposure.


### PR DESCRIPTION
Fixes #3709.

This PR adds a simple security policy for OpenH264.

As is, the policy offers two means of reporting a vulnerability: an email (currently a placeholder, I couldn't find an adequate address) or using GitHub's private reporting feature.

Let me know if you'd rather just use one of these. 