### PR TITLE
Fix regression in PR#3707 for multi-thread decoding

### DIFF
--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -432,6 +432,7 @@ typedef struct TagWelsDecoderContext {
 #endif
   bool       bNewSeqBegin;
   bool       bNextNewSeqBegin;
+  int32_t    *pStreamSeqNum;
   int32_t    iSeqNum;
 
 //for Parse only

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -621,6 +621,7 @@ int32_t WelsOpenDecoder (PWelsDecoderContext pCtx, SLogContext* pLogCtx) {
   pCtx->bPrintFrameErrorTraceFlag = true;
   pCtx->iIgnoredErrorInfoPacketCount = 0;
   pCtx->bFrameFinish = true;
+  pCtx->iSeqNum = 0;
   return iRet;
 }
 

--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -621,7 +621,6 @@ int32_t WelsOpenDecoder (PWelsDecoderContext pCtx, SLogContext* pLogCtx) {
   pCtx->bPrintFrameErrorTraceFlag = true;
   pCtx->iIgnoredErrorInfoPacketCount = 0;
   pCtx->bFrameFinish = true;
-  pCtx->iSeqNum = 0;
   return iRet;
 }
 

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2262,8 +2262,9 @@ int32_t WelsDecodeInitAccessUnitStart (PWelsDecoderContext pCtx, SBufferInfo* pD
   pCtx->pLastDecPicInfo->bLastHasMmco5 = false;
   bool bTmpNewSeqBegin = CheckNewSeqBeginAndUpdateActiveLayerSps (pCtx);
   if (bTmpNewSeqBegin)
-    pCtx->iSeqNum++;
+    (*pCtx->pStreamSeqNum)++;
   pCtx->bNewSeqBegin = pCtx->bNewSeqBegin || bTmpNewSeqBegin;
+  pCtx->iSeqNum = *pCtx->pStreamSeqNum;
   iErr = WelsDecodeAccessUnitStart (pCtx);
   GetVclNalTemporalId (pCtx);
 

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2261,10 +2261,15 @@ int32_t WelsDecodeInitAccessUnitStart (PWelsDecoderContext pCtx, SBufferInfo* pD
   pCtx->bAuReadyFlag = false;
   pCtx->pLastDecPicInfo->bLastHasMmco5 = false;
   bool bTmpNewSeqBegin = CheckNewSeqBeginAndUpdateActiveLayerSps (pCtx);
-  if (bTmpNewSeqBegin)
-    (*pCtx->pStreamSeqNum)++;
+  if (bTmpNewSeqBegin) {
+    if (pCtx->pStreamSeqNum)
+      (*pCtx->pStreamSeqNum)++;
+    else
+      pCtx->iSeqNum++;
+  }
   pCtx->bNewSeqBegin = pCtx->bNewSeqBegin || bTmpNewSeqBegin;
-  pCtx->iSeqNum = *pCtx->pStreamSeqNum;
+  if (pCtx->pStreamSeqNum)
+    pCtx->iSeqNum = *pCtx->pStreamSeqNum;
   iErr = WelsDecodeAccessUnitStart (pCtx);
   GetVclNalTemporalId (pCtx);
 

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -138,6 +138,7 @@ class CWelsDecoder : public ISVCDecoder {
   SVlcTable               m_sVlcTable;
   SWelsLastDecPicInfo     m_sLastDecPicInfo;
   SDecoderStatistics      m_sDecoderStatistics;// For real time debugging
+  int32_t                 m_iStreamSeqNum;
 
  private:
   int32_t InitDecoder (const SDecodingParam* pParam);

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -143,7 +143,8 @@ CWelsDecoder::CWelsDecoder (void)
     m_DecCtxActiveCount (0),
     m_pDecThrCtx (NULL),
     m_pLastDecThrCtx (NULL),
-    m_iLastBufferedIdx (0) {
+    m_iLastBufferedIdx (0),
+    m_iStreamSeqNum (0) {
 #ifdef OUTPUT_BIT_STREAM
   char chFileName[1024] = { 0 };  //for .264
   int iBufUsed = 0;
@@ -417,6 +418,7 @@ int32_t CWelsDecoder::InitDecoderCtx (PWelsDecoderContext& pCtx, const SDecoding
   pCtx->pPictInfoList = m_sPictInfoList;
   pCtx->pPictReoderingStatus = &m_sReoderingStatus;
   pCtx->pCsDecoder = &m_csDecoder;
+  pCtx->pStreamSeqNum = &m_iStreamSeqNum;
   WelsDecoderDefaults (pCtx, &m_pWelsTrace->m_sLogCtx);
   WelsDecoderSpsPpsDefaults (pCtx->sSpsPpsCtx);
   //check param and update decoder context
@@ -1137,24 +1139,6 @@ DECODING_STATE CWelsDecoder::ReorderPicturesInDisplay(PWelsDecoderContext pDecCo
     m_bIsBaseline = pDecContext->pSps->uiProfileIdc == 66 || pDecContext->pSps->uiProfileIdc == 83;
     if (!m_bIsBaseline) {
       if (pDstInfo->iBufferStatus == 1) {
-        if (pDecContext->pSliceHeader->eSliceType == B_SLICE &&
-            ((pDecContext->iSeqNum == m_sReoderingStatus.iLastWrittenSeqNum) ?
-              (pDecContext->pSliceHeader->iPicOrderCntLsb <= m_sReoderingStatus.iLastWrittenPOC + 2) :
-              (pDecContext->iSeqNum - m_sReoderingStatus.iLastWrittenSeqNum == 1 && pDecContext->pSliceHeader->iPicOrderCntLsb == 0))) {
-          m_sReoderingStatus.iLastWrittenPOC = pDecContext->pSliceHeader->iPicOrderCntLsb;
-          m_sReoderingStatus.iLastWrittenSeqNum = pDecContext->iSeqNum;
-          //issue #3478, use b-slice type to determine correct picture order as the first priority as POC order is not as reliable as based on b-slice 
-          ppDst[0] = pDstInfo->pDst[0];
-          ppDst[1] = pDstInfo->pDst[1];
-          ppDst[2] = pDstInfo->pDst[2];
-#if defined (_DEBUG)
-#ifdef _MOTION_VECTOR_DUMP_
-          fprintf (stderr, "Output POC: #%d uiDecodingTimeStamp=%d\n", pDecContext->pSliceHeader->iPicOrderCntLsb,
-             pDecContext->uiDecodingTimeStamp);
-#endif
-#endif
-          return iRet;
-        }
         BufferingReadyPicture(pDecContext, ppDst, pDstInfo);
         if (!m_sReoderingStatus.bHasBSlice && m_sReoderingStatus.iNumOfPicts > 1) {
           ReleaseBufferedReadyPictureNoReorder (pDecContext, ppDst, pDstInfo);


### PR DESCRIPTION
This PR fixes the issue https://github.com/cisco/openh264/issues/3733.

The variable `iSeqNum` introduced in PR[#3707](https://github.com/cisco/openh264/pull/3707) should be common within the decoder, however each decoding thread in the same decoder had its own one. Due to this issue, multi-thread decoding failed. This patch fixes that.