### PR TITLE
fix(decoder): reject DECODER_OPTION_NUM_OF_THREADS after initialization

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -489,6 +489,11 @@ long CWelsDecoder::SetOption (DECODER_OPTION eOptID, void* pOption) {
         threadCount = 3;
       }
       if (threadCount != m_iThreadCount) {
+        if (m_pDecThrCtx != NULL && m_pDecThrCtx[0].pCtx != NULL) {
+          WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR,
+                   "CWelsDecoder::SetOption(): DECODER_OPTION_NUM_OF_THREADS cannot be changed after decoder is initialized.");
+          return cmInitParaError;
+        }
         m_iThreadCount = threadCount;
         if (m_pDecThrCtx != NULL) {
           delete [] m_pDecThrCtx;

--- a/test/api/decoder_test.cpp
+++ b/test/api/decoder_test.cpp
@@ -45,6 +45,12 @@ class DecoderInitTest : public ::testing::Test, public BaseDecoderTest {
 
 TEST_F (DecoderInitTest, JustInit) {}
 
+TEST_F (DecoderInitTest, SetThreadCountPostInitFails) {
+  int iThreadCount = 2;
+  long rv = decoder_->SetOption (DECODER_OPTION_NUM_OF_THREADS, &iThreadCount);
+  EXPECT_NE (0, rv);
+}
+
 struct FileParam {
   const char* fileName;
   const char* hashStr;


### PR DESCRIPTION
Fixes #3969

When `SetOption(DECODER_OPTION_NUM_OF_THREADS)` is called after `ISVCDecoder::Initialize()`, resetting `m_pDecThrCtx` without re-creating worker threads leaves the decoder in an uninitialized thread context state, causing a deadlock in subsequent `DecodeFrameNoDelay` or `WelsDestroyDecoder` calls.

This fix returns `cmInitParaError` if `DECODER_OPTION_NUM_OF_THREADS` is set post-initialization (`m_pDecThrCtx[0].pCtx != NULL`), preventing thread context corruption.

Added unit test `DecoderInitTest.SetThreadCountPostInitFails` in `test/api/decoder_test.cpp` and verified full test suite passes.