### PR TITLE
Fix crash on multi-thread decoding.

### DIFF
--- a/codec/decoder/core/src/decoder.cpp
+++ b/codec/decoder/core/src/decoder.cpp
@@ -820,8 +820,6 @@ int32_t WelsDecodeBs (PWelsDecoderContext pCtx, const uint8_t* kpBsBuf, const in
             if (pCtx->bAuReadyFlag && pCtx->pAccessUnitList->uiAvailUnitsNum != 0) {
               if (GetThreadCount (pCtx) <= 1) {
                 ConstructAccessUnit (pCtx, ppDst, pDstBufInfo);
-              } else {
-                pCtx->pAccessUnitList->uiAvailUnitsNum = 1;
               }
             }
           }
@@ -884,8 +882,6 @@ int32_t WelsDecodeBs (PWelsDecoderContext pCtx, const uint8_t* kpBsBuf, const in
       if (pCtx->bAuReadyFlag && pCtx->pAccessUnitList->uiAvailUnitsNum != 0) {
         if (GetThreadCount (pCtx) <= 1) {
           ConstructAccessUnit (pCtx, ppDst, pDstBufInfo);
-        } else {
-          pCtx->pAccessUnitList->uiAvailUnitsNum = 1;
         }
       }
     }


### PR DESCRIPTION
When decoding:
https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov in multi-threads, openh264 crashes with segfault. This patch fixes the issue.

## How to reproduce:
- Download https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov
- Run `ffmpeg -i big_buck_bunny_1080p_h264.mov -t 10 -vcodec copy -an bbb.264`
- Enable multi-thread in h264dec by:
```
diff --git a/codec/console/dec/src/h264dec.cpp b/codec/console/dec/src/h264dec.cpp
index 59365844..4338bbce 100644
--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -624,7 +624,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
     pDecoder->SetOption (DECODER_OPTION_TRACE_LEVEL, &iLevelSetting);
   }

-  int32_t iThreadCount = 0;
+  int32_t iThreadCount = 3;
   pDecoder->SetOption (DECODER_OPTION_NUM_OF_THREADS, &iThreadCount);

   if (pDecoder->Initialize (&sDecParam)) {
```
- Build openh264.
- Run `./h264dec bbb.264 x.yuv`
- This crashes with segfault.
