### PR TITLE
Update windows/mingw CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       - run: ./codec_unittest
 
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
       - run: choco install nasm
@@ -54,7 +54,7 @@ jobs:
       - run: ./bin/Win32/Release/codec_unittest.exe
 
   mingw:
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
Actions has deprecated the windows 2019 build.