### PR TITLE
Add AVX2 intra prediction for 16x16 luma and 8x8 chroma

### DIFF
--- a/codec/common/inc/intra_pred_common.h
+++ b/codec/common/inc/intra_pred_common.h
@@ -1,6 +1,7 @@
 /*!
  * \copy
  *     Copyright (c)  2009-2013, Cisco Systems
+ *     Copyright (c)  2026, Richard Ben Aleya
  *     All rights reserved.
  *
  *     Redistribution and use in source and binary forms, with or without
@@ -56,6 +57,10 @@ extern "C" {
 //for intra-prediction ASM functions
 void WelsI16x16LumaPredV_sse2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
 void WelsI16x16LumaPredH_sse2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+#if defined(HAVE_AVX2)
+void WelsI16x16LumaPredV_avx2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+void WelsI16x16LumaPredH_avx2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+#endif//HAVE_AVX2
 #endif//X86_ASM
 
 #if defined(HAVE_NEON)

--- a/codec/common/x86/intra_pred_com.asm
+++ b/codec/common/x86/intra_pred_com.asm
@@ -1,6 +1,7 @@
 ;*!
 ;* \copy
 ;*     Copyright (c)  2009-2013, Cisco Systems
+;*     Copyright (c)  2026, Richard Ben Aleya
 ;*     All rights reserved.
 ;*
 ;*     Redistribution and use in source and binary forms, with or without
@@ -114,4 +115,47 @@ WELS_EXTERN WelsI16x16LumaPredV_sse2
     movdqa  [r0+240], xmm0
 
     ret
+
+%ifdef HAVE_AVX2
+;***********************************************************************
+; void WelsI16x16LumaPredV_avx2(uint8_t *pred, uint8_t *pRef, int32_t stride);
+;***********************************************************************
+WELS_EXTERN WelsI16x16LumaPredV_avx2
+    %assign push_num 0
+    LOAD_3_PARA
+    SIGN_EXTENSION r2, r2d
+    sub     r1, r2
+    vbroadcasti128 ymm0, [r1]
+    vmovdqu [r0],      ymm0
+    vmovdqu [r0+32],   ymm0
+    vmovdqu [r0+64],   ymm0
+    vmovdqu [r0+96],   ymm0
+    vmovdqu [r0+128],  ymm0
+    vmovdqu [r0+160],  ymm0
+    vmovdqu [r0+192],  ymm0
+    vmovdqu [r0+224],  ymm0
+    vzeroupper
+    ret
+
+;***********************************************************************
+; void WelsI16x16LumaPredH_avx2(uint8_t *pred, uint8_t *pRef, int32_t stride);
+;***********************************************************************
+WELS_EXTERN WelsI16x16LumaPredH_avx2
+    %assign push_num 0
+    LOAD_3_PARA
+    SIGN_EXTENSION r2, r2d
+    dec r1
+    %assign h_row 0
+    %rep 16
+        %if h_row > 0
+        add     r1, r2
+        %endif
+        vpbroadcastb xmm0, [r1]
+        vmovdqa [r0 + h_row * 16], xmm0
+        %assign h_row h_row + 1
+    %endrep
+    vzeroupper
+    ret
+
+%endif ; HAVE_AVX2
 

--- a/codec/encoder/core/inc/get_intra_predictor.h
+++ b/codec/encoder/core/inc/get_intra_predictor.h
@@ -1,6 +1,7 @@
 /*!
  * \copy
  *     Copyright (c)  2009-2013, Cisco Systems
+ *     Copyright (c)  2026, Richard Ben Aleya
  *     All rights reserved.
  *
  *     Redistribution and use in source and binary forms, with or without
@@ -109,6 +110,12 @@ void WelsI4x4LumaPredVR_mmx (uint8_t* pPred, uint8_t* pRef, const int32_t kiStri
 void WelsI4x4LumaPredHD_mmx (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
 void WelsI4x4LumaPredVL_mmx (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
 void WelsI4x4LumaPredHU_mmx (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+
+#if defined(HAVE_AVX2)
+void WelsI16x16LumaPredDc_avx2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+void WelsI16x16LumaPredPlane_avx2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+void WelsIChromaPredV_avx2 (uint8_t* pPred, uint8_t* pRef, const int32_t kiStride);
+#endif//HAVE_AVX2
 #endif//X86_ASM
 
 #if defined(HAVE_NEON)

--- a/codec/encoder/core/src/get_intra_predictor.cpp
+++ b/codec/encoder/core/src/get_intra_predictor.cpp
@@ -1,6 +1,7 @@
 /*!
  * \copy
  *     Copyright (c)  2009-2013, Cisco Systems
+ *     Copyright (c)  2026, Richard Ben Aleya
  *     All rights reserved.
  *
  *     Redistribution and use in source and binary forms, with or without
@@ -719,6 +720,15 @@ void WelsInitIntraPredFuncs (SWelsFuncPtrList* pFuncList, const uint32_t kuiCpuF
     pFuncList->pfGetChromaPred[C_PRED_V]    = WelsIChromaPredV_sse2;
     pFuncList->pfGetChromaPred[C_PRED_P]    = WelsIChromaPredPlane_sse2;
   }
+#if defined(HAVE_AVX2)
+  if (kuiCpuFlag & WELS_CPU_AVX2) {
+    pFuncList->pfGetLumaI16x16Pred[I16_PRED_V]  = WelsI16x16LumaPredV_avx2;
+    pFuncList->pfGetLumaI16x16Pred[I16_PRED_H]  = WelsI16x16LumaPredH_avx2;
+    pFuncList->pfGetLumaI16x16Pred[I16_PRED_DC] = WelsI16x16LumaPredDc_avx2;
+    pFuncList->pfGetLumaI16x16Pred[I16_PRED_P]  = WelsI16x16LumaPredPlane_avx2;
+    pFuncList->pfGetChromaPred[C_PRED_V]         = WelsIChromaPredV_avx2;
+  }
+#endif//HAVE_AVX2
 #endif
 
 #if defined(HAVE_MMI)


### PR DESCRIPTION
This adds AVX2-optimized intra prediction for the four 16x16 luma modes (Vertical, Horizontal, DC, Plane) and 8x8 chroma vertical prediction.

Key improvements over the SSE2 versions:
- **V/DC**: `vbroadcasti128` / `vpbroadcastb` + 256-bit stores write two rows per operation (8 stores instead of 16)
- **H**: `vpbroadcastb xmm, [mem]` replaces a multi-instruction broadcast sequence
- **Plane**: processes all 16 pixels per row in a single pass using 256-bit arithmetic (`vpmullw` + `vpaddw` + `vpackuswb` + `vpermq`), versus two 8-pixel passes in SSE2
- **Chroma V**: `vpbroadcastq` fills the entire 64-byte block with just 2 stores

**Files changed:**
- `codec/common/x86/intra_pred_com.asm` — V, H functions (+44 lines)
- `codec/encoder/core/x86/intra_pred.asm` — DC, Plane, Chroma V (+215 lines)
- `codec/common/inc/intra_pred_common.h` — declarations (+4 lines)
- `codec/encoder/core/inc/get_intra_predictor.h` — declarations (+6 lines)
- `codec/encoder/core/src/get_intra_predictor.cpp` — registration (+9 lines)

These optimizations were developed for [Vauban](https://github.com/rbenaley/Vauban), an open-source privileged access management (PAM) bastion that uses OpenH264 for real-time H.264 encoding of RDP desktop sessions streamed to web browsers. Combined with AVX2 SAD functions, enabling full AVX2 support reduced CPU usage per session by approximately 50% on an Intel Xeon E-2246G running FreeBSD.

For a detailed technical writeup covering the encoding pipeline context, implementation choices, and performance measurements, see:
https://github.com/rbenaley/Vauban/blob/main/docs/technical/Vauban_OpenH264_AVX2_Optimizations_EN(1.0).md