### PR TITLE
meson.build: Add FreeBSD to common posix platforms

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ cpp_lib = '-lstdc++'
 libm_dep = cpp.find_library('m', required : false)
 deps += [libm_dep]
 
-if ['linux', 'android', 'ios', 'darwin'].contains(system)
+if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
   asm_format32 = 'elf'
   asm_format64 = 'elf64'
   if ['ios', 'darwin'].contains(system)


### PR DESCRIPTION
This was all it took for me to build this project from source on FreeBSD 14.1.