### PR TITLE
meson.build: Enable PIC in x86 assembly code

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,7 @@ if ['linux', 'android', 'ios', 'darwin'].contains(system)
   endif
   if cpu_family == 'x86'
     asm_format = asm_format32
-    asm_args += ['-DX86_32', '-DHAVE_AVX2']
+    asm_args += ['-DX86_32', '-DX86_32_PICASM', '-DHAVE_AVX2']
     add_project_arguments('-DHAVE_AVX2', language: 'cpp')
     add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: 'c')
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')


### PR DESCRIPTION
This is needed especially when using asm code and  nasm assembler to compile it.

Fixes build errors e.g.

```text
i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/satd_sad.o)
>>> referenced by ../git/codec/common/x86/satd_sad.asm
>>>               libcommon.a.p/satd_sad.o:(.text+0x1CB8) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_chroma.o)
>>> referenced by ../git/codec/common/x86/mc_chroma.asm
>>>               libcommon.a.p/mc_chroma.o:(.text+0x7D) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_luma.o)
>>> referenced by ../git/codec/common/x86/mc_luma.asm
>>>               libcommon.a.p/mc_luma.o:(.text+0x1F) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/processing/libprocessing.a(libprocessing.a.p/denoisefilter.o)
>>> referenced by ../git/codec/processing/src/x86/denoisefilter.asm
>>>               libprocessing.a.p/denoisefilter.o:(.text+0x1B) in archive codec/processing/libprocessing.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/processing/libprocessing.a(libprocessing.a.p/denoisefilter.o)
>>> referenced by ../git/codec/processing/src/x86/denoisefilter.asm
>>>               libprocessing.a.p/denoisefilter.o:(.text+0x345) in archive codec/processing/libprocessing.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/processing/libprocessing.a(libprocessing.a.p/downsample_bilinear.o)
>>> referenced by ../git/codec/processing/src/x86/downsample_bilinear.asm
>>>               libprocessing.a.p/downsample_bilinear.o:(.text+0x70A) in archive codec/processing/libprocessing.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/satd_sad.o)
>>> referenced by ../git/codec/common/x86/satd_sad.asm
>>>               libcommon.a.p/satd_sad.o:(.text+0x1CC0) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_chroma.o)
>>> referenced by ../git/codec/common/x86/mc_chroma.asm
>>>               libcommon.a.p/mc_chroma.o:(.text+0x150) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_chroma.o)
>>> referenced by ../git/codec/common/x86/mc_chroma.asm
>>>               libcommon.a.p/mc_chroma.o:(.text+0x1BF) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/deblock.o)
>>> referenced by ../git/codec/common/x86/deblock.asm
>>>               libcommon.a.p/deblock.o:(.text+0x2A) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/dct.o)
>>> referenced by ../git/codec/common/x86/dct.asm
>>>               libcommon.a.p/dct.o:(.text+0x337) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/encoder/libencoder.a(libencoder.a.p/score.o)
>>> referenced by ../git/codec/encoder/core/x86/score.asm
>>>               libencoder.a.p/score.o:(.text+0x8A) in archive codec/encoder/libencoder.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/processing/libprocessing.a(libprocessing.a.p/downsample_bilinear.o)
>>> referenced by ../git/codec/processing/src/x86/downsample_bilinear.asm
>>>               libprocessing.a.p/downsample_bilinear.o:(.text+0x712) in archive codec/processing/libprocessing.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/dct.o)
>>> referenced by ../git/codec/common/x86/dct.asm
>>>               libcommon.a.p/dct.o:(.text+0x34D) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/satd_sad.o)
>>> referenced by ../git/codec/common/x86/satd_sad.asm
>>>               libcommon.a.p/satd_sad.o:(.text+0x1CC8) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/dct.o)
>>> referenced by ../git/codec/common/x86/dct.asm
>>>               libcommon.a.p/dct.o:(.text+0x355) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_luma.o)
>>> referenced by ../git/codec/common/x86/mc_luma.asm
>>>               libcommon.a.p/mc_luma.o:(.text+0x131) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/dct.o)
>>> referenced by ../git/codec/common/x86/dct.asm
>>>               libcommon.a.p/dct.o:(.text+0x366) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/mc_luma.o)
>>> referenced by ../git/codec/common/x86/mc_luma.asm
>>>               libcommon.a.p/mc_luma.o:(.text+0x1D1) in archive codec/common/libcommon.a

i686-yoe-linux-ld.lld: error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in codec/common/libcommon.a(libcommon.a.p/dct.o)
>>> referenced by ../git/codec/common/x86/dct.asm
>>>               libcommon.a.p/dct.o:(.text+0x37C) in archive codec/common/libcommon.a

```