### PR TITLE
psnr: do not use NAN, initialize to 0

### DIFF
--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3956,9 +3956,9 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
              (iLayerSize << 3));
 #endif//LAYER_INFO_OUTPUT
 
-    pLayerBsInfo->rPsnr[0] = NAN;
-    pLayerBsInfo->rPsnr[1] = NAN;
-    pLayerBsInfo->rPsnr[2] = NAN;
+    pLayerBsInfo->rPsnr[0] = 0;
+    pLayerBsInfo->rPsnr[1] = 0;
+    pLayerBsInfo->rPsnr[2] = 0;
     if (pSrcPic->bPsnrY) {
       pLayerBsInfo->rPsnr[0] = fSnrY;
     }


### PR DESCRIPTION
which is not supported in some older compilers as pointed out in #3824 Applications should always check whether they requested calculating PSNR before evaluating that field in the result.