### PR TITLE
Android x86 - ENABLEPIC flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ ABIs, add `ARCH=arm64`, `ARCH=x86`, `ARCH=x86_64`, `ARCH=mips` or `ARCH=mips64`.
 To build for the older `armeabi` ABI (which has armv5te as baseline), add `APP_ABI=armeabi` (`ARCH=arm` is implicit).
 To build for 64-bit ABI, such as `arm64`, explicitly set `NDKLEVEL` to 21 or higher.
 
+For `x86` specific builds additionally set make flag: `ENABLEPIC=Yes`.
+
 For iOS Builds
 --------------
 You can build the libraries and demo applications using xcode project files


### PR DESCRIPTION
Add information to add `ENABLEPIC` flag for `x86` Android builds.
Without it, `x86` builds are failing and there is no clear information how to resolve it, having to browse old release notes and threads.
Ref: https://github.com/cisco/openh264/issues/2263