### PR TITLE
expose timing info VUI parameters

### DIFF
--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -479,6 +479,10 @@ typedef struct {
   unsigned char
   uiColorMatrix;        // EColorMatrix; 8 bits in header (corresponds to FFmpeg "colorspace"); 0 - 10 => GBR, bt709,
   //   undef, ???, fcc, bt470bg, smpte170m, smpte240m, YCgCo, bt2020nc, bt2020c
+  bool bTimingInfoPresentFlag; // false => do not write any of the following three items to the header
+  unsigned uiNumUnitsInTick;   // clock tick time units: e.g. 1001 for a frame rate of 29.97 (30 000 ÷ 1001 Hz)
+  unsigned uiTimeScale;        // clock tick time scale: e.g. 60 000 for a frame rate of 29.97 (30 000 ÷ 1001 Hz)
+  bool bFixedFrameRateFlag;    // true => temporal distance between consecutive pictures in output order is constrained
 
   bool bAspectRatioPresent; ///< aspect ratio present in VUI
   ESampleAspectRatio eAspectRatio; ///< aspect ratio idc

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -204,7 +204,7 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
       for (int32_t idx = 0; idx < kiLesserSliceNum; idx++)
         param.sSpatialLayers[iLayer].sSliceArgument.uiSliceMbNum[idx] = 0; //default, using one row a slice if uiSliceMode is SM_RASTER_MODE
 
-      // See codec_app_def.h for more info about members bVideoSignalTypePresent through uiColorMatrix.  The default values
+      // See codec_app_def.h for more info about members bVideoSignalTypePresent through bFixedFrameRateFlag.  The default values
       // used below preserve the previous behavior; i.e., no additional information will be written to the output file.
       param.sSpatialLayers[iLayer].bVideoSignalTypePresent = false;			// do not write any of the following information to the header
       param.sSpatialLayers[iLayer].uiVideoFormat = VF_UNDEF;				// undefined
@@ -213,6 +213,10 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
       param.sSpatialLayers[iLayer].uiColorPrimaries = CP_UNDEF;				// undefined
       param.sSpatialLayers[iLayer].uiTransferCharacteristics = TRC_UNDEF;	// undefined
       param.sSpatialLayers[iLayer].uiColorMatrix = CM_UNDEF;				// undefined
+      param.sSpatialLayers[iLayer].bTimingInfoPresentFlag = false;	    	// do not write any of the following three items to the header
+      param.sSpatialLayers[iLayer].uiNumUnitsInTick = 1;				    // not set
+      param.sSpatialLayers[iLayer].uiTimeScale = 0;	                        // not set
+      param.sSpatialLayers[iLayer].bFixedFrameRateFlag = false;				// not set
     }
   }
 
@@ -450,7 +454,7 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
 
       pSpatialLayer->iDLayerQp = pCodingParam.sSpatialLayers[iIdxSpatial].iDLayerQp;
 
-      // See codec_app_def.h and parameter_sets.h for more info about members bVideoSignalTypePresent through uiColorMatrix.
+      // See codec_app_def.h and parameter_sets.h for more info about members bVideoSignalTypePresent through bFixedFrameRateFlag.
       pSpatialLayer->bVideoSignalTypePresent =   pCodingParam.sSpatialLayers[iIdxSpatial].bVideoSignalTypePresent;
       pSpatialLayer->uiVideoFormat =             pCodingParam.sSpatialLayers[iIdxSpatial].uiVideoFormat;
       pSpatialLayer->bFullRange =                pCodingParam.sSpatialLayers[iIdxSpatial].bFullRange;
@@ -458,6 +462,10 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
       pSpatialLayer->uiColorPrimaries =          pCodingParam.sSpatialLayers[iIdxSpatial].uiColorPrimaries;
       pSpatialLayer->uiTransferCharacteristics = pCodingParam.sSpatialLayers[iIdxSpatial].uiTransferCharacteristics;
       pSpatialLayer->uiColorMatrix =             pCodingParam.sSpatialLayers[iIdxSpatial].uiColorMatrix;
+      pSpatialLayer->bTimingInfoPresentFlag =    pCodingParam.sSpatialLayers[iIdxSpatial].bTimingInfoPresentFlag;
+      pSpatialLayer->uiNumUnitsInTick =          pCodingParam.sSpatialLayers[iIdxSpatial].uiNumUnitsInTick;
+      pSpatialLayer->uiTimeScale =               pCodingParam.sSpatialLayers[iIdxSpatial].uiTimeScale;
+      pSpatialLayer->bFixedFrameRateFlag =       pCodingParam.sSpatialLayers[iIdxSpatial].bFixedFrameRateFlag;
 
       pSpatialLayer->bAspectRatioPresent = pCodingParam.sSpatialLayers[iIdxSpatial].bAspectRatioPresent;
       pSpatialLayer->eAspectRatio = pCodingParam.sSpatialLayers[iIdxSpatial].eAspectRatio;

--- a/codec/encoder/core/inc/parameter_sets.h
+++ b/codec/encoder/core/inc/parameter_sets.h
@@ -56,8 +56,6 @@ int32_t         iLog2MaxPocLsb;
 // int8_t          iOffsetForRefFrame[256];
 SCropOffset     sFrameCrop;
 int16_t         iNumRefFrames;
-// uint32_t        uiNumUnitsInTick;
-// uint32_t        uiTimeScale;
 
 uint8_t         uiProfileIdc;
 uint8_t         iLevelIdc;
@@ -76,21 +74,23 @@ bool            bGapsInFrameNumValueAllowedFlag;
 bool            bFrameCroppingFlag;
 
 bool            bVuiParamPresentFlag;
-// bool            bTimingInfoPresentFlag;
-// bool            bFixedFrameRateFlag;
 
-// Note: members bVideoSignalTypePresent through uiColorMatrix below are also defined in SSpatialLayerConfig in codec_app_def.h,
+// Note: members bVideoSignalTypePresent through bFixedFrameRateFlag below are also defined in SSpatialLayerConfig in codec_app_def.h,
 // along with definitions for enumerators EVideoFormatSPS, EColorPrimaries, ETransferCharacteristics, and EColorMatrix.
-bool	bVideoSignalTypePresent;	// false => do not write any of the following information to the header
-uint8_t	uiVideoFormat;				// EVideoFormatSPS; 3 bits in header; 0-5 => component, kpal, ntsc, secam, mac, undef
-bool	bFullRange;					// false => analog video data range [16, 235]; true => full data range [0,255]
-bool	bColorDescriptionPresent;	// false => do not write any of the following three items to the header
-uint8_t	uiColorPrimaries;			// EColorPrimaries; 8 bits in header; 0 - 9 => ???, bt709, undef, ???, bt470m, bt470bg,
+bool	 bVideoSignalTypePresent;	// false => do not write any of the following information to the header
+uint8_t	 uiVideoFormat;				// EVideoFormatSPS; 3 bits in header; 0-5 => component, kpal, ntsc, secam, mac, undef
+bool	 bFullRange;				// false => analog video data range [16, 235]; true => full data range [0,255]
+bool	 bColorDescriptionPresent;	// false => do not write any of the following three items to the header
+uint8_t	 uiColorPrimaries;			// EColorPrimaries; 8 bits in header; 0 - 9 => ???, bt709, undef, ???, bt470m, bt470bg,
                                     //    smpte170m, smpte240m, film, bt2020
-uint8_t	uiTransferCharacteristics;	// ETransferCharacteristics; 8 bits in header; 0 - 15 => ???, bt709, undef, ???, bt470m, bt470bg, smpte170m,
+uint8_t	 uiTransferCharacteristics;	// ETransferCharacteristics; 8 bits in header; 0 - 15 => ???, bt709, undef, ???, bt470m, bt470bg, smpte170m,
                                     //   smpte240m, linear, log100, log316, iec61966-2-4, bt1361e, iec61966-2-1, bt2020-10, bt2020-12
-uint8_t	uiColorMatrix;				// EColorMatrix; 8 bits in header (corresponds to FFmpeg "colorspace"); 0 - 10 => GBR, bt709,
+uint8_t	 uiColorMatrix;				// EColorMatrix; 8 bits in header (corresponds to FFmpeg "colorspace"); 0 - 10 => GBR, bt709,
                                     //   undef, ???, fcc, bt470bg, smpte170m, smpte240m, YCgCo, bt2020nc, bt2020c
+bool     bTimingInfoPresentFlag;    // false => do not write any of the following three items to the header
+uint32_t uiNumUnitsInTick;          // clock tick time units: e.g. 1001 for a frame rate of 29.97 (30 000 ÷ 1001 Hz)
+uint32_t uiTimeScale;               // clock tick time scale: e.g. 60 000 for a frame rate of 29.97 (30 000 ÷ 1001 Hz)
+bool     bFixedFrameRateFlag;       // true => temporal distance between consecutive pictures in output order is constrained
 
 bool            bConstraintSet0Flag;
 bool            bConstraintSet1Flag;

--- a/codec/encoder/core/src/au_set.cpp
+++ b/codec/encoder/core/src/au_set.cpp
@@ -229,7 +229,16 @@ int32_t WelsWriteVUI (SWelsSPS* pSps, SBitStringAux* pBitStringAux) {
   }//write video signal type info to header
 
   BsWriteOneBit (pLocalBitStringAux, false); //chroma_loc_info_present_flag
-  BsWriteOneBit (pLocalBitStringAux, false); //timing_info_present_flag
+
+  BsWriteOneBit (pLocalBitStringAux, pSps->bTimingInfoPresentFlag); //timing_info_present_flag
+  if (pSps->bTimingInfoPresentFlag) {
+    //write timing info to header
+
+    BsWriteBits (pLocalBitStringAux, 32, pSps->uiNumUnitsInTick);
+    BsWriteBits (pLocalBitStringAux, 32, pSps->uiTimeScale);
+    BsWriteOneBit (pLocalBitStringAux, pSps->bFixedFrameRateFlag);
+  }//write timing info to header
+
   BsWriteOneBit (pLocalBitStringAux, false); //nal_hrd_parameters_present_flag
   BsWriteOneBit (pLocalBitStringAux, false); //vcl_hrd_parameters_present_flag
   BsWriteOneBit (pLocalBitStringAux, false); //pic_struct_present_flag
@@ -558,6 +567,10 @@ int32_t WelsInitSps (SWelsSPS* pSps, SSpatialLayerConfig* pLayerParam, SSpatialL
   pSps->uiColorPrimaries =          pLayerParam->uiColorPrimaries;
   pSps->uiTransferCharacteristics = pLayerParam->uiTransferCharacteristics;
   pSps->uiColorMatrix =             pLayerParam->uiColorMatrix;
+  pSps->bTimingInfoPresentFlag =    pLayerParam->bTimingInfoPresentFlag;
+  pSps->uiNumUnitsInTick =          pLayerParam->uiNumUnitsInTick;
+  pSps->uiTimeScale =               pLayerParam->uiTimeScale;
+  pSps->bFixedFrameRateFlag =       pLayerParam->bFixedFrameRateFlag;
 
   return 0;
 }


### PR DESCRIPTION
Allow the timing info fields in the VUI to be set via encoder parameters, defaults to not set