### PR TITLE
Enable access to reconstructed picture output in the encoder

### DIFF
--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -642,18 +642,6 @@ typedef struct {
 } SLayerBSInfo, *PLayerBSInfo;
 
 /**
-* @brief Frame bit stream info
-*/
-typedef struct {
-  int           iLayerNum;
-  SLayerBSInfo  sLayerInfo[MAX_LAYER_NUM_OF_FRAME];
-
-  EVideoFrameType eFrameType;
-  int iFrameSizeInBytes;
-  long long uiTimeStamp;
-} SFrameBSInfo, *PFrameBSInfo;
-
-/**
 *  @brief Structure for source picture
 */
 typedef struct Source_Picture_s {
@@ -667,6 +655,25 @@ typedef struct Source_Picture_s {
   bool      bPsnrU;                ///< get U PSNR for this frame
   bool      bPsnrV;                ///< get V PSNR for this frame
 } SSourcePicture;
+
+/**
+*  @brief Structure for reconstructed picture
+*/
+typedef SSourcePicture SReconPicture;
+
+/**
+* @brief Frame bit stream info
+*/
+typedef struct {
+  int           iLayerNum;
+  SLayerBSInfo  sLayerInfo[MAX_LAYER_NUM_OF_FRAME];
+
+  EVideoFrameType eFrameType;
+  int iFrameSizeInBytes;
+  long long uiTimeStamp;
+  SReconPicture *pReconPic;        ///< pointer to the reconstructed picture
+  bool bHaveRecon;                 ///< whether have reconstructed picture data
+} SFrameBSInfo, *PFrameBSInfo;
 
 /**
 * @brief Structure for bit rate info


### PR DESCRIPTION
Access to the reconstructed frame from the H.264 encoder is useful in scenarios where the application layer needs to perform further processing or analysis on the encoded video. By exposing the reconstructed picture, the encoder facilitates integration with advanced video processing workflows and enables more flexible application-level control.