### PR TITLE
build: fix build with meson on riscv64

### DIFF
--- a/codec/common/meson.build
+++ b/codec/common/meson.build
@@ -69,6 +69,8 @@ elif cpu_family in ['loongarch32', 'loongarch64']
     'loongarch/satd_sad_lasx.c',
   ]
   cpp_sources += asm_sources
+elif cpu_family == 'riscv64'
+  asm_sources = []
 else
   error('Unsupported cpu_family @0@'.format(cpu_family))
 endif

--- a/codec/decoder/meson.build
+++ b/codec/decoder/meson.build
@@ -54,6 +54,8 @@ elif cpu_family in ['loongarch32', 'loongarch64']
     'core/loongarch/mb_aux_lsx.c',
   ]
   cpp_sources += asm_sources
+elif cpu_family == 'riscv64'
+  asm_sources = []
 else
   error('Unsupported cpu family @0@'.format(cpu_family))
 endif

--- a/codec/encoder/meson.build
+++ b/codec/encoder/meson.build
@@ -83,6 +83,8 @@ elif cpu_family in ['loongarch32', 'loongarch64']
     'core/loongarch/sample_lasx.c',
   ]
   cpp_sources += asm_sources
+elif cpu_family == 'riscv64'
+  asm_sources = []
 else
   error('Unsupported cpu family @0@'.format(cpu_family))
 endif

--- a/codec/processing/meson.build
+++ b/codec/processing/meson.build
@@ -56,6 +56,8 @@ elif cpu_family in ['loongarch32', 'loongarch64']
     'src/loongarch/vaa_lasx.c',
   ]
   cpp_sources += asm_sources
+elif cpu_family == 'riscv64'
+  asm_sources = []
 else
   error('Unsupported cpu family @0@'.format(cpu_family))
 endif

--- a/meson.build
+++ b/meson.build
@@ -98,6 +98,9 @@ if ['linux', 'android', 'ios', 'darwin'].contains(system)
     add_project_arguments('-mlsx', '-DHAVE_LSX', '-mlasx', '-DHAVE_LASX', language: 'c')
     add_project_arguments('-DHAVE_LSX', '-DHAVE_LASX', language: 'cpp')
     casm_inc = include_directories(join_paths('codec', 'common', 'loongarch'))
+  elif cpu_family == 'riscv64'
+    # We dont't have riscv64-specific optimization for now.
+    asm_format = asm_format64
   else
     error('FIXME: unhandled CPU family @0@ for @1@'.format(cpu_family, system))
   endif


### PR DESCRIPTION
RISC-V is a rising open-standarded RISC ISA. This commit makes mesonbuild fallbacks to C implementation correctly on riscv64 platform instead of throwing a "FIXME: unhandled CPU family" error.