### PR TITLE
meson.build Add missing AVX2 flags for windows, Add missing ASM flags for cpp language.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,12 +115,16 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
 elif system == 'windows'
   if cpu_family == 'x86'
     asm_format = 'win32'
-    asm_args += ['-DPREFIX', '-DX86_32']
+    asm_args += ['-DPREFIX', '-DX86_32', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
+    add_project_arguments('-DX86_ASM', language: 'cpp')
+    add_project_arguments('-DX86_ASM', language: 'c')
   elif cpu_family == 'x86_64'
     asm_format = 'win64'
-    asm_args += ['-DWIN64']
+    asm_args += ['-DWIN64', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
+    add_project_arguments('-DX86_ASM', language: 'cpp')
+    add_project_arguments('-DX86_ASM', language: 'c')
   elif cpu_family == 'arm'
     if cpp.get_argument_syntax() == 'msvc'
       asm_format = 'armasm'

--- a/meson.build
+++ b/meson.build
@@ -67,13 +67,13 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
   if cpu_family == 'x86'
     asm_format = asm_format32
     asm_args += ['-DX86_32', '-DX86_32_PICASM', '-DHAVE_AVX2']
-    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: 'cpp')
     add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: 'c')
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'x86_64'
     asm_format = asm_format64
     asm_args += ['-DUNIX64', '-DHAVE_AVX2']
-    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM',  language: 'cpp')
     add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', language: 'c')
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'arm'
@@ -117,14 +117,14 @@ elif system == 'windows'
     asm_format = 'win32'
     asm_args += ['-DPREFIX', '-DX86_32', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
-    add_project_arguments('-DX86_ASM', language: 'cpp')
-    add_project_arguments('-DX86_ASM', language: 'c')
+    add_project_arguments('-DX86_ASM', '-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DX86_ASM', '-DHAVE_AVX2', language: 'c')
   elif cpu_family == 'x86_64'
     asm_format = 'win64'
     asm_args += ['-DWIN64', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
-    add_project_arguments('-DX86_ASM', language: 'cpp')
-    add_project_arguments('-DX86_ASM', language: 'c')
+    add_project_arguments('-DX86_ASM', '-DHAVE_AVX2', language: 'cpp')
+    add_project_arguments('-DX86_ASM', '-DHAVE_AVX2', language: 'c')
   elif cpu_family == 'arm'
     if cpp.get_argument_syntax() == 'msvc'
       asm_format = 'armasm'


### PR DESCRIPTION
Handling AVX2 flags for windows is already covered in following PR. https://github.com/cisco/openh264/pull/3881/files. Additionally X86_ASM flag is missing.
Main reason for low performance on linux was a missing X86_ASM flag for cpp language which prevented from recognizing the CPU features.