### PR TITLE
Fix SumOfFrame for extremely wide frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ endif
 
 ifeq ($(USE_ASAN), Yes)
 CFLAGS += -fsanitize=address
+CXXFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
 endif
 

--- a/codec/encoder/core/x86/sample_sc.asm
+++ b/codec/encoder/core/x86/sample_sc.asm
@@ -127,7 +127,7 @@ WIDTH_LOOP:
     psadbw  xmm2,   xmm0
     psubd   xmm1,   xmm2
     movd    eax,    xmm1
-    mov     cx,     [edi]
+    movzx   ecx,    word [edi]
     add     eax,    ecx
 
     mov     [edi+ebp*2],    ax
@@ -906,7 +906,7 @@ WIDTH_LOOP:
     psadbw  xmm2,   xmm0
     psubd   xmm1,   xmm2
     movd    r2d,    xmm1
-    mov     r6w,    [r4]
+    movzx   r6d,    word [r4]
     add     r2d,    r6d
     mov     [r4+r1*2],  r2w
     inc     dword [r5+r2*4]

--- a/test/encoder/EncUT_SVC_me.cpp
+++ b/test/encoder/EncUT_SVC_me.cpp
@@ -283,6 +283,9 @@ GENERATE_SumOfFrame (SumOf8x8BlockOfFrame_ref, SumOf8x8BlockOfFrame_sse2, 6, 320
 GENERATE_SumOfFrame (SumOf16x16BlockOfFrame_ref, SumOf16x16BlockOfFrame_sse2, 6, 320, WELS_CPU_SSE2)
 GENERATE_SumOfFrame (SumOf8x8BlockOfFrame_ref, SumOf8x8BlockOfFrame_sse2, 640, 320, WELS_CPU_SSE2)
 GENERATE_SumOfFrame (SumOf16x16BlockOfFrame_ref, SumOf16x16BlockOfFrame_sse2, 640, 320, WELS_CPU_SSE2)
+GENERATE_SumOfFrame (SumOf8x8BlockOfFrame_ref, SumOf8x8BlockOfFrame_sse2, 21840, 16, WELS_CPU_SSE2)
+GENERATE_SumOfFrame (SumOf16x16BlockOfFrame_ref, SumOf16x16BlockOfFrame_sse2, 21840, 16, WELS_CPU_SSE2)
+
 
 GENERATE_SumOfFrame (SumOf8x8BlockOfFrame_ref, SumOf8x8BlockOfFrame_sse4, 8, 2, WELS_CPU_SSE41)
 GENERATE_SumOfFrame (SumOf16x16BlockOfFrame_ref, SumOf16x16BlockOfFrame_sse4, 16, 2, WELS_CPU_SSE41)


### PR DESCRIPTION
When using very large strides (e.g. with wide resolutions like 21824x16), the value of `3 * kiRefStride` exceeds 65535 and sets the 17th bit of `r6`. 

Inside the loop, `r6w` is used to load a 16-bit value from memory. However, the 16-bit move does not clear the upper bits of `r6`, leaving the stale high bits from the stride calculation intact. This leads to incorrect index calculations when `r6` is subsequently used.

This PR resolves the issue by using `movzx` to zero-extend the 16-bit load into `r6d`, ensuring the upper bits of the register are cleared.