### PR TITLE
Remove unused pSpatialLayer variable in DetermineTemporalSettings

### DIFF
--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -231,7 +231,6 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
   unsigned long long uiTimeStamp = 0;
   int64_t iStart = 0, iEnd = 0, iTotal = 0;
   int32_t iSliceSize;
-  int32_t iSliceIndex = 0;
   uint8_t* pBuf = NULL;
   uint8_t uiStartCode[4] = {0, 0, 0, 1};
 
@@ -449,7 +448,6 @@ void H264DecodeInstance (ISVCDecoder* pDecoder, const char* kpH264FileName, cons
       }
     }
     iBufPos += iSliceSize;
-    ++ iSliceIndex;
   }
   FlushFrames (pDecoder, iTotal, pYuvFile, pOptionFile, iFrameCount, uiTimeStamp, iWidth, iHeight, iLastWidth,
                iLastHeight);

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -493,7 +493,6 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
     const int32_t iDecStages = WELS_LOG2 (uiGopSize); // (int8_t)GetLogFactor(1.0f, 1.0f * pcfg->uiGopSize);  //log2(uiGopSize)
     const uint8_t* pTemporalIdList = &g_kuiTemporalIdListTable[iDecStages][0];
     SSpatialLayerInternal* pDlp    = &sDependencyLayers[0];
-    SSpatialLayerConfig* pSpatialLayer = &sSpatialLayers[0];
     int8_t i = 0;
 
     while (i < iSpatialLayerNum) {
@@ -524,7 +523,6 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
         return ENC_RETURN_INVALIDINPUT;
       }
       ++ pDlp;
-      ++ pSpatialLayer;
       ++ i;
     }
     iDecompStages = (int8_t)iDecStages;

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,8 @@ cpu_family = host_machine.cpu_family()
 supported_arguments = cpp.get_supported_arguments([
   '-Wno-non-virtual-dtor',
   '-Wno-class-memaccess',
+  '-Werror',
+  '-Wunused-but-set-variable',
   '-Wno-strict-aliasing'])
 
 add_project_arguments(supported_arguments, language: 'cpp')

--- a/test/api/decoder_ec_test.cpp
+++ b/test/api/decoder_ec_test.cpp
@@ -248,7 +248,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   EXPECT_EQ (uiGet, uiEcIdc);
 
   //Start for enc/dec
-  int iIdx = 0;
   int len = 0;
   unsigned char* pData[3] = { NULL };
   ASSERT_TRUE (InitialEncDec (p.width, p.height));
@@ -265,11 +264,9 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_EQ (rv, 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1);
-  iIdx++;
 
   //Frame 1: P, EC_IDC=DISABLE, loss = 1
   EncodeOneFrame (1);
-  iIdx++;
 
   //Frame 2: P, EC_IDC=DISABLE, loss = 0
   EncodeOneFrame (1);
@@ -284,7 +281,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE (rv != 0); //construction error due to data loss
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); //no output due to EC DISABLE
-  iIdx++;
 
   //set EC=SLICE_COPY
   uiEcIdc = (uint32_t) (ERROR_CON_SLICE_COPY);
@@ -304,7 +300,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE (rv != 0); //construction error due to data loss
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1);
-  iIdx++;
 
   //set EC=DISABLE
   uiEcIdc = (uint32_t) (ERROR_CON_DISABLE);
@@ -325,11 +320,9 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   //Ref picture is ECed, so current status is ECed, when EC disable, NO output
   EXPECT_TRUE (rv != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0);
-  iIdx++;
 
   //Frame 5: P, EC_IDC=DISABLE, loss = 1
   EncodeOneFrame (1);
-  iIdx++;
 
   //set EC=FRAME_COPY
   uiEcIdc = (uint32_t) (ERROR_CON_FRAME_COPY);
@@ -339,7 +332,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   //Frame 6: P, EC_IDC=FRAME_COPY, loss = 1
   EncodeOneFrame (1);
   EXPECT_EQ (uiGet, uiEcIdc);
-  iIdx++;
 
   //Frame 7: P, EC_IDC=FRAME_COPY, loss = 0
   EncodeOneFrame (1);
@@ -354,7 +346,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificFrameChange) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE (rv != 0); //not sure if previous data drop would be detected in construction
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1);
-  iIdx++;
 }
 
 //This case contain 2 slices per picture for IDR loss
@@ -380,7 +371,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   decoder_->SetOption (DECODER_OPTION_TRACE_LEVEL, &iTraceLevel);
 
   //Start for enc/dec
-  int iIdx = 0;
   int len = 0;
   unsigned char* pData[3] = { NULL };
   int iTotalSliceSize = 0;
@@ -406,7 +396,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_EQ (rv, 0); // Reconstruct first slice OK
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); //slice incomplete, no output
-  iIdx++;
 
   //Frame 1: P, EC_IDC=2, loss = 0
   //will clean SPS/PPS status
@@ -422,7 +411,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //ECed status, reconstruction current frame 1
   EXPECT_TRUE ((rv & 32) != 0); //decoder ECed status
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1); //ECed output for frame 1
-  iIdx++;
 
   //set EC=DISABLE
   uiEcIdc = (uint32_t) (ERROR_CON_DISABLE);
@@ -443,7 +431,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   // Ref picture is ECed, so reconstructed picture is ECed
   EXPECT_TRUE ((rv & 32) != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0);
-  iIdx++;
 
   //set EC=SLICE_COPY
   uiEcIdc = (uint32_t) (ERROR_CON_FRAME_COPY);
@@ -464,7 +451,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE ((rv & 32) != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); //slice loss
-  iIdx++;
 
   //set EC=DISABLE
   uiEcIdc = (uint32_t) (ERROR_CON_DISABLE);
@@ -484,7 +470,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE (rv != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); // No ref picture, no output
-  iIdx++;
 
 }
 
@@ -512,7 +497,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   decoder_->SetOption (DECODER_OPTION_TRACE_LEVEL, &iTraceLevel);
 
   //Start for enc/dec
-  int iIdx = 0;
   int len = 0;
   unsigned char* pData[3] = { NULL };
   int iTotalSliceSize = 0;
@@ -537,7 +521,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_EQ (rv, 0); //parse correct
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1); //output frame 0
-  iIdx++;
 
   //Frame 1: P, EC_IDC=0, loss = 0
   //Expected result: all OK, 2nd Output
@@ -553,7 +536,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction current frame 1
   EXPECT_EQ (rv, 0); //parse correct
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1); //ECed output for frame 1
-  iIdx++;
 
   //Frame 2: P, EC_IDC=0, loss = 1
   //Expected result: all OK, no Output
@@ -570,7 +552,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_EQ (rv, 0); //parse correct
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0);
-  iIdx++;
 
   //set EC=SLICE_COPY
   uiEcIdc = (uint32_t) (ERROR_CON_SLICE_COPY);
@@ -591,7 +572,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction
   EXPECT_TRUE ((rv & 32) != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); //slice loss
-  iIdx++;
 
   //set EC=DISABLE
   uiEcIdc = (uint32_t) (ERROR_CON_DISABLE);
@@ -613,7 +593,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   // previous frame NOT output, no ref
   EXPECT_TRUE (rv != 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 0); //output previous pic
-  iIdx++;
 
   //Frame 5: IDR, EC_IDC=2->0, loss = 0
   //Expected result: depends on DecodeFrame2 result. If OK, output; else ,no output
@@ -654,7 +633,6 @@ TEST_F (EncodeDecodeTestAPI, SetOptionECIDC_SpecificSliceChange_IDRNoLoss) {
   rv = decoder_->DecodeFrame2 (NULL, 0, pData, &dstBufInfo_); //reconstruction,
   EXPECT_EQ (rv, 0);
   EXPECT_EQ (dstBufInfo_.iBufferStatus, 1); //output previous pic
-  iIdx++;
 
 }
 

--- a/test/decoder/DecUT_DecExt.cpp
+++ b/test/decoder/DecUT_DecExt.cpp
@@ -140,7 +140,6 @@ void DecoderInterfaceTest::DecoderBs (const char* sFileName) {
   int32_t iFileSize;
   int32_t i = 0;
   int32_t iSliceSize;
-  int32_t iSliceIndex = 0;
   int32_t iEndOfStreamFlag = 0;
   FILE* pH264File;
   uint8_t uiStartCode[4] = {0, 0, 0, 1};
@@ -174,7 +173,6 @@ void DecoderInterfaceTest::DecoderBs (const char* sFileName) {
     m_pDec->DecodeFrame2 (pBuf + iBufPos, iSliceSize, m_pData, &m_sBufferInfo);
     m_pDec->DecodeFrame2 (NULL, 0, m_pData, &m_sBufferInfo);
     iBufPos += iSliceSize;
-    ++ iSliceIndex;
   }
 
   fclose (pH264File);


### PR DESCRIPTION
which breaks on Mac CI settings due to the variable being unused

Fixes the build issue from #3752, as a separate commit for papertrail reasons.
```
./codec/encoder/core/inc/param_svc.h:496:26: error: variable 'pSpatialLayer' set but 
not used [-Werror,-Wunused-but-set-variable]
    SSpatialLayerConfig* pSpatialLayer = &sSpatialLayers[0];
```