### PR TITLE
Fix -loadbalancing parsing when used as the final option

### DIFF
--- a/codec/console/enc/src/welsenc.cpp
+++ b/codec/console/enc/src/welsenc.cpp
@@ -549,7 +549,7 @@ int ParseCommandLine (int argc, char** argv, SSourcePicture* pSrcPic, SEncParamE
 
     else if (!strcmp (pCommand, "-threadIdc") && (n < argc))
       pSvcParam.iMultipleThreadIdc = atoi (argv[n++]);
-    else if (!strcmp (pCommand, "-loadbalancing") && (n + 1 < argc)) {
+    else if (!strcmp (pCommand, "-loadbalancing") && (n < argc)) {
       pSvcParam.bUseLoadBalancing = (atoi (argv[n++])) ? true : false;
     } else if (!strcmp (pCommand, "-deblockIdc") && (n < argc))
       pSvcParam.iLoopFilterDisableIdc = atoi (argv[n++]);


### PR DESCRIPTION
## Summary

Fix command-line parsing of the -loadbalancing encoder option when it is placed at the end of the argument list.

## Problem

-loadbalancing consumes one value, but its argument availability check currently requires two remaining arguments:

(n + 1 < argc)

As a result, a valid final argument pair such as:

-loadbalancing 0

is silently ignored, leaving the default load-balancing setting enabled.

## Fix

Use the same one-argument availability check as the surrounding single-value options:

(n < argc)