### PR TITLE
Improve support for CYGWIN

### DIFF
--- a/codec/decoder/core/src/wels_decoder_thread.cpp
+++ b/codec/decoder/core/src/wels_decoder_thread.cpp
@@ -115,7 +115,10 @@ int SemWait (SWelsDecSemphore* s, int32_t timeout) {
 }
 
 void SemRelease (SWelsDecSemphore* s, long* prevcount) {
-  ReleaseSemaphore (s->h, 1, prevcount);
+  LONG _prevcount;
+
+  ReleaseSemaphore (s->h, 1, &_prevcount);
+  *prevcount = _prevcount;
 }
 
 void SemDestroy (SWelsDecSemphore* s) {

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -90,7 +90,7 @@ namespace WelsDec {
 ***************************************************************************/
 DECLARE_PROCTHREAD (pThrProcInit, p) {
   SWelsDecThreadInfo* sThreadInfo = (SWelsDecThreadInfo*)p;
-#if defined(WIN32)
+#if defined(WIN32) && !defined(__CYGWIN__)
   _alloca (WELS_DEC_MAX_THREAD_STACK_SIZE * (sThreadInfo->uiThrNum + 1));
 #endif
   return sThreadInfo->pThrProcMain (p);

--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -90,7 +90,7 @@ namespace WelsDec {
 ***************************************************************************/
 DECLARE_PROCTHREAD (pThrProcInit, p) {
   SWelsDecThreadInfo* sThreadInfo = (SWelsDecThreadInfo*)p;
-#if defined(WIN32)
+#if defined(_WIN32)
   _alloca (WELS_DEC_MAX_THREAD_STACK_SIZE * (sThreadInfo->uiThrNum + 1));
 #endif
   return sThreadInfo->pThrProcMain (p);

--- a/meson.build
+++ b/meson.build
@@ -112,7 +112,7 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
   if ['ios', 'darwin', 'android'].contains(system)
     cpp_lib = '-lc++'
   endif
-elif system == 'windows'
+elif ['windows', 'cygwin'].contains(system)
   if cpu_family == 'x86'
     asm_format = 'win32'
     asm_args += ['-DPREFIX', '-DX86_32']


### PR DESCRIPTION
I tried to build openh264 on CYGWIN but I got few errors that can be fixed quite easily, hopefully.

1)
The platform "cygwin" is not recognized by the script for Meson and this message is printed on the console.
```
meson.build:143:2: ERROR: Problem encountered: FIXME: Unhandled system cygwin

A full log can be found at meson-logs/meson-log.txt
```
However, CYGWIN can be handled by adding its name in the same path where MinGW is also handled.

2)
Later, this error appears on the console:
```
openh264/codec/decoder/plus/src/welsDecoderExt.cpp: In function ‘DWORD WelsDec::pThrProcInit(LPVOID)’:
openh264/codec/decoder/plus/src/welsDecoderExt.cpp:94:3: error: ‘_alloca’ was not declared in this scope; did you mean ‘alloca’?
   94 |   _alloca (WELS_DEC_MAX_THREAD_STACK_SIZE * (sThreadInfo->uiThrNum + 1));
      |   ^~~~~~~
      |   alloca
```
Similar to other POSIX platforms, CYGWIN supports `alloca()` rather than `_alloca()`, so this function needs to be used for reserving stack space.

3)
Finally, this last error happens:
```
openh264/codec/decoder/core/src/wels_decoder_thread.cpp: In function ‘void SemRelease(SWelsDecSemphore*, long int*)’:
openh264/codec/decoder/core/src/wels_decoder_thread.cpp:118:30: error: cannot convert ‘long int*’ to ‘LPLONG’ {aka ‘int*’}
  118 |   ReleaseSemaphore (s->h, 1, prevcount);
      |                              ^~~~~~~~~
      |                              |
      |                              long int*
```
On x86_64 and aarch64 ports, `long` has a size of 8 byte, while `LONG` is still 4 bytes even when `_WIN64` is defined with Windows APIs.
This can be fixed by using a local parameter declared as `LONG` and, in my opinion, it would be worth to do it also for traditional `_WIN32` platforms for a clear type matching.

I hope that you will find these tiny patches useful.