### PR TITLE
Motion Vector Extraction from H.264 Encoded Bitstream (CABAC Only)

### DIFF
--- a/codec/api/wels/codec_api.h
+++ b/codec/api/wels/codec_api.h
@@ -45,6 +45,7 @@ typedef unsigned char bool;
 
 #include "codec_app_def.h"
 #include "codec_def.h"
+#include <stdint.h>
 
 #if defined(_WIN32) || defined(__cdecl)
 #define EXTAPI __cdecl
@@ -452,6 +453,43 @@ class ISVCDecoder {
       int& iColorFormat) = 0;
 
   /**
+  * @brief  parse bitstream and get motion vectors - skip frame reconstruction
+  * @param   pSrc the h264 stream to be decoded
+  * @param   iSrcLen the length of h264 stream
+  * @param   ppDst buffer pointer of decoded data (YUV)
+  * @param   pDstInfo information provided to API(width, height, etc.)
+  * @param   MotionVectorSize size of the total motion vector for the given P frame.
+  * @param   MotionVectorData Motion vector data.(ex: MotionX, MotionY, Xoffset, Yoffset)
+  * @return  0 - success; otherwise -failed;
+  */
+  virtual DECODING_STATE EXTAPI ParseBitstreamGetMotionVectors (const unsigned char* kpSrc,
+    const int kiSrcLen,
+    unsigned char** ppDst,
+    SParserBsInfo* pDstInfo,
+    SBufferInfo* ppDecodeInfo,
+    int32_t* motionVectorSize,
+    int16_t** motionVectorData) = 0;
+
+  /**
+   @brief   ParseBitstreamGetMotionVectors is used to parse the encoded bitstream and get the motion vectors for the given P frame.
+  *          If bParseOnly mode is enabled then only motionVectorData and motionVectorSize is updated and ppDst is returned with NULL Value.
+  *          If bParseOnly mode is disabled then along MotionVectorData and motionVectorSize the deocoded YUV buffer is updated in ppDst. 
+  * @param   pSrc the h264 stream to be decoded
+  * @param   iSrcLen the length of h264 stream
+  * @param   ppDst buffer pointer of decoded data (YUV)
+  * @param   pDstInfo information provided to API(width, height, etc.)
+  * @param   MotionVectorSize size of the total motion vector for the given P frame.
+  * @param   MotionVectorData Motion vector data.(ex: MotionX, MotionY, Xoffset, Yoffset)
+  * @return  0 - success; otherwise -failed;
+  */
+   virtual DECODING_STATE EXTAPI DecodeFrameGetMotionVectorsNoDelay (const unsigned char* pSrc,
+      const int iSrcLen,
+      unsigned char** ppDst,
+      SBufferInfo* pDstInfo,
+      int32_t* motionVectorSize,
+      int16_t** motionVectorData) = 0;
+
+  /**
   * @brief   Set option for decoder, detail option type, please refer to enumurate DECODER_OPTION.
   * @param   pOption  option for decoder such as OutDataFormat, Eos Flag, EC method, ...
   * @return  CM_RETURN: 0 - success; otherwise - failed;
@@ -509,6 +547,21 @@ DECODING_STATE (*DecodeFrameNoDelay) (ISVCDecoder*, const unsigned char* pSrc,
                                       const int iSrcLen,
                                       unsigned char** ppDst,
                                       SBufferInfo* pDstInfo);
+
+DECODING_STATE (*ParseBitstreamGetMotionVectors) (const unsigned char* kpSrc,
+                                                  const int kiSrcLen,
+                                                  unsigned char** ppDst,
+                                                  SParserBsInfo* pDstInfo,
+                                                  SBufferInfo* ppDecodeInfo,
+                                                  int32_t* motionVectorSize,
+                                                  int16_t** motionVectorData);
+
+DECODING_STATE (*DecodeFrameGetMotionVectorsNoDelay) (const unsigned char* pSrc,
+                                                             const int iSrcLen,
+                                                             unsigned char** ppDst,
+                                                             SBufferInfo* pDstInfo,
+                                                             int32_t* motionVectorSize,
+                                                             int16_t** motionVectorData);
 
 DECODING_STATE (*DecodeFrame2) (ISVCDecoder*, const unsigned char* pSrc,
                                 const int iSrcLen,

--- a/codec/decoder/core/inc/decoder_context.h
+++ b/codec/decoder/core/inc/decoder_context.h
@@ -513,6 +513,8 @@ typedef struct TagWelsDecoderContext {
   CMemoryAlign*     pMemAlign;
   void* pThreadCtx;
   void* pLastThreadCtx;
+  int32_t mMotionVectorSize = 0; 
+  int16_t* mMotionVectorData ; 
   WELS_MUTEX* pCsDecoder;
   int16_t lastReadyHeightOffset[LIST_A][MAX_REF_PIC_COUNT]; //last ready reference MB offset
   PPictInfo               pPictInfoList;

--- a/codec/decoder/core/inc/parse_mb_syn_cabac.h
+++ b/codec/decoder/core/inc/parse_mb_syn_cabac.h
@@ -84,6 +84,7 @@ void    UpdateP8x8DirectCabac (PDqLayer pCurDqLayer, int32_t iPartIdx);
 void    UpdateP16x16DirectCabac (PDqLayer pCurDqLayer);
 void    UpdateP8x8RefCacheIdxCabac (int8_t pRefIndex[LIST_A][30], const int16_t& iPartIdx, const int32_t& listIdx,
                                     const int8_t& iRef);
+void UpdateMotionVector (PWelsDecoderContext pCtx , int16_t pMotionX, int16_t pMotionY, int16_t xOffset, int16_t yOffset);
 }
 //#pragma pack()
 #endif

--- a/codec/decoder/core/src/decoder_core.cpp
+++ b/codec/decoder/core/src/decoder_core.cpp
@@ -1587,6 +1587,9 @@ int32_t InitialDqLayersContext (PWelsDecoderContext pCtx, const int32_t kiMaxWid
     pCtx->sMb.pMbRefConcealedFlag[i] = (bool*) pMa->WelsMallocz (pCtx->sMb.iMbWidth * pCtx->sMb.iMbHeight * sizeof (
                                          bool),
                                        "pCtx->pMbRefConcealedFlag[]");
+    
+    pCtx->mMotionVectorData = (int16_t*)  pMa->WelsMallocz (pCtx->iImgWidthInPixel * pCtx->iImgHeightInPixel * 8 ,
+                                          "pCtx->pMbRefConcealedFlag[]");
 
     // check memory block valid due above allocated..
     WELS_VERIFY_RETURN_IF (ERR_INFO_OUT_OF_MEMORY,
@@ -1643,6 +1646,13 @@ void UninitialDqLayersContext (PWelsDecoderContext pCtx) {
     if (pDq == NULL) {
       ++ i;
       continue;
+    }
+
+     if (pCtx->mMotionVectorData)
+    {
+      pCtx->mMotionVectorData -= pCtx->mMotionVectorSize;
+      pMa->WelsFree (pCtx->mMotionVectorData, "pCtx->mMotionVectorData");
+      pCtx->mMotionVectorData = nullptr;
     }
 
     if (pCtx->sMb.pMbType[i]) {

--- a/codec/decoder/plus/inc/welsDecoderExt.h
+++ b/codec/decoder/plus/inc/welsDecoderExt.h
@@ -91,6 +91,21 @@ class CWelsDecoder : public ISVCDecoder {
       unsigned char** ppDst,
       SBufferInfo* pDstInfo);
 
+   virtual DECODING_STATE EXTAPI ParseBitstreamGetMotionVectors (const unsigned char* kpSrc,
+    const int kiSrcLen,
+    unsigned char** ppDst,
+    SParserBsInfo* pDstInfo,
+    SBufferInfo* ppDecodeInfo,
+    int32_t* motionVectorSize,
+    int16_t** motionVectorData);
+
+  virtual DECODING_STATE EXTAPI DecodeFrameGetMotionVectorsNoDelay (const unsigned char* pSrc,
+      const int iSrcLen,
+      unsigned char** ppDst,
+      SBufferInfo* pDstInfo,
+      int32_t* motionVectorSize,
+      int16_t** motionVectorData);
+
   virtual DECODING_STATE EXTAPI FlushFrame (unsigned char** ppDst,
       SBufferInfo* pDstInfo);
 

--- a/test/api/cpp_interface_test.cpp
+++ b/test/api/cpp_interface_test.cpp
@@ -82,6 +82,18 @@ struct SVCDecoderImpl : public ISVCDecoder {
     EXPECT_TRUE (gThis == this);
     return static_cast<DECODING_STATE> (4);
   }
+  virtual DECODING_STATE EXTAPI ParseBitstreamGetMotionVectors (const unsigned char* kpSrc,
+    const int kiSrcLen, unsigned char** ppDst, SParserBsInfo* pDstInfo, SBufferInfo* ppDecodeInfo, int32_t* motionVectorSize,
+    int16_t** motionVectorData) {
+    EXPECT_TRUE (gThis == this);
+    return static_cast<DECODING_STATE> (11);
+  }
+  virtual DECODING_STATE EXTAPI DecodeFrameGetMotionVectorsNoDelay (const unsigned char* pSrc,
+      const int iSrcLen, unsigned char** ppDst, SBufferInfo* pDstInfo,int32_t* motionVectorSize,
+      int16_t** motionVectorData) {
+    EXPECT_TRUE (gThis == this);
+    return static_cast<DECODING_STATE> (12);
+  }
   virtual DECODING_STATE EXTAPI DecodeFrame2 (const unsigned char* pSrc,
       const int iSrcLen, unsigned char** ppDst, SBufferInfo* pDstInfo) {
     EXPECT_TRUE (gThis == this);


### PR DESCRIPTION
This PR introduces a feature that allows the extraction of motion vectors from H.264 encoded bitstreams, specifically for streams using CABAC (Context-Adaptive Binary Arithmetic Coding), without performing full frame reconstruction. By focusing only on CABAC, this optimization reduces the computational overhead for decoding when motion vectors are the primary data of interest.

Key benefits:

CABAC-specific optimization: Reduces decoding time by bypassing frame reconstruction in CABAC-encoded streams, which typically consume the most computational resources.
Efficient for motion analysis: Ideal for use cases requiring only motion vector data, such as motion tracking and real-time analysis.
Streamlined decoding: Maintains the integrity of the bitstream while providing an efficient way to access motion vectors.
This enhancement is especially valuable for performance-critical applications where CABAC encoding is used, and full frame reconstruction is unnecessary.