### PR TITLE
meson: Fix crashes on 2k3000

### DIFF
--- a/codec/common/meson.build
+++ b/codec/common/meson.build
@@ -18,6 +18,7 @@ cpp_sources = [
 ]
 
 objs_asm = []
+libs_asm = []
 if cpu_family in ['x86', 'x86_64']
   asm_sources = [
     'x86/cpuid.asm',
@@ -59,16 +60,26 @@ elif cpu_family == 'aarch64'
     cpp_sources += asm_sources
   endif
 elif cpu_family in ['loongarch32', 'loongarch64']
-  asm_sources = [
+  lsx_sources = [
     'loongarch/copy_mb_lsx.c',
     'loongarch/deblock_lsx.c',
     'loongarch/intra_pred_com_lsx.c',
-    'loongarch/intra_pred_com_lasx.c',
     'loongarch/mc_chroma_lsx.c',
     'loongarch/mc_horver_lsx.c',
+  ]
+  lasx_sources = [
+    'loongarch/intra_pred_com_lasx.c',
     'loongarch/satd_sad_lasx.c',
   ]
-  cpp_sources += asm_sources
+  libcommon_lsx = static_library('common_lsx', lsx_sources,
+    include_directories: [inc, casm_inc],
+    dependencies: deps,
+    c_args: ['-mlsx'])
+  libcommon_lasx = static_library('common_lasx', lasx_sources,
+    include_directories: [inc, casm_inc],
+    dependencies: deps,
+    c_args: ['-mlasx'])
+  libs_asm = [libcommon_lsx, libcommon_lasx]
 elif cpu_family == 'riscv64'
   asm_sources = []
 elif cpu_family == 'ppc'
@@ -81,4 +92,5 @@ endif
 
 libcommon = static_library('common', cpp_sources, objs_asm,
   include_directories: [inc, casm_inc],
+  link_whole: libs_asm,
   dependencies: deps)

--- a/codec/encoder/meson.build
+++ b/codec/encoder/meson.build
@@ -34,6 +34,7 @@ cpp_sources = [
 ]
 
 objs_asm = []
+libs_asm = []
 if cpu_family in ['x86', 'x86_64']
   asm_sources = [
     'core/x86/coeff.asm',
@@ -75,14 +76,24 @@ elif cpu_family == 'aarch64'
     cpp_sources += asm_sources
   endif
 elif cpu_family in ['loongarch32', 'loongarch64']
-  asm_sources = [
+  lsx_sources = [
     'core/loongarch/quant_lsx.c',
     'core/loongarch/get_intra_predictor_lsx.c',
-    'core/loongarch/dct_lasx.c',
     'core/loongarch/svc_motion_estimate_lsx.c',
+  ]
+  lasx_sources = [
+    'core/loongarch/dct_lasx.c',
     'core/loongarch/sample_lasx.c',
   ]
-  cpp_sources += asm_sources
+  libencoder_lsx = static_library('encoder_lsx', lsx_sources,
+    include_directories: [inc, processing_inc, encoder_inc, casm_inc],
+    dependencies: deps,
+	c_args: '-mlsx')
+  libencoder_lasx = static_library('encoder_lasx', lasx_sources,
+    include_directories: [inc, processing_inc, encoder_inc, casm_inc],
+    dependencies: deps,
+	c_args: '-mlasx')
+  libs_asm = [libencoder_lsx, libencoder_lasx]
 elif cpu_family == 'riscv64'
   asm_sources = []
 elif cpu_family == 'ppc'
@@ -95,4 +106,5 @@ endif
 
 libencoder = static_library('encoder', cpp_sources, objs_asm,
   include_directories: [inc, processing_inc, encoder_inc, casm_inc],
+  link_whole: libs_asm,
   dependencies: deps)

--- a/codec/processing/meson.build
+++ b/codec/processing/meson.build
@@ -19,6 +19,7 @@ cpp_sources = [
 ]
 
 objs_asm = []
+libs_asm = []
 if cpu_family in ['x86', 'x86_64']
   asm_sources = [
     'src/x86/denoisefilter.asm',
@@ -51,11 +52,21 @@ elif cpu_family == 'aarch64'
     cpp_sources += asm_sources
   endif
 elif cpu_family in ['loongarch32', 'loongarch64']
-  asm_sources = [
+  lsx_sources = [
     'src/loongarch/vaa_lsx.c',
+  ]
+  lasx_sources = [
     'src/loongarch/vaa_lasx.c',
   ]
-  cpp_sources += asm_sources
+  libprocessing_lsx = static_library('processingi_lsx', lsx_sources,
+    include_directories: [inc, processing_inc, casm_inc],
+    dependencies: deps,
+	c_args: '-mlsx')
+  libprocessing_lasx = static_library('processingi_lasx', lasx_sources,
+    include_directories: [inc, processing_inc, casm_inc],
+    dependencies: deps,
+	c_args: '-mlasx')
+  libs_asm = [libprocessing_lsx, libprocessing_lasx]
 elif cpu_family == 'riscv64'
   asm_sources = []
 elif cpu_family == 'ppc'
@@ -68,4 +79,5 @@ endif
 
 libprocessing = static_library('processing', cpp_sources, objs_asm,
   include_directories: [inc, processing_inc, casm_inc],
+  link_whole: libs_asm,
   dependencies: deps)

--- a/meson.build
+++ b/meson.build
@@ -88,12 +88,12 @@ if ['linux', 'freebsd', 'android', 'ios', 'darwin'].contains(system)
     casm_inc = include_directories(join_paths('codec', 'common', 'arm64'))
   elif cpu_family == 'loongarch32'
     asm_format = asm_format32
-    add_project_arguments('-mlsx', '-DHAVE_LSX', '-mlasx', '-DHAVE_LASX', language: 'c')
+    add_project_arguments('-DHAVE_LSX', '-DHAVE_LASX', language: 'c')
     add_project_arguments('-DHAVE_LSX', '-DHAVE_LASX', language: 'cpp')
     casm_inc = include_directories(join_paths('codec', 'common', 'loongarch'))
   elif cpu_family == 'loongarch64'
     asm_format = asm_format64
-    add_project_arguments('-mlsx', '-DHAVE_LSX', '-mlasx', '-DHAVE_LASX', language: 'c')
+    add_project_arguments('-DHAVE_LSX', '-DHAVE_LASX', language: 'c')
     add_project_arguments('-DHAVE_LSX', '-DHAVE_LASX', language: 'cpp')
     casm_inc = include_directories(join_paths('codec', 'common', 'loongarch'))
   elif cpu_family == 'riscv64'


### PR DESCRIPTION
Similar to 1c5ac2f8d7fd, don't apply -mlsx or -mlasx globally. Unfortunately we cannot simply apply compiler flags to some source files in meson (see https://github.com/mesonbuild/meson/issues/1367), so we need to isolate those files into static libraries dedicated for LSX and LASX and use link_whole to put them together.