### PR TITLE
Fix race issue among decoding threads which causes broken frame.

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -693,9 +693,11 @@ DECODING_STATE CWelsDecoder::DecodeFrameNoDelay (const unsigned char* kpSrc,
     SBufferInfo* pDstInfo) {
   int iRet = dsErrorFree;
   if (m_iThreadCount >= 1) {
+    SET_EVENT (&m_sReleaseBufferEvent);
     iRet = ThreadDecodeFrameInternal (kpSrc, kiSrcLen, ppDst, pDstInfo);
     if (m_sReoderingStatus.iNumOfPicts) {
       WAIT_EVENT (&m_sBufferingEvent, WELS_DEC_THREAD_WAIT_INFINITE);
+      RESET_EVENT (&m_sBufferingEvent);
       RESET_EVENT (&m_sReleaseBufferEvent);
       if (!m_sReoderingStatus.bHasBSlice) {
         if (m_sReoderingStatus.iNumOfPicts > 1) {
@@ -705,7 +707,6 @@ DECODING_STATE CWelsDecoder::DecodeFrameNoDelay (const unsigned char* kpSrc,
       else {
         ReleaseBufferedReadyPictureReorder (NULL, ppDst, pDstInfo);
       }
-      SET_EVENT(&m_sReleaseBufferEvent);
     }
     return (DECODING_STATE)iRet;
   }
@@ -791,6 +792,10 @@ DECODING_STATE CWelsDecoder::DecodeFrame2WithCtx (PWelsDecoderContext pDecContex
   pDecContext->iFrameNum = -1; //initialize
 #endif
 
+  if (GetThreadCount (pDecContext) >= 1) {
+    WAIT_EVENT (&m_sReleaseBufferEvent, WELS_DEC_THREAD_WAIT_INFINITE);
+  }
+
   pDecContext->iFeedbackTidInAu = -1; //initialize
   pDecContext->iFeedbackNalRefIdc = -1; //initialize
   if (pDstInfo) {
@@ -873,8 +878,6 @@ DECODING_STATE CWelsDecoder::DecodeFrame2WithCtx (PWelsDecoderContext pDecContex
 
     OutputStatisticsLog (*pDecContext->pDecoderStatistics);
     if (GetThreadCount (pDecContext) >= 1) {
-      WAIT_EVENT (&m_sReleaseBufferEvent, WELS_DEC_THREAD_WAIT_INFINITE);
-      RESET_EVENT (&m_sBufferingEvent);
       BufferingReadyPicture (pDecContext, ppDst, pDstInfo);
       SET_EVENT (&m_sBufferingEvent);
     } else {
@@ -899,8 +902,6 @@ DECODING_STATE CWelsDecoder::DecodeFrame2WithCtx (PWelsDecoderContext pDecContex
   pDecContext->dDecTime += (iEnd - iStart) / 1e3;
 
   if (GetThreadCount (pDecContext) >= 1) {
-    WAIT_EVENT (&m_sReleaseBufferEvent, WELS_DEC_THREAD_WAIT_INFINITE);
-    RESET_EVENT (&m_sBufferingEvent);
     BufferingReadyPicture (pDecContext, ppDst, pDstInfo);
     SET_EVENT (&m_sBufferingEvent);
   } else {


### PR DESCRIPTION
Sometimes, the decoded frame output data will be broken due to the race issue among decoding threads. This patch trims event timings for multi-thread cooperation.

Releasing reordering buffer is single thread while writing to the reordering buffer is multi-thread. Therefore, `RESET_EVENT()` should not be called in writer side. Moreover, `WelsDecodeBs()` tries to acquire the empty buffer, so it should wait for `m_sReleaseBufferEvent` event.