### PR TITLE
Use void casts to silence warnings about memcpy to a class

### DIFF
--- a/build/platform-gnu-chain.mk
+++ b/build/platform-gnu-chain.mk
@@ -31,12 +31,3 @@ endif
 ifneq ($(filter %clang++,$(CXX)),)
 CXXFLAGS += -Wc++11-compat-reserved-user-defined-literal
 endif
-
-ifneq ($(filter %g++,$(CXX)),)
-ifeq ($(filter %clang++,$(CXX)),)
-GCCVER_GTEQ8 = $(shell echo $$(($$($(CXX) -dumpversion | awk -F "." '{print $$1}') >= 8)))
-ifeq ($(GCCVER_GTEQ8), 1)
-CXXFLAGS += -Wno-class-memaccess
-endif
-endif
-endif

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2329,7 +2329,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
     WelsUninitEncoderExt (&pCtx);
     return iRet;
   }
-  memcpy (pCtx->pSvcParam, pCodingParam, sizeof (SWelsSvcCodingParam)); // confirmed_safe_unsafe_usage
+  memcpy ((void*) pCtx->pSvcParam, pCodingParam, sizeof (SWelsSvcCodingParam)); // confirmed_safe_unsafe_usage
 
   pCtx->pFuncList = (SWelsFuncPtrList*)pCtx->pMemAlign->WelsMallocz (sizeof (SWelsFuncPtrList), "SWelsFuncPtrList");
   if (NULL == pCtx->pFuncList) {
@@ -4456,7 +4456,7 @@ int32_t WelsEncoderApplyLTR (SLogContext* pLogCtx, sWelsEncCtx** ppCtx, SLTRConf
   SWelsSvcCodingParam sConfig;
   int32_t iNumRefFrame = 1;
   int32_t iRet = 0;
-  memcpy (&sConfig, (*ppCtx)->pSvcParam, sizeof (SWelsSvcCodingParam));
+  memcpy ((void*) &sConfig, (*ppCtx)->pSvcParam, sizeof (SWelsSvcCodingParam));
   sConfig.bEnableLongTermReference = pLTRValue->bEnableLongTermReference;
   sConfig.iLTRRefNum = pLTRValue->iLTRRefNum;
   int32_t uiGopSize = 1 << (sConfig.iTemporalLayerNum - 1);

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -1056,7 +1056,7 @@ int CWelsH264SVCEncoder::SetOption (ENCODER_OPTION eOptionId, void* pOption) {
       return cmInitParaError;
     }
     SWelsSvcCodingParam sConfig;
-    memcpy (&sConfig, m_pEncContext->pSvcParam, sizeof (SWelsSvcCodingParam));
+    memcpy ((void*) &sConfig, m_pEncContext->pSvcParam, sizeof (SWelsSvcCodingParam));
     sConfig.eSpsPpsIdStrategy = eNewStrategy;
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO, " CWelsH264SVCEncoder::SetOption eSpsPpsIdStrategy = %d ",
              sConfig.eSpsPpsIdStrategy);

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,6 @@ cpu_family = host_machine.cpu_family()
 
 supported_arguments = cpp.get_supported_arguments([
   '-Wno-non-virtual-dtor',
-  '-Wno-class-memaccess',
   '-Werror',
   '-Wunused-but-set-variable',
   '-Wno-strict-aliasing'])


### PR DESCRIPTION
This was previously silenced by passing -Wno-class-memaccess, to the compiler, if it was supported (for GCC, it was supported since GCC 8).

Clang supports a similar option, -Wno-nontrivial-memaccess since Clang 8. It didn't use to warn about these cases, but since Clang 20, it also warns about this.

Simplify handling the issue by just adding void casts, to avoid needing to check for whether the options for silencing the warnings are supported.

This silences these warnings when building with Clang 20.