### PR TITLE
Enable pac bti support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ See <http://mesonbuild.com/Installing.html> for instructions on how to
 install meson, then:
 
 ``` shell
-meson builddir
+meson setup builddir
 ninja -C builddir
 ```
 

--- a/codec/common/arm64/arm_aarch64_common.h
+++ b/codec/common/arm64/arm_aarch64_common.h
@@ -1,0 +1,85 @@
+/*!
+ *@page License
+ *
+ * \copy
+ *     Copyright (c)  2024, ARM Ltd.
+ *     All rights reserved.
+ *
+ *     Redistribution and use in source and binary forms, with or without
+ *     modification, are permitted provided that the following conditions
+ *     are met:
+ *
+ *        * Redistributions of source code must retain the above copyright
+ *          notice, this list of conditions and the following disclaimer.
+ *
+ *        * Redistributions in binary form must reproduce the above copyright
+ *          notice, this list of conditions and the following disclaimer in
+ *          the documentation and/or other materials provided with the
+ *          distribution.
+ *
+ *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *     COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *     POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef CODEC_COMMON_ARM64_ARM_AARCH64_COMMON_H_
+#define CODEC_COMMON_ARM64_ARM_AARCH64_COMMON_H_
+
+/*
+ ; Support macros for
+ ;   - Armv8.3-A Pointer Authentication and
+ ;   - Armv8.5-A Branch Target Identification
+ ; Further documentation can be found at:
+ ;  - https://developer.arm.com/documentation/101028/0012/5--Feature-test-macros
+ ;
+ ; Since openh264 aarch64 assembly code provides functions with no storage of the
+ ; LR(x30) on the stack, PAC is not needed as modification of the LR value would
+ ; require modification of x30 and not memory. Additionally, no indirect control
+ ; flow changes are performed, so bti j instructions are not needed. Thus, just
+ ; mark the entry points with bti c landing pads and the ELF files as supporting
+ ; BTI and PAC.
+ */
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT == 1
+  /* BTI is enabled */
+  #define BTI_C hint 34
+  #define GNU_PROPERTY_AARCH64_BTI 0x1 /* Property for notes section in ELF */
+#else
+  /* BTI is NOT enabled */
+  #define BTI_C
+  #define GNU_PROPERTY_AARCH64_BTI 0
+#endif
+
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+  /* PAC is enabled */
+  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0x2 /* Property for notes section in ELF */
+#else
+  /* PAC is not enabled */
+  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0
+#endif
+
+/* Add the notes section to ELF only */
+#if defined(__ELF__)
+  .pushsection .note.gnu.property, "a";
+  .balign 8;
+  .long 4;
+  .long 0x10;
+  .long 0x5;
+  .asciz "GNU";
+  .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+  .long 4;
+  .long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI);
+  .long 0;
+  .popsection;
+#endif
+
+#endif /* CODEC_COMMON_ARM64_ARM_AARCH64_COMMON_H_ */

--- a/codec/common/arm64/arm_arch64_common_macro.S
+++ b/codec/common/arm64/arm_arch64_common_macro.S
@@ -30,6 +30,8 @@
  *
  */
 
+#include "arm_aarch64_common.h"
+
 #ifdef __APPLE__
 
 .text
@@ -60,6 +62,7 @@ ret
 .func \funcName
 #endif
 \funcName:
+    BTI_C
 .endm
 
 .macro WELS_ASM_AARCH64_FUNC_END

--- a/meson.build
+++ b/meson.build
@@ -83,8 +83,8 @@ if ['linux', 'android', 'ios', 'darwin'].contains(system)
     casm_inc = include_directories(join_paths('codec', 'common', 'arm'))
   elif cpu_family == 'aarch64'
     asm_format = asm_format64
-    add_project_arguments('-DHAVE_NEON_ARM64', language: 'c')
-    add_project_arguments('-DHAVE_NEON_ARM64', language: 'cpp')
+    add_project_arguments('-DHAVE_NEON_AARCH64', language: 'c')
+    add_project_arguments('-DHAVE_NEON_AARCH64', language: 'cpp')
     casm_inc = include_directories(join_paths('codec', 'common', 'arm64'))
   elif cpu_family == 'loongarch32'
     asm_format = asm_format32


### PR DESCRIPTION
- aarch64: enable PAC/BTI
- meson.build: fix suffix on HAVE_NEON_AARCH64
- readme: update meson build command

Fixes #3741