### PR TITLE
Do not use -Werror

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,6 @@ cpu_family = host_machine.cpu_family()
 
 supported_arguments = cpp.get_supported_arguments([
   '-Wno-non-virtual-dtor',
-  '-Werror',
   '-Wunused-but-set-variable',
   '-Wno-strict-aliasing'])
 


### PR DESCRIPTION
Using `-Werror` can cause builds to fail when using unexpected compilers.

For example: https://trac.macports.org/ticket/71354

By all means, manually add `-Werror` to your CI if you want to ensure warning-free builds using compilers you're testing, but don't force it on your users and make their builds fail just because they're using a compiler that has a warning you didn't anticipate.