### PR TITLE
meson.build: Enable AVX2 Instruction on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,12 +115,14 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
 elif system == 'windows'
   if cpu_family == 'x86'
     asm_format = 'win32'
-    asm_args += ['-DPREFIX', '-DX86_32']
+    asm_args += ['-DPREFIX', '-DX86_32', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', '-DX86_32_ASM', language: ['c', 'cpp'])
   elif cpu_family == 'x86_64'
     asm_format = 'win64'
-    asm_args += ['-DWIN64']
+    asm_args += ['-DWIN64', '-DHAVE_AVX2']
     asm_inc = join_paths(meson.current_source_dir(), 'codec', 'common', 'x86', '')
+    add_project_arguments('-DHAVE_AVX2', '-DX86_ASM', language: ['c', 'cpp'])
   elif cpu_family == 'arm'
     if cpp.get_argument_syntax() == 'msvc'
       asm_format = 'armasm'


### PR DESCRIPTION
Add necessary flags for Windows build to enable AVX2 instructions.