### PR TITLE
decoder: clear stale hand-off signals when the new-sequence chain is cut

### DIFF
--- a/codec/decoder/plus/src/welsDecoderExt.cpp
+++ b/codec/decoder/plus/src/welsDecoderExt.cpp
@@ -1386,6 +1386,14 @@ DECODING_STATE CWelsDecoder::ParseAccessUnit (SWelsDecoderThreadCTX& sThreadCtx)
           RELEASE_SEMAPHORE (&m_pDecThrCtxActive[i]->sThreadInfo.sIsIdle);
         }
       }
+      for (int32_t i = 0; i < m_iCtxCount; ++i) {
+        //Past the barrier nothing is decoding and the chain is cut for every context, so a
+        //hand-off signal still raised has lost the consumer that would have reset it. Left
+        //raised, the next frame that waits on that worker passes the wait at once and marks
+        //a picture that has not been decoded.
+        if (m_pDecThrCtx[i].pCtx != NULL)
+          RESET_EVENT (&m_pDecThrCtx[i].sSliceDecodeStart);
+      }
       sThreadCtx.pCtx->pLastThreadCtx = NULL;
     }
     iErr = AllocPicBuffOnNewSeqBegin (sThreadCtx.pCtx);


### PR DESCRIPTION
One-commit follow-up to the new-sequence handling in `ParseAccessUnit()`: the barrier
introduced there clears the state that would point into DPB storage about to be replaced, and
this adds the one remaining piece of per-worker state that the same cut leaves behind.

## What is missing

`sSliceDecodeStart` is a manual-reset event, one per worker, and the worker that *consumes* it
is the one that resets it — `ConstructAccessUnit()` waits on the previous worker's event and
calls `RESET_EVENT()` on it afterwards.

When the new-sequence path cuts the hand-off chain, that consumer never runs, so a signal
raised just before the boundary stays raised. The next frame that waits on that worker passes
the wait immediately — before the frame it is about to mark has been decoded — and carries out
the reference marking against whatever picture and marking state that context still holds.

The fix resets the events in the same place the rest of that state is cleared. Past the
barrier nothing is decoding and the chain is cut for every context, so any hand-off signal
still raised has lost its consumer.

## How it was found

`res/BA_MW_D.264` carries an IDR every 30 frames. Every access unit at which threaded output
first diverged from single-threaded output was congruent to an IDR's modulo the thread count —
the effect follows the worker that decoded the IDR rather than a fixed frame offset, which is
what pointed at per-worker state rather than at the picture data. Instrumenting the marking
then shows the consumer arriving before the producer has recorded anything for the frame, and
the following frame's reference list missing a picture:

    threads=1   frame_num=3   L0 = [2 1 0]
    threads=3   frame_num=3   L0 = [1 0]

`ThreadDecoderPreviousPicRaceTest` is what made this findable at all: it fails intermittently
on the parent commit, and it is deterministic afterwards.

## Measurements

Cygwin/x86_64, gcc 14, 8 cores. `ThreadDecoderPreviousPicRaceTest`, 60 attempts:

| | passed | failed |
|---|---|---|
| parent commit | 58 | 2 |
| with this change | 60 | 0 |

The whole `ThreadDecoder*` set passes. `res/BA_MW_D.264`, `res/MR2_MW_A.264`,
`res/MR2_TANDBERG_E.264` and the 1280x544 and 1280x720 `temporal_direct` vectors each give a
single digest over fifteen in-process passes at two and at three threads, equal to their
`threads=1` digest.

Two failures in sixty is a thin margin to measure a change against, so the same change was
measured on a build carrying diagnostic instrumentation, which widens the window and raises
the rate on `res/BA_MW_D.264` at three threads from roughly one pass in seventy to better than
one in two. Decoding it repeatedly in one process — the effect only shows up that way, one
decode per process looks clean — on the same build with the resets compiled in or out:

| | without | with |
|---|---|---|
| output differs from `threads=1` | 54 of 99 | 0 of 100 |
| reference list differs from `threads=1` | 54 | 0 |
| `ThreadDecoderPreviousPicRaceTest` | 50 of 60 fail | 0 of 60 fail |

## One caveat

I could not observe the stale signal being consumed directly. The proportion of hand-off waits
that find the event already raised is around 26% even in runs whose output is correct, so that
count cannot separate a legitimate early completion from a leftover. The mechanism above
matches the instrumented log, but the causal claim rests on the effect of the change rather
than on a direct observation of the stale wait. If someone sees a cheaper way to pin that
down, I would be glad to add it.

## Relationship to #4006

#4006 is based on an older master and does not contain this code path, so the two are
independent: this applies to master with no fuzz and does not apply to #4006's head at all.
Merging them in either order is clean, and the combined tree passes
`ThreadDecoderPreviousPicRaceTest` 60 of 60 and the whole `ThreadDecoder*` set. The
intermittent failures of that test seen in #4006's CI come from this path, not from #4006 —
CI tests the pull request merged with master.
