### PR TITLE
encoder: use memset instead of mmx for fixed-size buffer zero-ing

### DIFF
--- a/codec/encoder/core/src/svc_encode_mb.cpp
+++ b/codec/encoder/core/src/svc_encode_mb.cpp
@@ -179,7 +179,6 @@ void WelsEncRecI4x4Y (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache, uin
 
 void WelsEncInterY (SWelsFuncPtrList* pFuncList, SMB* pCurMb, SMbCache* pMbCache) {
   PQuantizationMaxFunc pfQuantizationFour4x4Max         = pFuncList->pfQuantizationFour4x4Max;
-  PSetMemoryZero pfSetMemZeroSize8                      = pFuncList->pfSetMemZeroSize8;
   PSetMemoryZero pfSetMemZeroSize64                     = pFuncList->pfSetMemZeroSize64;
   PScanFunc pfScan4x4                                   = pFuncList->pfScan4x4;
   PCalculateSingleCtrFunc pfCalculateSingleCtr4x4       = pFuncList->pfCalculateSingleCtr4x4;
@@ -199,7 +198,7 @@ void WelsEncInterY (SWelsFuncPtrList* pFuncList, SMB* pCurMb, SMbCache* pMbCache
     iSingleCtr8x8[i] = 0;
     for (j = 0; j < 4; j++) {
       if (aMax[ (i << 2) + j] == 0)
-        pfSetMemZeroSize8 (pBlock, 32);
+        memset (pBlock, 0, 32);
       else {
         pfScan4x4 (pBlock, pRes);
         if (aMax[ (i << 2) + j] > 1)
@@ -244,7 +243,6 @@ void WelsEncInterY (SWelsFuncPtrList* pFuncList, SMB* pCurMb, SMbCache* pMbCache
 void    WelsEncRecUV (SWelsFuncPtrList* pFuncList, SMB* pCurMb, SMbCache* pMbCache, int16_t* pRes, int32_t iUV) {
   PQuantizationHadamardFunc pfQuantizationHadamard2x2   = pFuncList->pfQuantizationHadamard2x2;
   PQuantizationMaxFunc pfQuantizationFour4x4Max         = pFuncList->pfQuantizationFour4x4Max;
-  PSetMemoryZero pfSetMemZeroSize8                      = pFuncList->pfSetMemZeroSize8;
   PSetMemoryZero pfSetMemZeroSize64                     = pFuncList->pfSetMemZeroSize64;
   PScanFunc pfScan4x4Ac                                 = pFuncList->pfScan4x4Ac;
   PCalculateSingleCtrFunc pfCalculateSingleCtr4x4       = pFuncList->pfCalculateSingleCtr4x4;
@@ -267,7 +265,7 @@ void    WelsEncRecUV (SWelsFuncPtrList* pFuncList, SMB* pCurMb, SMbCache* pMbCac
 
   for (j = 0; j < 4; j++) {
     if (aMax[j] == 0)
-      pfSetMemZeroSize8 (pBlock, 32);
+      memset (pBlock, 0, 32);
     else {
       pfScan4x4Ac (pBlock, pRes);
       if (kiInterFlag) {
@@ -319,7 +317,7 @@ void    WelsRecPskip (SDqLayer* pCurLayer, SWelsFuncPtrList* pFuncList, SMB* pCu
   pFuncList->pfCopy16x16Aligned (pCsMb[0],  *iRecStride++,  pMbCache->pSkipMb,       16);
   pFuncList->pfCopy8x8Aligned (pCsMb[1],    *iRecStride++,  pMbCache->pSkipMb + 256, 8);
   pFuncList->pfCopy8x8Aligned (pCsMb[2],    *iRecStride,    pMbCache->pSkipMb + 320, 8);
-  pFuncList->pfSetMemZeroSize8 (pCurMb->pNonZeroCount,  24);
+  memset (pCurMb->pNonZeroCount, 0, 24);
 }
 
 bool WelsTryPYskip (sWelsEncCtx* pEncCtx, SMB* pCurMb, SMbCache* pMbCache) {


### PR DESCRIPTION
The sizes are compile-time constants, so memset expands to two inline SSE stores instead of a call to WelsSetMemZeroSize8_mmx, which zeroes 8 bytes per loop iteration and ends in emms, serialising against the SSE code around it.

Bit-exact, no changes to the bitstream. Increases performance by 1.5-2%