### PR TITLE
Fix broken decode result in multi-thread decoding.

### DIFF
--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -2706,7 +2706,6 @@ int32_t DecodeCurrentAccessUnit (PWelsDecoderContext pCtx, uint8_t** ppDst, SBuf
 
         if (iCurrIdD == kuiDependencyIdMax && iCurrIdQ == BASE_QUALITY_ID && isNewFrame) {
           iRet = InitRefPicList (pCtx, pCtx->uiNalRefIdc, pSh->iPicOrderCntLsb);
-          if (iThreadCount > 1) isNewFrame = false;
           if (iRet) {
             pCtx->bRPLRError = true;
             bAllRefComplete = false; // RPLR error, set ref pictures complete flag false


### PR DESCRIPTION
If the following test video is decoded with multi-thread by openh264, the decode result will be broken.

https://github.com/user-attachments/assets/b3fbfc09-f3a3-468c-bbc7-d761ae7fdd8c

The following file is the re-encoded result of the broken decoded result.

https://github.com/user-attachments/assets/ed5de14d-c78c-4a92-a0fc-82c5f32f119f

This patch just removes
```
          if (iThreadCount > 1) isNewFrame = false;
```
which was introduced by the commit 54f6c4ddbd771e3af64d763f1551ed22655102f2, but it is not clear why this was necessary.