### PR TITLE
Fix crashes at WelsDec::DecodeFrameConstruction() as reported in Issue #4008

### DIFF
--- a/module/gmp-openh264.cpp
+++ b/module/gmp-openh264.cpp
@@ -1040,11 +1040,11 @@ class OpenH264VideoDecoder : public GMPVideoDecoder, public RefCounted {
     if (gmp_api_version_ >= kGMPVersion34) {
       decoded.uiInBsTimeStamp = inputFrame->TimeStamp();
     }
-    unsigned char* data[3] = {nullptr, nullptr, nullptr};
+    memset(data_, 0, sizeof(data_));
 
     dState = decoder_->DecodeFrameNoDelay (inputFrame->Buffer(),
                                      inputFrame->Size(),
-                                     data,
+                                     data_,
                                      &decoded);
 
     if (dState) {
@@ -1058,7 +1058,7 @@ class OpenH264VideoDecoder : public GMPVideoDecoder, public RefCounted {
                                  &OpenH264VideoDecoder::Decode_m,
                                  inputFrame,
                                  &decoded,
-                                 data,
+                                 data_,
                                  renderTimeMs,
                                  valid));
   }
@@ -1177,6 +1177,8 @@ class OpenH264VideoDecoder : public GMPVideoDecoder, public RefCounted {
   FrameStats stats_;
   uint32_t gmp_api_version_;
   bool shutting_down;
+  // Make data_, used in Decode_w(), live as long as the class object.
+  unsigned char* data_[3];
 };
 
 extern "C" {


### PR DESCRIPTION
This fixes the crashes I reported in Issue #4008.

I had no problems with it in any of my tests, on macOS, Linux or Windows (Windows 11). In all the decoding sessions I observed, there is only ever a single `OpenH264VideoDecoder` object, and it lives as long as the session itself (after which the Gecko Media Plugins process terminates). And all calls to `OpenH264VideoDecoder::Decode_w()`  happen on the `GMPThread`.
