### PR TITLE
meson.build: fix missing ASM flags for cpp on Linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,14 +67,12 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
   if cpu_family == 'x86'
     asm_format = asm_format32
     asm_args += ['-DX86_32', '-DX86_32_PICASM', '-DHAVE_AVX2']
-    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
-    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: 'c')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: ['c', 'cpp'])
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'x86_64'
     asm_format = asm_format64
     asm_args += ['-DUNIX64', '-DHAVE_AVX2']
-    add_project_arguments('-DHAVE_AVX2', language: 'cpp')
-    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', language: 'c')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM',  language: ['c', 'cpp'])
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
   elif cpu_family == 'arm'
     asm_format = asm_format32


### PR DESCRIPTION
Add missing ASM flags for cpp compiler to enable CPU feature detection. Otherwise, AVX2 extensions are not used.