### PR TITLE
Fix deadlock at the end of decoding.

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -325,6 +325,7 @@ void CWelsDecoder::OpenDecoderThreads() {
 }
 void CWelsDecoder::CloseDecoderThreads() {
   if (m_iThreadCount >= 1) {
+    SET_EVENT (&m_sReleaseBufferEvent);
     for (int32_t i = 0; i < m_iThreadCount; i++) { //waiting the completion begun slices
       WAIT_SEMAPHORE (&m_pDecThrCtx[i].sThreadInfo.sIsIdle, WELS_DEC_THREAD_WAIT_INFINITE);
       m_pDecThrCtx[i].sThreadInfo.uiCommand = WELS_DEC_THREAD_COMMAND_ABORT;
@@ -513,6 +514,8 @@ long CWelsDecoder::SetOption (DECODER_OPTION eOptID, void* pOption) {
       if (pDecContext == NULL) return dsInitialOptExpected;
 
       pDecContext->bEndOfStreamFlag = iVal ? true : false;
+      if (iVal && m_iThreadCount >= 1)
+        SET_EVENT (&m_sReleaseBufferEvent);
 
       return cmResultSuccess;
     } else if (eOptID == DECODER_OPTION_ERROR_CON_IDC) { // Indicate error concealment status


### PR DESCRIPTION
# Issue
For some h264 files, h264dec hangs at the end of decoding. This is regression caused by the commit 1c2388750acf. This patch fixes the issue by adding SET_EVENT(&m_sReleaseBufferEvent) to SetOption(DECODER_OPTION_END_OF_STREAM).

# To reproduce
* Apply the following patch to h264dec and build it to enable multi-thread decoding.
```
diff --git a/codec/console/dec/src/h264dec.cpp b/codec/console/dec/src/h264dec.cpp
index 78c5c5d0..4851062f 100644
--- a/codec/console/dec/src/h264dec.cpp
+++ b/codec/console/dec/src/h264dec.cpp
@@ -622,7 +622,7 @@ int32_t main (int32_t iArgC, char* pArgV[]) {
     pDecoder->SetOption (DECODER_OPTION_TRACE_LEVEL, &iLevelSetting);
   }

-  int32_t iThreadCount = 0;
+  int32_t iThreadCount = 3;
   pDecoder->SetOption (DECODER_OPTION_NUM_OF_THREADS, &iThreadCount);

   if (pDecoder->Initialize (&sDecParam)) {
```
* Download https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov
* Convert .mov to .264 (You can use ffmepg like ```ffmpeg -i big_buck_bunny_1080p_h264.mov -c:v copy big_buck_bunny_1080p_h264.264```).
* Run ```h246dec big_buck_bunny_1080p_h264.264 big_buck_bunny_1080p_h264.yuv```
