### PR TITLE
Allow calculating PSNR for Y/U/V components

### DIFF
--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -592,6 +592,9 @@ typedef struct TagEncParamExt {
   bool    bIsLosslessLink;             ///< LTR advanced setting
   bool    bFixRCOverShoot;             ///< fix rate control overshooting
   int     iIdrBitrateRatio;            ///< the target bits of IDR is (idr_bitrate_ratio/100) * average target bit per frame.
+  bool    bPsnrY;                      ///< get Y PSNR stats for the whole video sequence
+  bool    bPsnrU;                      ///< get U PSNR stats for the whole video sequence
+  bool    bPsnrV;                      ///< get V PSNR stats for the whole video sequence
 } SEncParamExt;
 
 /**
@@ -635,6 +638,7 @@ typedef struct {
   int   iNalCount;              ///< count number of NAL coded already
   int*  pNalLengthInByte;       ///< length of NAL size in byte from 0 to iNalCount-1
   unsigned char*  pBsBuf;       ///< buffer of bitstream contained
+  float rPsnr[3];               ///< PSNR values for Y/U/V
 } SLayerBSInfo, *PLayerBSInfo;
 
 /**
@@ -659,7 +663,11 @@ typedef struct Source_Picture_s {
   int       iPicWidth;             ///< luma picture width in x coordinate
   int       iPicHeight;            ///< luma picture height in y coordinate
   long long uiTimeStamp;           ///< timestamp of the source picture, unit: millisecond
+  bool      bPsnrY;                ///< get Y PSNR for this frame
+  bool      bPsnrU;                ///< get U PSNR for this frame
+  bool      bPsnrV;                ///< get V PSNR for this frame
 } SSourcePicture;
+
 /**
 * @brief Structure for bit rate info
 */

--- a/codec/encoder/core/inc/as264_common.h
+++ b/codec/encoder/core/inc/as264_common.h
@@ -74,7 +74,6 @@ $(TargetPath)
 #endif//ENABLE_FRAME_DUMP
 #endif//__UNITTEST__
 
-//#define ENABLE_PSNR_CALC
 //#define STAT_OUTPUT
 //#define MB_TYPES_CHECK
 //
@@ -87,10 +86,6 @@ $(TargetPath)
 /* macros dependencies check */
 //@if !FRAME_INFO_OUTPUT
 #if !defined(FRAME_INFO_OUTPUT)
-
-#if defined(ENABLE_PSNR_CALC)
-#undef ENABLE_PSNR_CALC
-#endif//ENABLE_PSNR_CALC
 
 //#if defined(STAT_OUTPUT)
 //#undef STAT_OUTPUT

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -180,6 +180,9 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
     param.bIsLosslessLink = false;
     param.bFixRCOverShoot = true;
     param.iIdrBitrateRatio = IDR_BITRATE_RATIO * 100;
+    param.bPsnrY = false;
+    param.bPsnrU = false;
+    param.bPsnrV = false;
     for (int32_t iLayer = 0; iLayer < MAX_SPATIAL_LAYER_NUM; iLayer++) {
       param.sSpatialLayers[iLayer].uiProfileIdc = PRO_UNKNOWN;
       param.sSpatialLayers[iLayer].uiLevelIdc = LEVEL_UNKNOWN;
@@ -345,6 +348,9 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
     bIsLosslessLink = pCodingParam.bIsLosslessLink;
     bFixRCOverShoot = pCodingParam.bFixRCOverShoot;
     iIdrBitrateRatio = pCodingParam.iIdrBitrateRatio;
+    bPsnrY = pCodingParam.bPsnrY;
+    bPsnrU = pCodingParam.bPsnrU;
+    bPsnrV = pCodingParam.bPsnrV;
     if (iUsageType == SCREEN_CONTENT_REAL_TIME && !bIsLosslessLink && bEnableLongTermReference) {
       bEnableLongTermReference = false;
     }

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2186,7 +2186,7 @@ void StatOverallEncodingExt (sWelsEncCtx* pCtx) {
 
   }
 }
-#endif
+#endif //#if defined(STAT_OUTPUT)
 
 
 int32_t GetMultipleThreadIdc (SLogContext* pLogCtx, SWelsSvcCodingParam* pCodingParam, int16_t& iSliceNum,
@@ -3956,6 +3956,19 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
              (iLayerSize << 3));
 #endif//LAYER_INFO_OUTPUT
 
+    pLayerBsInfo->rPsnr[0] = NAN;
+    pLayerBsInfo->rPsnr[1] = NAN;
+    pLayerBsInfo->rPsnr[2] = NAN;
+    if (pSrcPic->bPsnrY) {
+      pLayerBsInfo->rPsnr[0] = fSnrY;
+    }
+    if (pSrcPic->bPsnrU) {
+      pLayerBsInfo->rPsnr[1] = fSnrU;
+    }
+    if (pSrcPic->bPsnrV) {
+      pLayerBsInfo->rPsnr[2] = fSnrV;
+    }
+
 #if defined(STAT_OUTPUT)
 
     {
@@ -3968,18 +3981,6 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
       if (pSvcParam->bPsnrV) {
         pCtx->sStatData[iCurDid][0].sQualityStat.rVPsnr[pCtx->eSliceType] += fSnrV;
       }
-    }
-    pLayerBsInfo->rPsnr[0] = NAN;
-    pLayerBsInfo->rPsnr[1] = NAN;
-    pLayerBsInfo->rPsnr[2] = NAN;
-    if (pSrcPic->bPsnrY) {
-      pLayerBsInfo->rPsnr[0] = fSnrY;
-    }
-    if (pSrcPic->bPsnrU) {
-      pLayerBsInfo->rPsnr[1] = fSnrU;
-    }
-    if (pSrcPic->bPsnrV) {
-      pLayerBsInfo->rPsnr[2] = fSnrV;
     }
 
 #if defined(MB_TYPES_CHECK) //091025, frame output


### PR DESCRIPTION
by requesting this either as a option for all frames in
  SEncParamExt.bPsnrY (and U/V)
or per-frame using
  SSourcePicture.bPsnrY (and U/V)

The resulting data goes into
  SLayerBSInfo.rPsnr
with is a three-element array for the Y/U/V components of the PSNR.

This is disabled by default. Also removes the ENABLE_PSNR_CALC preprocessor define in favor of the API.

See
  https://www.researchgate.net/publication/383545049_Low-Complexity_Video_PSNR_Measurement_in_Real-Time_Communication_Products
by @YCSun-Meta for a research paper explaining the background.